### PR TITLE
feat: HDK DX remediation + attention-surface CLI

### DIFF
--- a/LICENSE-FAQ.md
+++ b/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/README.md
+++ b/README.md
@@ -265,6 +265,6 @@ Safety has to be **upstream and structural**: the canonical channel at [apps.llo
 
 **Commercial use is unrestricted** — build and sell products with HDK, embed it in proprietary software, run it in production. The FSL restriction is narrow: you cannot ship a competing HDK runtime, managed HDK service, or alternative HDK App distribution channel.
 
-HDK 3.0 runtime packages (`@lloyal-labs/lloyal-agents`, `@lloyal-labs/sdk`, `@lloyal-labs/rig`, `@lloyal-labs/web-app`, `@lloyal-labs/corpus-app`, `@lloyal-labs/wikipedia-app`) are source-available under FSL-1.1-Apache-2.0 and convert to Apache 2.0 two years after each release. `packages/harness-cli` (the `harness.dev` CLI) is Apache 2.0 from day one — see its own `LICENSE` file.
+HDK 3.0 runtime packages (`@lloyal-labs/lloyal-agents`, `@lloyal-labs/sdk`, `@lloyal-labs/rig`, `@lloyal-labs/web-app`, `@lloyal-labs/corpus-app`, `@lloyal-labs/wikipedia-app`) are Fair Source under FSL-1.1-Apache-2.0 and convert to Apache 2.0 two years after each release. `packages/harness-cli` (the `harness.dev` CLI) is Apache 2.0 from day one — see its own `LICENSE` file.
 
 See [`LICENSE-FAQ.md`](./LICENSE-FAQ.md) for concrete examples of what's permitted and what's restricted, [`LICENSE`](./LICENSE) for the legal text, and [`NOTICE`](./NOTICE) for attribution.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2500,7 +2500,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "3.0.0",
+      "version": "3.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -2545,7 +2545,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "bin": {
         "harness.dev": "dist/cli.js"
@@ -2556,7 +2556,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",
@@ -2573,7 +2573,7 @@
     },
     "packages/sdk": {
       "name": "@lloyal-labs/sdk",
-      "version": "3.0.0",
+      "version": "3.0.2",
       "license": "SEE LICENSE IN LICENSE"
     }
   }

--- a/packages/agents/LICENSE-FAQ.md
+++ b/packages/agents/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@lloyal-labs/lloyal-agents",
-  "version": "3.0.2",
-  "description": "Multi-agent inference inside the decode loop \u2014 structured concurrency over shared KV state",
+  "version": "3.1.0",
+  "description": "Multi-agent inference inside the decode loop — structured concurrency over shared KV state",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "publishConfig": {

--- a/packages/agents/src/Tool.ts
+++ b/packages/agents/src/Tool.ts
@@ -41,7 +41,12 @@ import type { JsonSchema, ToolSchema, ToolContext } from './types';
  *
  * @category Agents
  */
-export abstract class Tool<TArgs = Record<string, unknown>> {
+// `TArgs` defaults to `any` (not `Record<string, unknown>`) so heterogeneous
+// `Tool` subclasses — each with its own `execute(args: TArgs)` shape — assign to
+// a uniform `Tool[]` / `Record<string, Tool>` without an `as unknown as Tool[]`
+// cast. `TArgs` sits in a contravariant (parameter) position; `any` is the
+// variance-neutral default. Authors still narrow `TArgs` per tool for safety.
+export abstract class Tool<TArgs = any> {
   /** Tool name — used as the function identifier in tool calls */
   abstract readonly name: string;
   /** Human-readable description shown to the model */

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -511,7 +511,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       }
     });
     const tw = yield* Trace.expect();
-    const { spine, orchestrate, toolsJson, tools, maxTurns = 100, terminalToolName, trace = false, pruneOnReturn = false, enableThinking = false, eagerGrammar } = opts;
+    const { spine, orchestrate, toolsJson, tools, maxTurns = 100, terminalToolName, trace = false, pruneOnReturn = false, enableThinking = true, eagerGrammar } = opts;
 
     // Tool index map for trace — position in toolkit array
     const toolIndexMap = new Map([...tools.keys()].map((name, i) => [name, i]));

--- a/packages/agents/src/create-agent-pool.ts
+++ b/packages/agents/src/create-agent-pool.ts
@@ -63,7 +63,7 @@ export interface CreateAgentPoolOpts {
   /**
    * Whether the chat template delimits `<think>` blocks for this pool's agents.
    * See {@link AgentPoolOptions.enableThinking}.
-   * @default false
+   * @default true
    */
   enableThinking?: boolean;
   /**

--- a/packages/agents/src/spine.ts
+++ b/packages/agents/src/spine.ts
@@ -72,7 +72,7 @@ export interface SpineOptions {
    * pool — divergent values produce inconsistent grammar between the
    * prefilled spine and per-agent suffixes.
    *
-   * @default false
+   * @default true
    */
   enableThinking?: boolean;
 }
