### PR TITLE
chore(release): reconcile root lockfile with v3.1.1 workspace versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2500,7 +2500,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -2556,7 +2556,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",
@@ -2573,7 +2573,7 @@
     },
     "packages/sdk": {
       "name": "@lloyal-labs/sdk",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "SEE LICENSE IN LICENSE"
     }
   }


### PR DESCRIPTION
Reconciles the root `package-lock.json` workspace versions with the v3.1.1 bump from #15 (`sdk 3.0.3 / agents 3.1.1 / rig 3.1.1`).

The manual version-field edit in #15 didn't update the lockfile, leaving it stale (`3.0.2 / 3.1.0 / 3.1.0`) — which fails `npm ci`. Fixed deterministically with `npm install --package-lock-only`. 3-line diff, no node_modules change.

v3.1.1 is already published (release.yml uses `npm install`, which tolerated the drift); this only makes `main` consistent for `npm ci` / fresh clones.