@@ -171,7 +171,7 @@ export function* withSpine<T>(
   // tool schemas in each agent's suffix.
   let spineFmt: FormatConfig | null = null;
   if (opts.systemPrompt !== undefined) {
-    const enableThinking = opts.enableThinking ?? false;
+    const enableThinking = opts.enableThinking ?? true;
     const messages = JSON.stringify([{ role: "system", content: opts.systemPrompt }]);
     const fmtOpts: Record<string, unknown> = {
       enableThinking,

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -280,8 +280,10 @@ export interface AgentPoolOptions {
    * expect — thoughts are correctly delimited and `parseChatOutput`
    * extracts them into `reasoning_content`. Setting `false` omits think
    * tokens; if the model emits them anyway (as Qwen3.5 does) they leak
-   * into visible content.
-   * @default false
+   * into visible content — so leave this `true` (the default) for thinking
+   * models, and only set `false` for non-thinking `-Instruct` models or
+   * deliberate agent-side suppression (shared spine, session trunk, reranker).
+   * @default true
    */
   enableThinking?: boolean;
   /** Entailment scorer for semantic coherence across recursive depths.

--- a/packages/agents/test/invariants/scenarios/enable-thinking-propagation.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/enable-thinking-propagation.scenario.test.ts
@@ -10,8 +10,10 @@
  * and models had `<think>\n` prefilled on turns 1+ only (not turn 0).
  *
  * What this locks:
- *   - `agent.fmt.enableThinking` is `false` by default (existing behavior).
- *   - Callers can override to `true` via `useAgentPool({enableThinking})`.
+ *   - `agent.fmt.enableThinking` is `true` by default (correct for the
+ *     thinking models — Qwen3.5 — that are now the reference).
+ *   - Callers can override to `false` via `useAgentPool({enableThinking})`
+ *     for non-thinking models or agent-side suppression.
  *   - Whatever value is set at pool construction is stored on the agent
  *     and can be read from `run.result.agents[i].agent.fmt.enableThinking`.
  */
@@ -30,13 +32,13 @@ describe('scenario: enableThinking propagation (pool → agent.fmt)', () => {
     onRecovery: () => ({ type: 'skip' }),
   };
 
-  it('default (no enableThinking set) → agent.fmt.enableThinking = false', async () => {
+  it('default (no enableThinking set) → agent.fmt.enableThinking = true', async () => {
     const run = await runPool({
       scripts: [{ tokens: [1, STOP] }],
       policy: minimalPolicy,
     });
     expect(run.result.agents.length).toBe(1);
-    expect(run.result.agents[0].agent.fmt.enableThinking).toBe(false);
+    expect(run.result.agents[0].agent.fmt.enableThinking).toBe(true);
   });
 
   it('explicit enableThinking: true → agent.fmt.enableThinking = true', async () => {

--- a/packages/apps/corpus/LICENSE-FAQ.md
+++ b/packages/apps/corpus/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/packages/apps/corpus/package.json
+++ b/packages/apps/corpus/package.json
@@ -17,6 +17,7 @@
     "dist/",
     "app.json",
     "skill.eta",
+    "attention-surface.json",
     "LICENSE",
     "LICENSE-FAQ.md"
   ],

--- a/packages/apps/web/LICENSE-FAQ.md
+++ b/packages/apps/web/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/packages/apps/web/package.json
+++ b/packages/apps/web/package.json
@@ -17,6 +17,7 @@
     "dist/",
     "app.json",
     "skill.eta",
+    "attention-surface.json",
     "LICENSE",
     "LICENSE-FAQ.md"
   ],

--- a/packages/apps/wikipedia/package.json
+++ b/packages/apps/wikipedia/package.json
@@ -17,6 +17,7 @@
     "dist/",
     "app.json",
     "skill.eta",
+    "attention-surface.json",
     "LICENSE"
   ],
   "scripts": {

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "harness.dev",
-  "version": "0.4.1",
-  "description": "The Harness Development Kit CLI \u2014 scaffold HDK harnesses and apps.",
+  "version": "0.5.0",
+  "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "dist/cli.js"
   },

--- a/packages/harness-cli/src/commands/install.ts
+++ b/packages/harness-cli/src/commands/install.ts
@@ -439,39 +439,53 @@ async function renderAttentionSurface(tarball: Uint8Array, name: string): Promis
     process.stdout.write(`\n  note: ${name}'s attention surface could not be parsed.\n`);
     return;
   }
-  const out = process.stdout;
-  out.write(`\nWhat ${name} adds to your model's context:\n`);
-  if (s.protocol?.name) out.write(`  protocol:  ${s.protocol.name}\n`);
-  if (s.protocol?.useWhen) out.write(`  use when:  ${s.protocol.useWhen}\n`);
+  process.stdout.write(formatAttentionSurface(s, name));
+}
 
-  const tools = Array.isArray(s.tools) ? s.tools : [];
-  out.write(`\n  Tools (${tools.length}):\n`);
+/**
+ * Build the human-readable attention-surface disclosure. PURE + TOTAL: the
+ * input is signed-for-authenticity but NOT shape-validated publisher JSON, so
+ * every field is coerced/guarded — a malformed `tools`/`skill`/`configSchema`
+ * degrades just that line, never throws. This is what keeps
+ * {@link renderAttentionSurface}'s "never blocks" promise honest. Exported for
+ * unit testing of the malformed-input paths.
+ */
+export function formatAttentionSurface(s: AttentionSurface, name: string): string {
+  const lines: string[] = [`\nWhat ${name} adds to your model's context:`];
+  if (typeof s.protocol?.name === 'string') lines.push(`  protocol:  ${s.protocol.name}`);
+  if (typeof s.protocol?.useWhen === 'string') lines.push(`  use when:  ${s.protocol.useWhen}`);
+
+  const tools = (Array.isArray(s.tools) ? s.tools : []).filter(
+    (t): t is NonNullable<typeof t> => !!t && typeof t === 'object',
+  );
+  lines.push(`\n  Tools (${tools.length}):`);
   for (const t of tools) {
-    const tag = t.protected ? '  [writes]' : '';
-    const desc = t.description ? ` — ${t.description}` : '';
-    out.write(`    • ${t.name}${desc}${tag}\n`);
+    const nm = typeof t.name === 'string' && t.name ? t.name : '(unnamed)';
+    const tag = t.protected === true ? '  [writes]' : '';
+    const desc = typeof t.description === 'string' && t.description ? ` — ${t.description}` : '';
+    lines.push(`    • ${nm}${desc}${tag}`);
   }
-  if (s.degraded) {
-    out.write('    (tool descriptions unavailable for this version)\n');
-  }
+  if (s.degraded) lines.push('    (tool descriptions unavailable for this version)');
 
-  const props = (s.configSchema as { properties?: Record<string, { type?: string; 'x-secret'?: boolean }> } | undefined)
-    ?.properties;
-  const keys = props ? Object.keys(props) : [];
+  const props = (s.configSchema as { properties?: Record<string, unknown> } | undefined)?.properties;
+  const keys = props && typeof props === 'object' ? Object.keys(props) : [];
   if (keys.length) {
-    out.write('\n  Config it reads:\n');
+    lines.push('\n  Config it reads:');
     for (const k of keys) {
-      const secret = props![k]?.['x-secret'] ? ', secret' : '';
-      out.write(`    • ${k} (${props![k]?.type ?? 'value'}${secret})\n`);
+      const p = props![k] as { type?: unknown; 'x-secret'?: unknown } | null | undefined;
+      const secret = p && typeof p === 'object' && p['x-secret'] ? ', secret' : '';
+      const ty = p && typeof p === 'object' && typeof p.type === 'string' ? p.type : 'value';
+      lines.push(`    • ${k} (${ty}${secret})`);
     }
   }
 
-  if (s.skill) {
-    const lines = s.skill.split('\n');
-    const shown = lines.slice(0, 10);
-    out.write('\n  System-prompt skill (per turn):\n');
-    for (const l of shown) out.write(`    | ${l}\n`);
-    if (lines.length > shown.length) out.write(`    | … (${lines.length - shown.length} more lines)\n`);
+  if (typeof s.skill === 'string' && s.skill) {
+    const all = s.skill.split('\n');
+    const shown = all.slice(0, 10);
+    lines.push('\n  System-prompt skill (per turn):');
+    for (const l of shown) lines.push(`    | ${l}`);
+    if (all.length > shown.length) lines.push(`    | … (${all.length - shown.length} more lines)`);
   }
-  out.write('\n');
+  lines.push('');
+  return `${lines.join('\n')}\n`;
 }

--- a/packages/harness-cli/src/commands/install.ts
+++ b/packages/harness-cli/src/commands/install.ts
@@ -12,7 +12,7 @@ import {
   sha512Integrity,
   BundleVerificationError,
 } from '../verify';
-import { readTarEntry } from '../tar-read';
+import { readTarEntry, isGzipReadable } from '../tar-read';
 import type { AttentionSurface } from '../describe';
 
 const USAGE = [
@@ -427,9 +427,13 @@ function asMessage(err: unknown): string {
 async function renderAttentionSurface(tarball: Uint8Array, name: string): Promise<void> {
   const raw = await readTarEntry(tarball, 'package/attention-surface.json');
   if (raw === null) {
-    process.stdout.write(
-      `\n  note: ${name} ships no attention-surface.json (published before context disclosure).\n`,
-    );
+    // null = absent OR unreadable tarball. The bytes are Ed25519-verified, so
+    // corruption is near-impossible; the real residual case is a package whose
+    // decompressed size exceeds the inspect cap. Say which, honestly.
+    const note = isGzipReadable(tarball)
+      ? `${name} ships no attention-surface.json (published before context disclosure).`
+      : `${name}'s package could not be read to disclose its attention surface (it exceeds the inspect cap or is corrupt).`;
+    process.stdout.write(`\n  note: ${note}\n`);
     return;
   }
   let s: AttentionSurface;
@@ -461,7 +465,9 @@ export function formatAttentionSurface(s: AttentionSurface, name: string): strin
   lines.push(`\n  Tools (${tools.length}):`);
   for (const t of tools) {
     const nm = typeof t.name === 'string' && t.name ? t.name : '(unnamed)';
-    const tag = t.protected === true ? '  [writes]' : '';
+    // `protected` means the tool requires a session grant (authGuard/GrantStore)
+    // to be callable — it is about consent, NOT about whether the tool mutates.
+    const tag = t.protected === true ? '  [needs grant]' : '';
     const desc = typeof t.description === 'string' && t.description ? ` — ${t.description}` : '';
     lines.push(`    • ${nm}${desc}${tag}`);
   }

--- a/packages/harness-cli/src/commands/install.ts
+++ b/packages/harness-cli/src/commands/install.ts
@@ -12,6 +12,8 @@ import {
   sha512Integrity,
   BundleVerificationError,
 } from '../verify';
+import { readTarEntry } from '../tar-read';
+import type { AttentionSurface } from '../describe';
 
 const USAGE = [
   'harness.dev install — install a signed HDK app from apps.lloyal.ai into the current project',
@@ -173,6 +175,11 @@ export const installCommand: Command = {
       );
       return 1;
     }
+
+    // 5b. Disclose what this app injects into the model's context, read from the
+    // ALREADY-VERIFIED tarball bytes (the attention surface rides inside the signed
+    // package). Absent for apps published before the feature — note + continue.
+    await renderAttentionSurface(tarball, name);
 
     const cacheDir = join(xdgCacheHome(), 'lloyal', 'apps');
     const cachePath = join(
@@ -410,4 +417,61 @@ async function auditLockfile(npmPackageName: string): Promise<LockfileAudit | nu
 
 function asMessage(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Print the app's attention surface — exactly what it injects into the model's
+ * context — read from the Ed25519-verified tarball bytes. Best-effort disclosure:
+ * a parse failure or a pre-feature app degrades to a one-line note, never blocks.
+ */
+async function renderAttentionSurface(tarball: Uint8Array, name: string): Promise<void> {
+  const raw = await readTarEntry(tarball, 'package/attention-surface.json');
+  if (raw === null) {
+    process.stdout.write(
+      `\n  note: ${name} ships no attention-surface.json (published before context disclosure).\n`,
+    );
+    return;
+  }
+  let s: AttentionSurface;
+  try {
+    s = JSON.parse(raw) as AttentionSurface;
+  } catch {
+    process.stdout.write(`\n  note: ${name}'s attention surface could not be parsed.\n`);
+    return;
+  }
+  const out = process.stdout;
+  out.write(`\nWhat ${name} adds to your model's context:\n`);
+  if (s.protocol?.name) out.write(`  protocol:  ${s.protocol.name}\n`);
+  if (s.protocol?.useWhen) out.write(`  use when:  ${s.protocol.useWhen}\n`);
+
+  const tools = Array.isArray(s.tools) ? s.tools : [];
+  out.write(`\n  Tools (${tools.length}):\n`);
+  for (const t of tools) {
+    const tag = t.protected ? '  [writes]' : '';
+    const desc = t.description ? ` — ${t.description}` : '';
+    out.write(`    • ${t.name}${desc}${tag}\n`);
+  }
+  if (s.degraded) {
+    out.write('    (tool descriptions unavailable for this version)\n');
+  }
+
+  const props = (s.configSchema as { properties?: Record<string, { type?: string; 'x-secret'?: boolean }> } | undefined)
+    ?.properties;
+  const keys = props ? Object.keys(props) : [];
+  if (keys.length) {
+    out.write('\n  Config it reads:\n');
+    for (const k of keys) {
+      const secret = props![k]?.['x-secret'] ? ', secret' : '';
+      out.write(`    • ${k} (${props![k]?.type ?? 'value'}${secret})\n`);
+    }
+  }
+
+  if (s.skill) {
+    const lines = s.skill.split('\n');
+    const shown = lines.slice(0, 10);
+    out.write('\n  System-prompt skill (per turn):\n');
+    for (const l of shown) out.write(`    | ${l}\n`);
+    if (lines.length > shown.length) out.write(`    | … (${lines.length - shown.length} more lines)\n`);
+  }
+  out.write('\n');
 }

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -6,7 +6,7 @@ import { spawn } from 'node:child_process';
 import type { Command } from '../command';
 import { ensureFreshToken } from '../cf-access-oauth';
 import { buildAttentionSurface } from '../describe';
-import { readTarEntry } from '../tar-read';
+import { readTarEntry, isGzipReadable } from '../tar-read';
 
 const API_BASE = 'https://api.lloyal.ai';
 const DEFAULT_PUBLISH_ENDPOINT = `${API_BASE}/v1/publish`;
@@ -246,10 +246,21 @@ export const publishCommand: Command = {
     // GUARD: a missing `files` whitelist entry would silently ship a
     // surface-less tarball. Fail LOUD here on the publisher's machine.
     if ((await readTarEntry(tarball, 'package/attention-surface.json')) === null) {
-      process.stderr.write(
-        'harness.dev publish: attention-surface.json was generated but did NOT land in the ' +
-          'tarball. Add "attention-surface.json" to your package.json "files" array.\n',
-      );
+      // `readTarEntry` → null means absent OR the tarball couldn't be read at
+      // all (corrupt / over the inspect cap). Distinguish so we don't tell the
+      // publisher to fix their `files` array when the real fault is the tarball.
+      if (!isGzipReadable(tarball)) {
+        process.stderr.write(
+          'harness.dev publish: the produced tarball could not be read (corrupt, or its ' +
+            'decompressed size exceeds the 64MB inspect cap) — cannot verify attention-surface.json ' +
+            'landed. This is unexpected for npm pack output; please file an issue.\n',
+        );
+      } else {
+        process.stderr.write(
+          'harness.dev publish: attention-surface.json was generated but did NOT land in the ' +
+            'tarball. Add "attention-surface.json" to your package.json "files" array.\n',
+        );
+      }
       return 1;
     }
 

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -1,10 +1,12 @@
 import { parseArgs } from 'node:util';
-import { readFile, mkdtemp, rm } from 'node:fs/promises';
+import { readFile, writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import type { Command } from '../command';
 import { ensureFreshToken } from '../cf-access-oauth';
+import { buildAttentionSurface } from '../describe';
+import { readTarEntry } from '../tar-read';
 
 const API_BASE = 'https://api.lloyal.ai';
 const DEFAULT_PUBLISH_ENDPOINT = `${API_BASE}/v1/publish`;
@@ -56,6 +58,7 @@ interface AppJson {
 interface PackageJson {
   name: string;
   version: string;
+  main?: string;
   peerDependencies?: Record<string, string>;
 }
 
@@ -206,22 +209,43 @@ export const publishCommand: Command = {
       catalogName = `${publisherHandle}/${appJson.name}`;
     }
 
-    // Build the tarball via `npm pack` shell-out.
-    let tarballPath: string;
-    let packTmpDir: string;
+    // Serialize the app's ATTENTION SURFACE (skill prose + full tool schemas +
+    // useWhen + configSchema) into `attention-surface.json` in the app dir, so
+    // `npm pack` includes it and it's covered by the signed tarball. Written
+    // before pack, deleted in `finally` regardless of outcome.
+    const surfacePath = join(appDir, 'attention-surface.json');
     try {
-      packTmpDir = await mkdtemp(join(tmpdir(), 'harness-dev-publish-'));
-      tarballPath = await npmPack(appDir, packTmpDir);
+      const surface = await buildAttentionSurface(appDir, appJson, packageJson);
+      await writeFile(surfacePath, `${JSON.stringify(surface, null, 2)}\n`);
     } catch (err) {
-      process.stderr.write(`harness.dev publish: npm pack failed: ${asMessage(err)}\n`);
+      process.stderr.write(`harness.dev publish: could not build attention surface: ${asMessage(err)}\n`);
       return 1;
     }
 
+    // Build the tarball via `npm pack` shell-out, then assert the surface landed.
+    let tarballPath: string;
+    let packTmpDir: string;
     let tarball: Uint8Array;
     try {
+      packTmpDir = await mkdtemp(join(tmpdir(), 'harness-dev-publish-'));
+      tarballPath = await npmPack(appDir, packTmpDir);
       tarball = new Uint8Array(await readFile(tarballPath));
     } catch (err) {
-      process.stderr.write(`harness.dev publish: cannot read packed tarball: ${asMessage(err)}\n`);
+      process.stderr.write(`harness.dev publish: npm pack failed: ${asMessage(err)}\n`);
+      await rm(surfacePath, { force: true }).catch(() => {});
+      return 1;
+    } finally {
+      // The packed copy is immutable; the source-tree artifact is transient.
+      await rm(surfacePath, { force: true }).catch(() => {});
+    }
+
+    // GUARD: a missing `files` whitelist entry would silently ship a
+    // surface-less tarball. Fail LOUD here on the publisher's machine.
+    if ((await readTarEntry(tarball, 'package/attention-surface.json')) === null) {
+      process.stderr.write(
+        'harness.dev publish: attention-surface.json was generated but did NOT land in the ' +
+          'tarball. Add "attention-surface.json" to your package.json "files" array.\n',
+      );
       await cleanupTmpDir(packTmpDir);
       return 1;
     }

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -224,8 +224,19 @@ export const publishCommand: Command = {
     let existingSurface: string | undefined;
     try {
       existingSurface = await readFile(surfacePath, 'utf-8');
-    } catch {
-      existingSurface = undefined; // no pre-existing file — the normal case
+    } catch (err) {
+      // ONLY ENOENT means "no pre-existing file" (the normal case). Any other
+      // error (EACCES, EISDIR, …) means something IS there that we can't read —
+      // treating it as absent would let restoreSurface() rm it, deleting the
+      // publisher's file. Fail loud BEFORE writing anything.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+        process.stderr.write(
+          `harness.dev publish: ${surfacePath} exists but could not be read (${asMessage(err)}). ` +
+            `Refusing to overwrite it — remove or fix that path and re-run.\n`,
+        );
+        return 1;
+      }
+      existingSurface = undefined;
     }
     const restoreSurface = async (): Promise<void> => {
       if (existingSurface !== undefined) {

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -211,16 +211,35 @@ export const publishCommand: Command = {
 
     // Serialize the app's ATTENTION SURFACE (skill prose + full tool schemas +
     // useWhen + configSchema) into `attention-surface.json` in the app dir, so
-    // `npm pack` includes it and it's covered by the signed tarball. Written
-    // before pack; removed on EVERY exit — the build-failure catch right here
-    // and the pack block's `finally` below.
+    // `npm pack` includes it and it's covered by the signed tarball.
+    //
+    // The file is a GENERATED artifact, but a publisher may already have one in
+    // their working tree (committed, stale from an interrupted run, or hand-
+    // authored). We must NOT clobber or delete it: capture any existing contents
+    // first, and `restoreSurface()` on EVERY exit (the build-failure catch here
+    // and the pack block's `finally`) — restore the original if one existed,
+    // otherwise remove only the file we created. (The PUBLISHED surface is
+    // always the freshly-generated one; we just never destroy the publisher's.)
     const surfacePath = join(appDir, 'attention-surface.json');
+    let existingSurface: string | undefined;
+    try {
+      existingSurface = await readFile(surfacePath, 'utf-8');
+    } catch {
+      existingSurface = undefined; // no pre-existing file — the normal case
+    }
+    const restoreSurface = async (): Promise<void> => {
+      if (existingSurface !== undefined) {
+        await writeFile(surfacePath, existingSurface).catch(() => {});
+      } else {
+        await rm(surfacePath, { force: true }).catch(() => {});
+      }
+    };
     try {
       const surface = await buildAttentionSurface(appDir, appJson, packageJson);
       await writeFile(surfacePath, `${JSON.stringify(surface, null, 2)}\n`);
     } catch (err) {
       process.stderr.write(`harness.dev publish: could not build attention surface: ${asMessage(err)}\n`);
-      await rm(surfacePath, { force: true }).catch(() => {});
+      await restoreSurface();
       return 1;
     }
 
@@ -239,7 +258,7 @@ export const publishCommand: Command = {
       process.stderr.write(`harness.dev publish: npm pack failed: ${asMessage(err)}\n`);
       return 1;
     } finally {
-      await rm(surfacePath, { force: true }).catch(() => {});
+      await restoreSurface();
       if (packTmpDir) await cleanupTmpDir(packTmpDir);
     }
 

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -212,31 +212,35 @@ export const publishCommand: Command = {
     // Serialize the app's ATTENTION SURFACE (skill prose + full tool schemas +
     // useWhen + configSchema) into `attention-surface.json` in the app dir, so
     // `npm pack` includes it and it's covered by the signed tarball. Written
-    // before pack, deleted in `finally` regardless of outcome.
+    // before pack; removed on EVERY exit — the build-failure catch right here
+    // and the pack block's `finally` below.
     const surfacePath = join(appDir, 'attention-surface.json');
     try {
       const surface = await buildAttentionSurface(appDir, appJson, packageJson);
       await writeFile(surfacePath, `${JSON.stringify(surface, null, 2)}\n`);
     } catch (err) {
       process.stderr.write(`harness.dev publish: could not build attention surface: ${asMessage(err)}\n`);
+      await rm(surfacePath, { force: true }).catch(() => {});
       return 1;
     }
 
     // Build the tarball via `npm pack` shell-out, then assert the surface landed.
-    let tarballPath: string;
-    let packTmpDir: string;
+    // The tarball bytes are read fully into memory, so both transient artifacts —
+    // the source-tree `attention-surface.json` and the pack temp dir — are cleaned
+    // in `finally`, regardless of success or the early-return below. Nothing
+    // downstream reads either, so a failed pack can't leak a temp dir.
+    let packTmpDir: string | undefined;
     let tarball: Uint8Array;
     try {
       packTmpDir = await mkdtemp(join(tmpdir(), 'harness-dev-publish-'));
-      tarballPath = await npmPack(appDir, packTmpDir);
+      const tarballPath = await npmPack(appDir, packTmpDir);
       tarball = new Uint8Array(await readFile(tarballPath));
     } catch (err) {
       process.stderr.write(`harness.dev publish: npm pack failed: ${asMessage(err)}\n`);
-      await rm(surfacePath, { force: true }).catch(() => {});
       return 1;
     } finally {
-      // The packed copy is immutable; the source-tree artifact is transient.
       await rm(surfacePath, { force: true }).catch(() => {});
+      if (packTmpDir) await cleanupTmpDir(packTmpDir);
     }
 
     // GUARD: a missing `files` whitelist entry would silently ship a
@@ -246,7 +250,6 @@ export const publishCommand: Command = {
         'harness.dev publish: attention-surface.json was generated but did NOT land in the ' +
           'tarball. Add "attention-surface.json" to your package.json "files" array.\n',
       );
-      await cleanupTmpDir(packTmpDir);
       return 1;
     }
 
@@ -281,7 +284,6 @@ export const publishCommand: Command = {
     if (!res.ok) {
       const body = await res.text();
       process.stderr.write(`harness.dev publish: HTTP ${res.status} ${res.statusText}\n${body}\n`);
-      await cleanupTmpDir(packTmpDir);
       return 1;
     }
 
@@ -304,7 +306,6 @@ export const publishCommand: Command = {
     if (out.submittedAt) process.stdout.write(`  submitted:  ${out.submittedAt}\n`);
     if (out.statusUrl) process.stdout.write(`  poll:       harness.dev publish status ${out.submissionId ?? '<id>'}\n`);
 
-    await cleanupTmpDir(packTmpDir);
     return 0;
   },
 };

--- a/packages/harness-cli/src/describe.ts
+++ b/packages/harness-cli/src/describe.ts
@@ -67,6 +67,7 @@ const DESCRIBE_SCRIPT = `(async () => {
   const path = require('node:path');
   const os = require('node:os');
   const fs = require('node:fs');
+  const tmpDirs = [];
   try {
     const entry = process.env.HARNESS_DESCRIBE_ENTRY;
     const required = JSON.parse(process.env.HARNESS_DESCRIBE_REQUIRED || '[]');
@@ -80,6 +81,7 @@ const DESCRIBE_SCRIPT = `(async () => {
     for (const k of required) {
       if (/path|dir|file|root/i.test(k)) {
         const d = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-describe-'));
+        tmpDirs.push(d);
         // Seed a placeholder doc so resource-loading factories (e.g. corpus)
         // construct over a NON-empty dir instead of throwing "no files matched".
         try { fs.writeFileSync(path.join(d, '_describe.md'), '# describe placeholder'); } catch {}
@@ -109,11 +111,17 @@ const DESCRIBE_SCRIPT = `(async () => {
       protected: t.protected === true,
     }));
     process.stdout.write(JSON.stringify({ tools }));
-    process.exit(0);
   } catch (e) {
     process.stderr.write(String((e && e.stack) || e));
-    process.exit(3);
+    process.exitCode = 3;
+  } finally {
+    // Reap the synthetic config dirs created above — else every describe run
+    // (publish, tests) leaks a harness-describe-* dir per path-like config key.
+    for (const d of tmpDirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    }
   }
+  process.exit(process.exitCode || 0);
 })();`;
 
 function requiredConfigKeys(configSchema: DescribeAppJson['configSchema']): string[] {

--- a/packages/harness-cli/src/describe.ts
+++ b/packages/harness-cli/src/describe.ts
@@ -1,0 +1,235 @@
+/**
+ * Publish-time "attention surface" extraction.
+ *
+ * At `harness.dev publish` (a TRUSTED publisher-machine context) we serialize
+ * everything the app injects into the model's context — the per-spawn skill
+ * prose, every tool's name + description + parameter schema, `useWhen`, and the
+ * config schema — into `attention-surface.json`, which the publish command
+ * writes INTO the npm tarball. Because the worker signs the tarball bytes at
+ * approval, this artifact is covered by the same Ed25519 signature: a reviewer
+ * and `harness.dev install` can verify exactly what enters the model WITHOUT
+ * executing untrusted code.
+ *
+ * Tool descriptions + parameter schemas live in compiled `Tool` instances, so
+ * the only way to read them is to CONSTRUCT the app. We do that in an ISOLATED
+ * subprocess (`node -e`, cwd = the app dir so its own deps resolve) under a
+ * describe harness that seeds mock Effection contexts — never in the CLI's own
+ * process. This keeps the consumer-facing CLI dependency-free, sandboxes
+ * arbitrary construction code behind a 30s timeout, and degrades LOUDLY to
+ * app.json tool NAMES if construction throws / times out / the app is ESM-only.
+ */
+
+import { spawn } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+
+export interface AttentionSurfaceTool {
+  name: string;
+  description: string;
+  /** JSON Schema for the tool's args, or null if absent. */
+  parameters: unknown | null;
+  protected: boolean;
+}
+
+export interface AttentionSurface {
+  /** Forward-compat seam (number, not a literal) so install tolerates bumps. */
+  schemaVersion: number;
+  protocol: { name: string; useWhen: string; tools: string[] };
+  /** Raw skill.eta template — the per-spawn system prompt. NEVER pre-rendered. */
+  skill: string;
+  configSchema?: unknown;
+  tools: AttentionSurfaceTool[];
+  /** True when tool descriptions/params could not be extracted (names only). */
+  degraded?: boolean;
+}
+
+export interface DescribeAppJson {
+  name: string;
+  appProtocolVersion?: string;
+  protocol?: { name?: string; useWhen?: string; tools?: string[] };
+  configSchema?: { required?: unknown } & Record<string, unknown>;
+}
+
+export interface DescribePackageJson {
+  name: string;
+  version: string;
+  main?: string;
+}
+
+const DESCRIBE_TIMEOUT_MS = 30_000;
+
+/**
+ * The describe subprocess body. Runs in the APP's directory so `require`
+ * resolves the app's own `effection` + `@lloyal-labs/lloyal-agents`. Reads the
+ * entry path + required-config keys from env (robust vs `-e` argv quirks).
+ */
+const DESCRIBE_SCRIPT = `(async () => {
+  const path = require('node:path');
+  const os = require('node:os');
+  const fs = require('node:fs');
+  try {
+    const entry = process.env.HARNESS_DESCRIBE_ENTRY;
+    const required = JSON.parse(process.env.HARNESS_DESCRIBE_REQUIRED || '[]');
+    const { run } = require('effection');
+    const { RerankerCtx, AppConfigStoreCtx } = require('@lloyal-labs/lloyal-agents');
+    const mod = require(entry);
+    const key = Object.keys(mod).find((k) => /^create[A-Za-z0-9]*App$/.test(k) && typeof mod[k] === 'function');
+    if (!key) throw new Error('no create*App factory export in ' + entry);
+    const factory = mod[key];
+    const synth = {};
+    for (const k of required) {
+      if (/path|dir|file|root/i.test(k)) {
+        const d = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-describe-'));
+        // Seed a placeholder doc so resource-loading factories (e.g. corpus)
+        // construct over a NON-empty dir instead of throwing "no files matched".
+        try { fs.writeFileSync(path.join(d, '_describe.md'), '# describe placeholder'); } catch {}
+        synth[k] = d;
+      } else {
+        synth[k] = 'describe-placeholder';
+      }
+    }
+    // Mock reranker — only construction needs it to exist (tokenizeChunks is
+    // promise-returning per the corpus call site; the rest are never hit at build).
+    const reranker = {
+      tokenizeChunks: async () => {},
+      rank: async () => [],
+      score: async () => 0,
+      rerank: async (_q, items) => items,
+    };
+    const cfgStore = { *get() { return synth; }, *set() {}, *clear() {} };
+    const app = await run(function* () {
+      yield* RerankerCtx.set(reranker);
+      yield* AppConfigStoreCtx.set(cfgStore);
+      return yield* factory();
+    });
+    const tools = (app.tools || []).map((t) => ({
+      name: String(t.name),
+      description: typeof t.description === 'string' ? t.description : '',
+      parameters: t.parameters == null ? null : t.parameters,
+      protected: t.protected === true,
+    }));
+    process.stdout.write(JSON.stringify({ tools }));
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write(String((e && e.stack) || e));
+    process.exit(3);
+  }
+})();`;
+
+function requiredConfigKeys(configSchema: DescribeAppJson['configSchema']): string[] {
+  const req = configSchema?.required;
+  return Array.isArray(req) ? req.filter((k): k is string => typeof k === 'string') : [];
+}
+
+function coerceTool(t: unknown): AttentionSurfaceTool | null {
+  if (typeof t !== 'object' || t === null) return null;
+  const o = t as Record<string, unknown>;
+  if (typeof o.name !== 'string' || o.name.length === 0) return null;
+  return {
+    name: o.name,
+    description: typeof o.description === 'string' ? o.description : '',
+    parameters: o.parameters ?? null,
+    protected: o.protected === true,
+  };
+}
+
+/**
+ * Construct the app in an isolated subprocess and read its tool schemas.
+ * Returns null on ANY failure (logged) so the caller falls back to names.
+ */
+function describeTools(
+  appDir: string,
+  mainRel: string,
+  required: string[],
+  appName: string,
+): Promise<AttentionSurfaceTool[] | null> {
+  return new Promise((resolvePromise) => {
+    const entry = resolve(appDir, mainRel);
+    // Strip NODE_OPTIONS so a parent-process loader (e.g. a test runner's, or a
+    // publisher's wrapper) isn't inherited by the bare `node -e` describe child.
+    const childEnv: NodeJS.ProcessEnv = {
+      ...process.env,
+      HARNESS_DESCRIBE_ENTRY: entry,
+      HARNESS_DESCRIBE_REQUIRED: JSON.stringify(required),
+    };
+    delete childEnv.NODE_OPTIONS;
+    const proc = spawn(process.execPath, ['-e', DESCRIBE_SCRIPT], {
+      cwd: appDir,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: DESCRIBE_TIMEOUT_MS,
+      env: childEnv,
+    });
+    let out = '';
+    let err = '';
+    proc.stdout.on('data', (c: Buffer) => (out += c.toString('utf-8')));
+    proc.stderr.on('data', (c: Buffer) => (err += c.toString('utf-8')));
+    const fallback = (why: string) => {
+      process.stderr.write(
+        `harness.dev publish: WARNING — could not construct "${appName}" to read tool ` +
+          `descriptions/parameters (${why.trim().split('\n')[0] || 'unknown'}). ` +
+          `Falling back to tool NAMES only from app.json. The attention surface for ` +
+          `this version will omit tool descriptions + parameter schemas.\n`,
+      );
+      resolvePromise(null);
+    };
+    proc.on('error', (e) => fallback(String((e as Error).message)));
+    proc.on('close', (code) => {
+      if (code !== 0) return fallback(err || `describe exited ${code}`);
+      try {
+        const parsed = JSON.parse(out) as { tools?: unknown };
+        const tools = Array.isArray(parsed.tools)
+          ? parsed.tools.map(coerceTool).filter((t): t is AttentionSurfaceTool => t !== null)
+          : [];
+        resolvePromise(tools);
+      } catch {
+        fallback('describe produced unparseable output');
+      }
+    });
+  });
+}
+
+/**
+ * Build the full attention surface for an app. `protocol` + `configSchema` come
+ * from app.json; `skill` is the raw skill.eta file; tool schemas come from the
+ * describe subprocess (with a names-only fallback).
+ */
+export async function buildAttentionSurface(
+  appDir: string,
+  appJson: DescribeAppJson,
+  packageJson: DescribePackageJson,
+): Promise<AttentionSurface> {
+  const protocol = {
+    name: appJson.protocol?.name ?? appJson.name,
+    useWhen: appJson.protocol?.useWhen ?? '',
+    tools: Array.isArray(appJson.protocol?.tools)
+      ? appJson.protocol!.tools!.filter((t): t is string => typeof t === 'string')
+      : [],
+  };
+
+  let skill = '';
+  try {
+    skill = await readFile(join(appDir, 'skill.eta'), 'utf-8');
+  } catch {
+    // Apps without a skill.eta are valid (rare) — leave skill empty.
+  }
+
+  const described = await describeTools(
+    appDir,
+    packageJson.main ?? 'dist/index.js',
+    requiredConfigKeys(appJson.configSchema),
+    appJson.name,
+  );
+
+  const degraded = described === null;
+  const tools: AttentionSurfaceTool[] = described ?? protocol.tools.map((name) => ({
+    name,
+    description: '',
+    parameters: null,
+    protected: false,
+  }));
+
+  const surface: AttentionSurface = { schemaVersion: 1, protocol, skill, tools };
+  if (appJson.configSchema !== undefined) surface.configSchema = appJson.configSchema;
+  if (degraded) surface.degraded = true;
+  return surface;
+}

--- a/packages/harness-cli/src/describe.ts
+++ b/packages/harness-cli/src/describe.ts
@@ -121,7 +121,13 @@ const DESCRIBE_SCRIPT = `(async () => {
       try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
     }
   }
-  process.exit(process.exitCode || 0);
+  // Do NOT call process.exit() here. The parent reads stdout as a PIPE, so the
+  // write is async — process.exit() can terminate before a large JSON payload
+  // finishes flushing, truncating it so the parent mis-reads a successful
+  // describe as "unparseable output" and degrades to names-only. Let Node exit
+  // naturally once the event loop drains (stdout/stderr flush first);
+  // process.exitCode (set to 3 on failure above) is honored. A genuine hang is
+  // bounded by the parent spawn's \`timeout\`.
 })();`;
 
 function requiredConfigKeys(configSchema: DescribeAppJson['configSchema']): string[] {

--- a/packages/harness-cli/src/describe.ts
+++ b/packages/harness-cli/src/describe.ts
@@ -181,8 +181,12 @@ function describeTools(
       resolvePromise(null);
     };
     proc.on('error', (e) => fallback(String((e as Error).message)));
-    proc.on('close', (code) => {
-      if (code !== 0) return fallback(err || `describe exited ${code}`);
+    proc.on('close', (code, signal) => {
+      // A signal kill (e.g. the `timeout` option firing SIGTERM) reports
+      // code===null + a non-null signal; surface the signal so a timeout reads
+      // as a kill, not the unhelpful "describe exited null".
+      if (code !== 0)
+        return fallback(err || (signal ? `describe killed by ${signal}` : `describe exited ${code}`));
       try {
         const parsed = JSON.parse(out) as { tools?: unknown };
         const tools = Array.isArray(parsed.tools)

--- a/packages/harness-cli/src/tar-read.ts
+++ b/packages/harness-cli/src/tar-read.ts
@@ -62,7 +62,13 @@ function findEntry(tar: Uint8Array, wantedName: string): Uint8Array | null {
   return null;
 }
 
-/** Read one file's UTF-8 contents from a gzipped tarball, or null if absent. */
+/**
+ * Read one file's UTF-8 contents from a gzipped tarball. Returns null when the
+ * entry is ABSENT — but ALSO when the tarball is unreadable/corrupt or its
+ * decompressed size exceeds {@link MAX_DECOMPRESSED_BYTES} (gunzip throws), or
+ * when a header is malformed. Callers that need to distinguish "entry missing"
+ * from "tarball unreadable" should probe with {@link isGzipReadable}.
+ */
 export async function readTarEntry(
   gzippedTarball: Uint8Array,
   entryName: string,
@@ -75,4 +81,20 @@ export async function readTarEntry(
   }
   const bytes = findEntry(tar, entryName);
   return bytes ? new TextDecoder().decode(bytes) : null;
+}
+
+/**
+ * True if the gzip stream decompresses within the size cap. Lets callers tell
+ * an ABSENT entry apart from an UNREADABLE/over-cap tarball — both of which
+ * otherwise surface as {@link readTarEntry} → null — so they can print an
+ * honest diagnostic instead of mislabeling a corrupt/oversized package as
+ * "entry not present".
+ */
+export function isGzipReadable(gzippedTarball: Uint8Array): boolean {
+  try {
+    gunzip(gzippedTarball);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/harness-cli/src/tar-read.ts
+++ b/packages/harness-cli/src/tar-read.ts
@@ -1,0 +1,78 @@
+/**
+ * Dependency-free reader for a single entry out of a gzipped npm-pack tarball.
+ *
+ * Ported verbatim from the publish-worker's `tarball-inspect.ts` (the format is
+ * frozen ustar; npm-pack never emits GNU long-names or sparse files). Used by:
+ *   - `publish`  — assert `package/attention-surface.json` actually landed in the
+ *                  produced .tgz (a missing `files` whitelist entry fails LOUD on
+ *                  the publisher's machine, not silently in the channel).
+ *   - `install`  — read the (Ed25519-verified) attention surface for display.
+ *
+ * Decompression uses the Node built-in `zlib.gunzipSync` (with a bounded
+ * `maxOutputLength`) — no npm dependency, preserving the CLI's zero-dep promise.
+ */
+
+import { gunzipSync } from 'node:zlib';
+
+const TAR_BLOCK_SIZE = 512;
+const MAX_DECOMPRESSED_BYTES = 64 * 1024 * 1024;
+
+/**
+ * Decompress a gzip stream with a hard output cap (a tiny zip bomb can expand
+ * ~1000×). `maxOutputLength` makes zlib throw before allocating past the cap.
+ */
+function gunzip(bytes: Uint8Array): Uint8Array {
+  const out = gunzipSync(bytes, { maxOutputLength: MAX_DECOMPRESSED_BYTES });
+  return new Uint8Array(out.buffer, out.byteOffset, out.byteLength);
+}
+
+function readString(tar: Uint8Array, offset: number, maxLen: number): string {
+  let end = offset;
+  const limit = Math.min(offset + maxLen, tar.byteLength);
+  while (end < limit && tar[end] !== 0) end++;
+  return new TextDecoder().decode(tar.subarray(offset, end));
+}
+
+function isZeroBlock(tar: Uint8Array, offset: number): boolean {
+  for (let i = offset; i < offset + TAR_BLOCK_SIZE && i < tar.byteLength; i++) {
+    if (tar[i] !== 0) return false;
+  }
+  return true;
+}
+
+function findEntry(tar: Uint8Array, wantedName: string): Uint8Array | null {
+  let offset = 0;
+  while (offset + TAR_BLOCK_SIZE <= tar.byteLength) {
+    if (isZeroBlock(tar, offset)) return null;
+    const name = readString(tar, offset, 100);
+    const prefix = readString(tar, offset + 345, 155);
+    const fullName = prefix ? `${prefix}/${name}` : name;
+    const sizeStr = readString(tar, offset + 124, 12);
+    const size = sizeStr ? parseInt(sizeStr, 8) : 0;
+    if (!Number.isFinite(size) || size < 0) return null;
+    if (offset + TAR_BLOCK_SIZE + size > tar.byteLength) return null;
+    const typeflag = tar[offset + 156];
+    const isRegularFile = typeflag === 0 || typeflag === 0x30; /* '0' */
+    if (isRegularFile && fullName === wantedName) {
+      return tar.slice(offset + TAR_BLOCK_SIZE, offset + TAR_BLOCK_SIZE + size);
+    }
+    const contentBlocks = Math.ceil(size / TAR_BLOCK_SIZE);
+    offset += TAR_BLOCK_SIZE + contentBlocks * TAR_BLOCK_SIZE;
+  }
+  return null;
+}
+
+/** Read one file's UTF-8 contents from a gzipped tarball, or null if absent. */
+export async function readTarEntry(
+  gzippedTarball: Uint8Array,
+  entryName: string,
+): Promise<string | null> {
+  let tar: Uint8Array;
+  try {
+    tar = gunzip(gzippedTarball);
+  } catch {
+    return null;
+  }
+  const bytes = findEntry(tar, entryName);
+  return bytes ? new TextDecoder().decode(bytes) : null;
+}

--- a/packages/harness-cli/src/verify.ts
+++ b/packages/harness-cli/src/verify.ts
@@ -89,9 +89,26 @@ export interface CatalogVersion {
   importName: string;
 }
 
+/**
+ * Optional signed display/disclosure block on a catalog entry. Produced by the
+ * publish worker, rendered by the storefront; the CLI does not read it. Typed
+ * here only for parity with the worker's `CatalogEntry` so the one signed shape
+ * stays in sync. `schemaVersion` is `number` (not a literal) so a future bump is
+ * tolerated, not a type error.
+ */
+export interface CatalogEntryMetadata {
+  schemaVersion: number;
+  title: string;
+  shortDesc: string;
+  category: string;
+  iconUrl?: string;
+  entitlements: readonly string[];
+}
+
 export interface CatalogEntry {
   name: string;
   versions: readonly CatalogVersion[];
+  metadata?: CatalogEntryMetadata;
 }
 
 export interface SignedCatalog {

--- a/packages/harness-cli/test/attention-surface-render.test.ts
+++ b/packages/harness-cli/test/attention-surface-render.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the install-time attention-surface RENDER path. The tarball is
+ * Ed25519-verified for authenticity, but its `attention-surface.json` is still
+ * publisher-authored JSON whose SHAPE is not validated — a buggy or hostile
+ * publisher can ship malformed fields. `formatAttentionSurface` must be total:
+ * it degrades a bad field rather than throwing (which would crash install,
+ * breaking the "never blocks" promise).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatAttentionSurface } from '../src/commands/install';
+import type { AttentionSurface } from '../src/describe';
+
+// Cast helper: feed deliberately ill-typed shapes through the typed signature.
+const surface = (raw: unknown): AttentionSurface => raw as AttentionSurface;
+
+describe('formatAttentionSurface — malformed publisher input', () => {
+  it('renders a well-formed surface', () => {
+    const out = formatAttentionSurface(
+      surface({
+        protocol: { name: 'web_research', useWhen: 'questions about the live web' },
+        tools: [{ name: 'web_search', description: 'search the web', protected: false }],
+        configSchema: { properties: { apiKey: { type: 'string', 'x-secret': true } } },
+        skill: 'line 1\nline 2',
+      }),
+      'web',
+    );
+    expect(out).toContain('web_research');
+    expect(out).toContain('• web_search — search the web');
+    expect(out).toContain('apiKey (string, secret)');
+    expect(out).toContain('Tools (1)');
+  });
+
+  it('does not throw when tools contains null / non-object entries', () => {
+    let out = '';
+    expect(() => {
+      out = formatAttentionSurface(surface({ tools: [null, 42, { name: 'ok' }, undefined] }), 'x');
+    }).not.toThrow();
+    // The two malformed entries are skipped; only the valid one renders.
+    expect(out).toContain('Tools (1)');
+    expect(out).toContain('• ok');
+  });
+
+  it('does not throw when a tool name/description is the wrong type', () => {
+    let out = '';
+    expect(() => {
+      out = formatAttentionSurface(surface({ tools: [{ name: 123, description: { nested: true } }] }), 'x');
+    }).not.toThrow();
+    expect(out).toContain('• (unnamed)');
+  });
+
+  it('does not throw when skill is a non-string', () => {
+    expect(() => formatAttentionSurface(surface({ skill: 123 }), 'x')).not.toThrow();
+    expect(() => formatAttentionSurface(surface({ skill: { a: 1 } }), 'x')).not.toThrow();
+  });
+
+  it('does not throw when configSchema.properties is malformed', () => {
+    expect(() => formatAttentionSurface(surface({ configSchema: { properties: { k: null } } }), 'x')).not.toThrow();
+    expect(() => formatAttentionSurface(surface({ configSchema: 'nonsense' }), 'x')).not.toThrow();
+  });
+
+  it('does not throw on an empty object', () => {
+    let out = '';
+    expect(() => {
+      out = formatAttentionSurface(surface({}), 'x');
+    }).not.toThrow();
+    expect(out).toContain('Tools (0)');
+  });
+});

--- a/packages/harness-cli/test/attention-surface-render.test.ts
+++ b/packages/harness-cli/test/attention-surface-render.test.ts
@@ -18,7 +18,10 @@ describe('formatAttentionSurface — malformed publisher input', () => {
     const out = formatAttentionSurface(
       surface({
         protocol: { name: 'web_research', useWhen: 'questions about the live web' },
-        tools: [{ name: 'web_search', description: 'search the web', protected: false }],
+        tools: [
+          { name: 'web_search', description: 'search the web', protected: false },
+          { name: 'send_email', description: 'send mail', protected: true },
+        ],
         configSchema: { properties: { apiKey: { type: 'string', 'x-secret': true } } },
         skill: 'line 1\nline 2',
       }),
@@ -27,7 +30,10 @@ describe('formatAttentionSurface — malformed publisher input', () => {
     expect(out).toContain('web_research');
     expect(out).toContain('• web_search — search the web');
     expect(out).toContain('apiKey (string, secret)');
-    expect(out).toContain('Tools (1)');
+    expect(out).toContain('Tools (2)');
+    // `protected` → "[needs grant]" (requires consent), NOT "[writes]".
+    expect(out).toContain('• send_email — send mail  [needs grant]');
+    expect(out).not.toContain('[writes]');
   });
 
   it('does not throw when tools contains null / non-object entries', () => {

--- a/packages/harness-cli/test/describe.test.ts
+++ b/packages/harness-cli/test/describe.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the publish-time attention-surface extraction. The "real app" cases
+ * construct the actual built first-party apps in an isolated subprocess and read
+ * their tool schemas (the genuinely novel mechanism); the fallback case proves a
+ * non-constructable app degrades LOUDLY to tool NAMES rather than throwing.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFile, mkdtemp, writeFile, mkdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { buildAttentionSurface, type DescribeAppJson, type DescribePackageJson } from '../src/describe';
+
+const APPS_DIR = fileURLToPath(new URL('../../apps', import.meta.url));
+
+async function readApp(name: string): Promise<{ dir: string; app: DescribeAppJson; pkg: DescribePackageJson }> {
+  const dir = join(APPS_DIR, name);
+  const app = JSON.parse(await readFile(join(dir, 'app.json'), 'utf-8')) as DescribeAppJson;
+  const pkg = JSON.parse(await readFile(join(dir, 'package.json'), 'utf-8')) as DescribePackageJson;
+  return { dir, app, pkg };
+}
+
+describe('buildAttentionSurface — real first-party apps', () => {
+  it('wikipedia: full tool schemas + skill + useWhen, not degraded', async () => {
+    const { dir, app, pkg } = await readApp('wikipedia');
+    const s = await buildAttentionSurface(dir, app, pkg);
+    expect(s.degraded).toBeUndefined();
+    expect(s.protocol.name).toBe('wikipedia_research');
+    expect(s.protocol.useWhen.length).toBeGreaterThan(0);
+    expect(s.skill.length).toBeGreaterThan(0);
+    const names = s.tools.map((t) => t.name).sort();
+    expect(names).toEqual(['wikipedia_fetch', 'wikipedia_search']);
+    for (const t of s.tools) {
+      expect(t.description.length).toBeGreaterThan(0);
+      expect(t.parameters).not.toBeNull();
+    }
+  }, 60_000);
+
+  it('corpus: constructs over a seeded temp dir → full schemas', async () => {
+    const { dir, app, pkg } = await readApp('corpus');
+    const s = await buildAttentionSurface(dir, app, pkg);
+    expect(s.tools.map((t) => t.name).sort()).toEqual(['grep', 'read_file', 'search']);
+    expect(s.tools.every((t) => t.description.length > 0)).toBe(true);
+    expect(s.degraded).toBeUndefined();
+  }, 60_000);
+});
+
+describe('buildAttentionSurface — fallback', () => {
+  it('degrades LOUDLY to app.json tool NAMES when the app cannot be constructed', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'describe-fallback-'));
+    await mkdir(join(dir, 'dist'), { recursive: true });
+    // A dist that throws on require + no node_modules → subprocess fails → fallback.
+    await writeFile(join(dir, 'dist', 'index.js'), 'throw new Error("boom");');
+    await writeFile(join(dir, 'skill.eta'), 'the skill template');
+    const app: DescribeAppJson = {
+      name: 'broken',
+      protocol: { name: 'broken_protocol', useWhen: 'never', tools: ['alpha', 'beta'] },
+    };
+    const pkg: DescribePackageJson = { name: '@x/broken', version: '1.0.0', main: 'dist/index.js' };
+
+    const s = await buildAttentionSurface(dir, app, pkg);
+    expect(s.degraded).toBe(true);
+    expect(s.tools.map((t) => t.name)).toEqual(['alpha', 'beta']);
+    expect(s.tools.every((t) => t.description === '' && t.parameters === null)).toBe(true);
+    expect(s.skill).toBe('the skill template'); // skill.eta still read
+    expect(s.protocol.useWhen).toBe('never');
+  }, 60_000);
+});

--- a/packages/harness-cli/test/tar-read.test.ts
+++ b/packages/harness-cli/test/tar-read.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for the dep-free tarball reader used by publish (post-pack assert) +
+ * install (attention-surface display). Builds a gzipped ustar tarball with
+ * node:zlib + a manual header writer, matching the worker's tarball-inspect test.
+ */
+import { describe, it, expect } from 'vitest';
+import { gzipSync } from 'node:zlib';
+import { readTarEntry } from '../src/tar-read';
+
+const TAR_BLOCK = 512;
+
+function writeField(buf: Uint8Array, off: number, val: string, len: number): void {
+  const bytes = new TextEncoder().encode(val);
+  for (let i = 0; i < len; i++) buf[off + i] = i < bytes.length ? bytes[i] : 0;
+}
+
+function header(name: string, size: number): Uint8Array {
+  const h = new Uint8Array(TAR_BLOCK);
+  writeField(h, 0, name, 100);
+  writeField(h, 100, '0000644', 8);
+  writeField(h, 124, size.toString(8).padStart(11, '0'), 12);
+  writeField(h, 136, '00000000000', 12);
+  for (let i = 148; i < 156; i++) h[i] = 0x20;
+  h[156] = 0x30;
+  writeField(h, 257, 'ustar', 6);
+  writeField(h, 263, '00', 2);
+  let cksum = 0;
+  for (let i = 0; i < TAR_BLOCK; i++) cksum += h[i];
+  writeField(h, 148, cksum.toString(8).padStart(6, '0'), 6);
+  h[154] = 0x00;
+  h[155] = 0x20;
+  return h;
+}
+
+function buildTarball(entries: Array<{ name: string; content: string }>): Uint8Array {
+  const parts: Uint8Array[] = [];
+  for (const e of entries) {
+    const body = new TextEncoder().encode(e.content);
+    parts.push(header(e.name, body.byteLength));
+    const padded = new Uint8Array(Math.ceil(body.byteLength / TAR_BLOCK) * TAR_BLOCK);
+    padded.set(body);
+    parts.push(padded);
+  }
+  parts.push(new Uint8Array(TAR_BLOCK * 2));
+  const total = parts.reduce((n, p) => n + p.byteLength, 0);
+  const tar = new Uint8Array(total);
+  let off = 0;
+  for (const p of parts) {
+    tar.set(p, off);
+    off += p.byteLength;
+  }
+  return new Uint8Array(gzipSync(tar));
+}
+
+describe('readTarEntry', () => {
+  it('reads a present entry by full path', async () => {
+    const tgz = buildTarball([
+      { name: 'package/package.json', content: '{"name":"x"}' },
+      { name: 'package/attention-surface.json', content: '{"skill":"hi"}' },
+    ]);
+    expect(await readTarEntry(tgz, 'package/attention-surface.json')).toBe('{"skill":"hi"}');
+  });
+
+  it('returns null for an absent entry', async () => {
+    const tgz = buildTarball([{ name: 'package/package.json', content: '{}' }]);
+    expect(await readTarEntry(tgz, 'package/attention-surface.json')).toBeNull();
+  });
+
+  it('returns null on non-gzip / corrupt input (never throws)', async () => {
+    expect(await readTarEntry(new Uint8Array([1, 2, 3, 4]), 'package/x')).toBeNull();
+  });
+
+  it('caps a zip bomb instead of OOMing', async () => {
+    const bomb = new Uint8Array(gzipSync(Buffer.alloc(65 * 1024 * 1024, 0)));
+    expect(bomb.byteLength).toBeLessThan(1024 * 1024);
+    // The 64 MiB maxOutputLength makes gunzip throw → readTarEntry returns null.
+    expect(await readTarEntry(bomb, 'package/x')).toBeNull();
+  });
+});

--- a/packages/rig/LICENSE-FAQ.md
+++ b/packages/rig/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/bundle.ts
+++ b/packages/rig/src/bundle.ts
@@ -118,6 +118,28 @@ export interface CatalogVersion {
 }
 
 /**
+ * Optional signed display/disclosure block on a catalog entry. Produced by the
+ * publish worker and rendered by the storefront; the rig runtime does not read
+ * it. Typed here for parity with the worker's `CatalogEntry` so the one signed
+ * shape stays in sync. `schemaVersion` is `number` (not a literal) so a future
+ * bump is tolerated rather than a type error.
+ */
+export interface CatalogEntryMetadata {
+  /** Block schema revision; consumers ignore an unknown future version. */
+  schemaVersion: number;
+  /** Storefront display title. */
+  title: string;
+  /** One-line storefront description. */
+  shortDesc: string;
+  /** Display category (from the storefront taxonomy). */
+  category: string;
+  /** Optional content-addressed icon URL. */
+  iconUrl?: string;
+  /** Disclosure entitlement keys — display-only (no runtime enforcement). */
+  entitlements: readonly string[];
+}
+
+/**
  * One app's entry in the catalog.
  */
 export interface CatalogEntry {
@@ -125,6 +147,8 @@ export interface CatalogEntry {
   name: string;
   /** Published versions, unordered. */
   versions: readonly CatalogVersion[];
+  /** Optional signed display/disclosure block; absent until a publisher submits metadata. */
+  metadata?: CatalogEntryMetadata;
 }
 
 /**

--- a/packages/rig/src/protocol.ts
+++ b/packages/rig/src/protocol.ts
@@ -135,9 +135,8 @@ export const VALIDATED_MODELS_3_0: readonly ValidatedModelFamily[] = [
 /**
  * The App protocol version this build of `@lloyal-labs/rig` ships.
  *
- * Apps declare `appProtocolVersion` in `app.json`; `defineApp` and the
- * registry (`createAppRegistry({ apps })` / `registry.enable`) refuse to
- * enable apps whose declared version is not in
+ * Apps declare `appProtocolVersion` in `app.json`; `defineApp` and
+ * `registry.enable` refuse to enable apps whose declared version is not in
  * {@link SUPPORTED_APP_PROTOCOL_VERSIONS}.
  */
 export const APP_PROTOCOL_VERSION = '3.0';

--- a/packages/rig/src/registry.ts
+++ b/packages/rig/src/registry.ts
@@ -1,20 +1,21 @@
 /**
- * `createAppRegistry` — harness-wide app registry with a **declarative**
- * app set and structured, **isolated** per-app lifecycle.
+ * `createAppRegistry` — harness-wide app registry with structured,
+ * **isolated** per-app lifecycle.
  *
- * The harness declares its apps as factories; the registry owns the rest:
+ * `createAppRegistry({ configStore, grantStore? })` returns an **empty**
+ * registry; `registry.enable(factory)` is the single way to enable an app —
+ * creation is never enablement, so the two paths can't collide.
  *
- * - `createAppRegistry({ configStore, apps })` runs each factory in its own
- *   **detached** Effection scope, seeded with the app-facing framework
- *   contexts (`AppConfigStoreCtx`, `RerankerCtx`) so the factory
- *   reads config + reranker. The factory body is setup; a `resource()`
- *   factory's `ensure(...)` is teardown. The registry tears the scopes
- *   down on its own scope exit, reverse register-order, **best-effort** —
- *   a throwing teardown is logged but never strands a sibling, and never
+ * - `registry.enable(factory)` runs the factory in its own **detached**
+ *   Effection scope, seeded with the app-facing framework contexts
+ *   (`AppConfigStoreCtx`, `RerankerCtx`) so the factory reads config +
+ *   reranker. The factory body is setup; a `resource()` factory's
+ *   `ensure(...)` is teardown. Every enabled app's scope is torn down on the
+ *   registry's own scope exit, reverse enable-order, **best-effort** — a
+ *   throwing teardown is logged but never strands a sibling, and never
  *   crashes the harness. The harness does **not** call a per-app register
- *   verb at boot.
- * - `registry.enable(factory)` / `registry.disable(name)` handle the
- *   genuine dynamic case (mid-session enable/disable). `enable` →
+ *   verb at boot; it just calls `enable` for each boot app.
+ * - `registry.disable(name)` handles mid-session removal. `enable` →
  *   `'enabled'`, `disable` → `'disabled'` (matching {@link AppState}).
  *   `disable` swallows + logs a throwing teardown, so a mid-session
  *   uninstall can't crash the session — possible only because each app

--- a/packages/rig/src/registry.ts
+++ b/packages/rig/src/registry.ts
@@ -67,15 +67,6 @@ export interface CreateAppRegistryOpts {
    * authGuard fails closed (every protected tool denied).
    */
   grantStore?: GrantStore;
-  /**
-   * App factories to enable at construction (the boot set). Each runs in
-   * its own detached scope and is torn down on registry scope exit. The
-   * harness assembles this list from static imports of installed apps
-   * (`import { createXxxApp } from '@lloyal-labs/<name>-app'`).
-   * **Set `RerankerCtx` before calling** if any factory reads the
-   * shared reranker.
-   */
-  apps?: readonly AppFactory[];
 }
 
 interface RegistryEntry {
@@ -88,21 +79,20 @@ interface RegistryEntry {
  * Create the harness-wide app registry.
  *
  * Sets `AppRegistryCtx` and `AppConfigStoreCtx` in the caller's scope (the
- * `initAgents` pattern), enables each factory in `opts.apps`, and tears
- * every enabled app's scope down on the caller's scope exit (reverse
- * order, best-effort).
+ * `initAgents` pattern). Returns an empty registry — enable the boot set with
+ * explicit `registry.enable(factory)` calls. Every enabled app's scope is torn
+ * down on the caller's scope exit (reverse order, best-effort). Creation is not
+ * enablement: there is one way to enable an app, so the two paths can't collide.
  *
  * @example
  * ```ts
  * import { createWebApp } from '@lloyal-labs/web-app';
  * import { createCorpusApp } from '@lloyal-labs/corpus-app';
- * import { createJiraApp } from '@lloyal-labs/jira-app';
  *
  * yield* RerankerCtx.set(reranker);          // before, if factories read it
- * const registry = yield* createAppRegistry({
- *   configStore,
- *   apps: [createWebApp, createCorpusApp, createJiraApp],
- * });
+ * const registry = yield* createAppRegistry({ configStore });
+ * yield* registry.enable(createWebApp);
+ * yield* registry.enable(createCorpusApp);
  * // ... pool dispatch ...
  * // registry scope exit tears down every app (factory ensures fire)
  * ```
@@ -110,7 +100,7 @@ interface RegistryEntry {
 export function* createAppRegistry(
   opts: CreateAppRegistryOpts,
 ): Operation<AppRegistry> {
-  const { configStore, grantStore, apps } = opts;
+  const { configStore, grantStore } = opts;
   const entries = new Map<string, RegistryEntry>();
   const order: string[] = [];
 
@@ -184,6 +174,39 @@ export function* createAppRegistry(
           );
         }
 
+        // Namespace-collision guard. The catalog scopes apps by handle
+        // (`acme/web` vs `lloyal/web`), but the runtime/model surface is
+        // UNSCOPED — `manifest.name` keys this registry, and `protocol.name` +
+        // each tool name address the app in the shared spine the model reads.
+        // Two same-short-named apps from different publishers therefore collide
+        // here. The `manifest.name` check above catches one face; this catches
+        // the model-facing faces (otherwise spine-render emits two CATALOG_ENTRY
+        // blocks with the same protocol/tool names — silent routing ambiguity +
+        // a collided BOUNDARY_MARKER). Fail loud, naming both apps, so the
+        // integrator knows it's a cross-publisher clash — not their bug.
+        const incomingProtocol = app.manifest.protocol.name;
+        const incomingTools = app.manifest.protocol.tools;
+        for (const { app: existing } of entries.values()) {
+          if (existing.manifest.protocol.name === incomingProtocol) {
+            throw new Error(
+              `Cannot enable "${app.manifest.name}": its protocol "${incomingProtocol}" ` +
+                `collides with already-enabled "${existing.manifest.name}". Two AgentApps ` +
+                `can't share a model-facing protocol name in one harness — disable one, or ` +
+                `use apps with distinct protocol names.`,
+            );
+          }
+          const clashTool = incomingTools.find((t) =>
+            existing.manifest.protocol.tools.includes(t),
+          );
+          if (clashTool !== undefined) {
+            throw new Error(
+              `Cannot enable "${app.manifest.name}": its tool "${clashTool}" collides with ` +
+                `already-enabled "${existing.manifest.name}". Two AgentApps can't share a ` +
+                `tool name in one harness — disable one, or use apps with distinct tool names.`,
+            );
+          }
+        }
+
         entries.set(app.manifest.name, { app, destroy });
         order.push(app.manifest.name);
         added = true;
@@ -245,12 +268,6 @@ export function* createAppRegistry(
     entries.clear();
     order.length = 0;
   });
-
-  if (apps) {
-    for (const factory of apps) {
-      yield* registry.enable(factory);
-    }
-  }
 
   return registry;
 }

--- a/packages/rig/test/registry.test.ts
+++ b/packages/rig/test/registry.test.ts
@@ -2,9 +2,10 @@
  * Tests for `createAppRegistry` + `registry.enable` / `disable` —
  * RFC §5.4, §6 (declarative per-app scope model).
  *
- * The model: the harness declares its boot set via
- * `createAppRegistry({ apps })`; each factory runs in its own *detached*
- * Effection scope (`createScope()` — does NOT inherit context, so the
+ * The model: the harness enables its boot set via explicit
+ * `registry.enable(factory)` calls (creation is not enablement — there is one
+ * enable path, so the two can't collide); each factory runs in its own
+ * *detached* Effection scope (`createScope()` — does NOT inherit context, so the
  * registry seeds `AppConfigStoreCtx` / `AppRegistryCtx` / `RerankerCtx`
  * into it explicitly; the detachment is what isolates teardown errors so
  * `disable` can swallow them). `disable` / registry scope-exit tear that
@@ -13,7 +14,7 @@
  * standalone register verb.
  *
  * Protocols verified:
- * 1. **Boot set (`apps: []`) is enabled** — `byName`/`enabled`/`stateOf` reflect it.
+ * 1. **Boot set (explicit `enable()`) is enabled** — `byName`/`enabled`/`stateOf` reflect it.
  * 2. **Factory runs in a context-bearing scope** — a factory reading
  *    `AppConfigStoreCtx` works (the regression for the detached-scope bug).
  * 3. **Factory body is setup; runs during enable.**
@@ -42,12 +43,21 @@ function fakeApp(opts: {
   name: string;
   appProtocolVersion?: string;
   configSchema?: AppManifest['configSchema'];
+  /** Override the model-facing protocol name (defaults to `${name}_research`). */
+  protocolName?: string;
+  /** Override the tool names (default a single per-name tool, so distinct
+   *  apps don't trip the namespace-collision guard). */
+  tools?: string[];
 }): App {
   const manifest: AppManifest = {
     name: opts.name,
     version: '1.0.0',
     appProtocolVersion: opts.appProtocolVersion ?? '3.0',
-    protocol: { name: `${opts.name}_research`, useWhen: 'do things', tools: ['x'] },
+    protocol: {
+      name: opts.protocolName ?? `${opts.name}_research`,
+      useWhen: 'do things',
+      tools: opts.tools ?? [`${opts.name}_tool`],
+    },
     configSchema: opts.configSchema,
   };
   return {
@@ -86,12 +96,13 @@ function resourceFactory(
 // ── Tests ────────────────────────────────────────────────────────
 
 describe('createAppRegistry', () => {
-  it('enables the declarative boot set and exposes it via byName / enabled / stateOf', async () => {
+  it('enables the boot set via explicit enable() and exposes it via byName / enabled / stateOf', async () => {
     const result = await run(function* () {
       const registry = yield* createAppRegistry({
         configStore: createInMemoryConfigStore(),
-        apps: [plainFactory({ name: 'web' }), plainFactory({ name: 'corpus' })],
       });
+      yield* registry.enable(plainFactory({ name: 'web' }));
+      yield* registry.enable(plainFactory({ name: 'corpus' }));
       return {
         viaByName: registry.byName('web')?.manifest.name,
         enabledNames: registry.enabled().map((a) => a.manifest.name),
@@ -118,7 +129,8 @@ describe('createAppRegistry', () => {
         readConfig = yield* cs.get('ctxapp');
         return fakeApp({ name: 'ctxapp' });
       };
-      yield* createAppRegistry({ configStore, apps: [ctxFactory] });
+      const registry = yield* createAppRegistry({ configStore });
+      yield* registry.enable(ctxFactory);
       return readConfig;
     });
     expect(seen).toEqual({ key: 'value' });
@@ -169,14 +181,12 @@ describe('createAppRegistry', () => {
   it('fires ensure() teardown on registry scope exit, reverse register order', async () => {
     const order: string[] = [];
     await run(function* () {
-      yield* createAppRegistry({
+      const registry = yield* createAppRegistry({
         configStore: createInMemoryConfigStore(),
-        apps: [
-          resourceFactory({ name: 'a' }, { onTeardown: () => order.push('a') }),
-          resourceFactory({ name: 'b' }, { onTeardown: () => order.push('b') }),
-          resourceFactory({ name: 'c' }, { onTeardown: () => order.push('c') }),
-        ],
       });
+      yield* registry.enable(resourceFactory({ name: 'a' }, { onTeardown: () => order.push('a') }));
+      yield* registry.enable(resourceFactory({ name: 'b' }, { onTeardown: () => order.push('b') }));
+      yield* registry.enable(resourceFactory({ name: 'c' }, { onTeardown: () => order.push('c') }));
     });
     expect(order).toEqual(['c', 'b', 'a']);
   });
@@ -189,16 +199,14 @@ describe('createAppRegistry', () => {
     const seen: string[] = [];
     await expect(
       run(function* () {
-        yield* createAppRegistry({
+        const registry = yield* createAppRegistry({
           configStore: createInMemoryConfigStore(),
-          apps: [
-            resourceFactory({ name: 'good1' }, { onTeardown: () => seen.push('good1') }),
-            resourceFactory({ name: 'bad' }, {
-              onTeardown: () => { throw new Error('teardown failed'); },
-            }),
-            resourceFactory({ name: 'good2' }, { onTeardown: () => seen.push('good2') }),
-          ],
         });
+        yield* registry.enable(resourceFactory({ name: 'good1' }, { onTeardown: () => seen.push('good1') }));
+        yield* registry.enable(resourceFactory({ name: 'bad' }, {
+          onTeardown: () => { throw new Error('teardown failed'); },
+        }));
+        yield* registry.enable(resourceFactory({ name: 'good2' }, { onTeardown: () => seen.push('good2') }));
       }),
     ).resolves.not.toThrow();
     expect(seen).toEqual(['good2', 'good1']);
@@ -248,19 +256,17 @@ describe('createAppRegistry', () => {
       run(function* () {
         const configStore = createInMemoryConfigStore();
         yield* configStore.set('webcfg', { wrongField: 'oops' });
-        yield* createAppRegistry({
-          configStore,
-          apps: [
-            plainFactory({
-              name: 'webcfg',
-              configSchema: {
-                type: 'object',
-                required: ['tavilyKey'],
-                properties: { tavilyKey: { type: 'string' } },
-              },
-            }),
-          ],
-        });
+        const registry = yield* createAppRegistry({ configStore });
+        yield* registry.enable(
+          plainFactory({
+            name: 'webcfg',
+            configSchema: {
+              type: 'object',
+              required: ['tavilyKey'],
+              properties: { tavilyKey: { type: 'string' } },
+            },
+          }),
+        );
       }),
     ).rejects.toThrow('missing required key "tavilyKey"');
   });
@@ -270,19 +276,17 @@ describe('createAppRegistry', () => {
       run(function* () {
         const configStore = createInMemoryConfigStore();
         yield* configStore.set('typecheck', { port: 'not-a-number' });
-        yield* createAppRegistry({
-          configStore,
-          apps: [
-            plainFactory({
-              name: 'typecheck',
-              configSchema: {
-                type: 'object',
-                required: ['port'],
-                properties: { port: { type: 'number' } },
-              },
-            }),
-          ],
-        });
+        const registry = yield* createAppRegistry({ configStore });
+        yield* registry.enable(
+          plainFactory({
+            name: 'typecheck',
+            configSchema: {
+              type: 'object',
+              required: ['port'],
+              properties: { port: { type: 'number' } },
+            },
+          }),
+        );
       }),
     ).rejects.toThrow('declares "number"');
   });
@@ -306,6 +310,58 @@ describe('createAppRegistry', () => {
     expect(result.message).toContain('already enabled');
     expect(result.stillThere).toBe(true);
     expect(result.count).toBe(1);
+  });
+
+  it('throws on a colliding protocol name across two differently-named apps (cross-publisher clash)', async () => {
+    // `lloyal/web` and `acme/web` install as distinct catalog/npm entries but
+    // both carry the bare model-facing `protocol.name`. Enabling both in one
+    // harness must fail loud (otherwise the spine emits two same-named blocks).
+    const result = await run(function* () {
+      const registry = yield* createAppRegistry({ configStore: createInMemoryConfigStore() });
+      yield* registry.enable(
+        plainFactory({ name: 'web-lloyal', protocolName: 'web_research', tools: ['lloyal_search'] }),
+      );
+      try {
+        yield* registry.enable(
+          plainFactory({ name: 'web-acme', protocolName: 'web_research', tools: ['acme_search'] }),
+        );
+        return { message: undefined as string | undefined, enabled: registry.enabled().length };
+      } catch (err) {
+        return { message: (err as Error).message, enabled: registry.enabled().length };
+      }
+    });
+    expect(result.message).toContain('protocol "web_research"');
+    expect(result.message).toContain('web-lloyal');
+    expect(result.enabled).toBe(1);
+  });
+
+  it('throws on a colliding tool name across two differently-named apps', async () => {
+    const result = await run(function* () {
+      const registry = yield* createAppRegistry({ configStore: createInMemoryConfigStore() });
+      yield* registry.enable(
+        plainFactory({ name: 'docs-lloyal', protocolName: 'lloyal_docs', tools: ['search', 'read'] }),
+      );
+      try {
+        yield* registry.enable(
+          plainFactory({ name: 'docs-acme', protocolName: 'acme_docs', tools: ['search', 'write'] }),
+        );
+        return undefined as string | undefined;
+      } catch (err) {
+        return (err as Error).message;
+      }
+    });
+    expect(result).toContain('tool "search"');
+    expect(result).toContain('docs-lloyal');
+  });
+
+  it('coexists when protocol + tool names are distinct (the happy path)', async () => {
+    const names = await run(function* () {
+      const registry = yield* createAppRegistry({ configStore: createInMemoryConfigStore() });
+      yield* registry.enable(plainFactory({ name: 'web' }));
+      yield* registry.enable(plainFactory({ name: 'corpus' }));
+      return registry.enabled().map((a) => a.manifest.name);
+    });
+    expect(names).toEqual(['web', 'corpus']);
   });
 
   it('disable on an unknown name is a no-op', async () => {

--- a/packages/sdk/LICENSE-FAQ.md
+++ b/packages/sdk/LICENSE-FAQ.md
@@ -17,8 +17,8 @@ of this page is illustration.
 
 HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
 packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
-source-available under **FSL-1.1-Apache-2.0** (the Functional Source License,
-Apache 2.0 future grant). FSL is a [Fair Source](https://fair.io) license.
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
 
 Each version converts to Apache 2.0 two years after its release. The
 restriction during those two years is narrow: **you cannot offer a competing

--- a/packages/sdk/test/rerank-integration.test.ts
+++ b/packages/sdk/test/rerank-integration.test.ts
@@ -110,6 +110,11 @@ async function drain<T>(iter: AsyncIterable<T>): Promise<T> {
 }
 
 // Vitest 5+ syntax: skipIf at the describe level.
+// @TODO(rerank-ci): these margin/rank thresholds are QUANT-SPECIFIC — they pass
+// on q8_0 and fail on q4_k_m (margin 1.13 < 2, rank 4 ≥ 3). Because the suite
+// skips when no GGUF is present, CI never runs them and they gate nothing. Pin a
+// known quant + SHA and wire a tag-triggered rerank gate (see lloyal-sdk task
+// #453) so this stops being machine/quant-dependent. Until then: skips on CI.
 const describeWithModel = SKIP_REASON ? describe.skip : describe;
 
 describeWithModel(`Rerank integration (post-R3) — ${SKIP_REASON ?? path.basename(MODEL_PATH!)}`, () => {


### PR DESCRIPTION
Third-party app-developer DX feedback remediation, plus the parked attention-surface CLI work.

## Commits
- `feat(cli)` — `harness.dev describe` extracts an app's attention surface (protocol, tools, declared entitlements) into `attention-surface.json`, publish ships it inside the tarball, install renders it on fetch. **harness.dev 0.4.1 → 0.5.0**
- `feat(agents,rig)!` — DX remediation:
  - `enableThinking` pool default `false → true` (reference model is now Qwen3.5-4B, a thinking model). Every regression-protected site already passes `false` explicitly, so the flip only reaches callers who never set it.
  - `registry.enable()` fails loud on a colliding `protocol.name` or tool name across differently-named apps (cross-publisher namespace clash — the handle scope evaporates at enable-time).
  - remove the auto-enabling `apps` option from `createAppRegistry` (creation is not enablement).
  - `Tool<TArgs = any>` so heterogeneous `Tool` subclasses fit `Tool[]` without a cast.
  - **agents + rig 3.0.2 → 3.1.0**

## Breaking
- `createAppRegistry` no longer accepts `apps`.
- `enableThinking` now defaults `true`.

## Verification
- `tsc -b` green across all packages.
- 437/439 unit tests pass. The 2 failures are known quant-specific `rerank-integration` threshold tests (local q4_k_m vs q8_0 margins) — `@TODO`'d and `describe.skip`'d on CI.

Docs land separately in the hdk-docs PR.