### PR TITLE
feat(agents): target-dispatch fan-out — per-agent serial, inter-agent concurrent

### DIFF
--- a/packages/agents/src/Tool.ts
+++ b/packages/agents/src/Tool.ts
@@ -78,6 +78,28 @@ export abstract class Tool<TArgs = any> {
   readonly protected?: boolean;
 
   /**
+   * Whether this tool is eligible for **fan-out** dispatch — running on a
+   * child fiber concurrently with other agents' tool calls (and the pool's
+   * own decode), instead of inline on the single tick-loop fiber.
+   *
+   * **Inline by default** (`false`/unset): the pool `await`s `execute()` on
+   * the loop fiber. Safe for ANY tool, and REQUIRED for any tool that issues
+   * a native op on the **main** `llama_context` — anything that nests
+   * `agentPool` / `withSpine` / `useAgent` (e.g. `delegate`, `plan`) or
+   * decodes on `context.branch`. Two concurrent decodes on one context
+   * segfault, so the single-fiber discipline must hold for these.
+   *
+   * **Fan-out** (`true`): `execute()` issues NO native op on the main context
+   * — only network I/O, pure CPU, or a *separate* context (e.g. the reranker,
+   * which owns its own and self-serializes). The pool spawns it off the loop
+   * fiber so one agent's slow/hung tool never stalls the others; completions
+   * drain back on-fiber. Set this ONLY when the no-main-context-decode
+   * invariant holds: a wrong `true` is a segfault, a wrong `false` is merely a
+   * parked loop — so the default is deliberately the safe one.
+   */
+  readonly fanout?: boolean;
+
+  /**
    * Execute the tool with parsed arguments
    *
    * Called by the agent pool when the model emits a tool call matching

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -54,10 +54,19 @@ type ToolCompletion =
   | { kind: 'retry'; agent: Agent; tc: ParsedToolCall; callId: string; dispatchTraceId: number; toolT0: number; retryAttempt: number; err: ToolRetryError }
   | { kind: 'error'; agent: Agent; tc: ParsedToolCall; callId: string; dispatchTraceId: number; err: Error };
 
-/** Max concurrent fan-out tool children (Effection has no semaphore — a
- *  FIFO counting gate caps it). Inline tools don't count: the loop fiber
- *  already serializes them. */
-const MAX_CONCURRENT_TOOLS = 8;
+/** Default cap on concurrent fan-out tool children (Effection has no semaphore
+ *  — a FIFO counting gate enforces it). Overridable per pool via
+ *  {@link AgentPoolOptions.maxConcurrentTools}. Inline tools don't count: the
+ *  loop fiber already serializes them. */
+const DEFAULT_MAX_CONCURRENT_TOOLS = 8;
+
+/** Normalize a thrown value to an `Error`. Tools — especially third-party —
+ *  may throw non-Error values (`throw 'rate limited'`, `throw { code: 500 }`);
+ *  an `err as Error` cast would leave `.message` undefined in the `tool:error`
+ *  trace and the agent's result. */
+function toError(err: unknown): Error {
+  return err instanceof Error ? err : new Error(String(err));
+}
 
 /** FIFO counting gate: acquire before a fan-out child's `execute`, release in
  *  an `ensure`. A halt while queued runs the action cleanup (drops the waiter);
@@ -932,7 +941,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     const inflightTasks = new Map<number, Task<void>>();
     // Fired by a child on completion so the all-parked nap wakes immediately.
     const toolWake = createSignal<void, void>();
-    const permits = makePermits(MAX_CONCURRENT_TOOLS);
+    const permits = makePermits(opts.maxConcurrentTools ?? DEFAULT_MAX_CONCURRENT_TOOLS);
     function* awaitToolCompletion(): Operation<void> {
       const sub = yield* toolWake;
       yield* sub.next();
@@ -1087,6 +1096,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           inflightTasks.set(agent.id, yield* spawn(function*() {
             let took = false;
             try {
+              // Own this agent's inflightTasks entry: remove it on ANY exit —
+              // completion OR halt (wind-down/teardown). A halt unwinds via
+              // ensure (not catch), so it pushes no completion and DRAIN never
+              // runs for it; without this the stale entry keeps `fanoutQuiet`
+              // false and the loop never terminates.
+              yield* ensure(() => { inflightTasks.delete(agent.id); });
               yield* ensure(() => { if (took) permits.release(); });
               yield* permits.acquire(); took = true;
               // Per-tool TRACE/CALLER context set INSIDE the child so concurrent
@@ -1105,7 +1120,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
               if (err instanceof ToolRetryError) {
                 completedTools.push({ kind: 'retry', agent, tc, callId, dispatchTraceId, toolT0, retryAttempt: (retryAttempt ?? 0) + 1, err });
               } else {
-                completedTools.push({ kind: 'error', agent, tc, callId, dispatchTraceId, err: err as Error });
+                completedTools.push({ kind: 'error', agent, tc, callId, dispatchTraceId, err: toError(err) });
               }
             } finally {
               toolWake.send();
@@ -1143,7 +1158,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         } catch (err) {
           completion = err instanceof ToolRetryError
             ? { kind: 'retry', agent, tc, callId, dispatchTraceId, toolT0, retryAttempt: (retryAttempt ?? 0) + 1, err }
-            : { kind: 'error', agent, tc, callId, dispatchTraceId, err: err as Error };
+            : { kind: 'error', agent, tc, callId, dispatchTraceId, err: toError(err) };
         }
         const settled = yield* processCompletion(completion);
         if (settled) results.push(settled);
@@ -1352,7 +1367,9 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       const newlySettled: SettledTool[] = [];
       if (completedTools.length > 0) {
         for (const c of completedTools.splice(0)) {
-          inflightTasks.delete(c.agent.id);
+          // The inflightTasks entry was already removed by the child's `ensure`
+          // (runs synchronously on completion before the loop resumes — and on
+          // halt too, which is the case DRAIN can't see). DRAIN just post-processes.
           const settled = yield* processCompletion(c);
           if (settled) newlySettled.push(settled);
         }

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -1,5 +1,5 @@
-import { resource, call, ensure, createSignal, createChannel, spawn, scoped, each, sleep, action } from 'effection';
-import type { Operation, Subscription } from 'effection';
+import { resource, call, ensure, createSignal, createChannel, spawn, scoped, each, sleep, action, race } from 'effection';
+import type { Operation, Subscription, Task } from 'effection';
 import type { Branch } from '@lloyal-labs/sdk';
 import { CHAT_FORMAT_CONTENT_ONLY, CHAT_FORMAT_GENERIC, GrammarTriggerType, type ParsedToolCall, type SessionContext } from '@lloyal-labs/sdk';
 import type { BranchStore } from '@lloyal-labs/sdk';
@@ -40,6 +40,47 @@ interface SettledTool {
   callId: string;
   args: string;
   probe?: string;
+}
+
+/**
+ * A fan-out tool's completion, pushed by its off-fiber child onto
+ * `completedTools` and processed on the loop fiber in DRAIN. Carries
+ * everything DRAIN needs to run the post-processing that the inline path runs
+ * inline — that post-processing tokenizes/reads the main `llama_context`, so it
+ * must stay on the loop fiber, never in the child.
+ */
+type ToolCompletion =
+  | { kind: 'result'; agent: Agent; tc: ParsedToolCall; callId: string; dispatchTraceId: number; toolT0: number; result: unknown }
+  | { kind: 'retry'; agent: Agent; tc: ParsedToolCall; callId: string; dispatchTraceId: number; toolT0: number; retryAttempt: number; err: ToolRetryError }
+  | { kind: 'error'; agent: Agent; tc: ParsedToolCall; callId: string; dispatchTraceId: number; err: Error };
+
+/** Max concurrent fan-out tool children (Effection has no semaphore — a
+ *  FIFO counting gate caps it). Inline tools don't count: the loop fiber
+ *  already serializes them. */
+const MAX_CONCURRENT_TOOLS = 8;
+
+/** FIFO counting gate: acquire before a fan-out child's `execute`, release in
+ *  an `ensure`. A halt while queued runs the action cleanup (drops the waiter);
+ *  a halt before acquire returns never released, so callers guard release with
+ *  a `took` flag. */
+interface Permits { acquire(): Operation<void>; release(): void }
+function makePermits(n: number): Permits {
+  let available = n;
+  const waiters: Array<() => void> = [];
+  return {
+    *acquire(): Operation<void> {
+      if (available > 0) { available--; return; }
+      yield* action<void>((resolve) => {
+        const w = () => resolve();
+        waiters.push(w);
+        return () => { const i = waiters.indexOf(w); if (i >= 0) waiters.splice(i, 1); };
+      });
+    },
+    release(): void {
+      const w = waiters.shift();
+      if (w) w(); else available++;
+    },
+  };
 }
 
 /**
@@ -792,6 +833,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
 
       const prefillPairs: [Branch, number[]][] = [];
       const settledAgents: Agent[] = [];
+      const settledOrder: { agentId: number; callId: string; tokenCount: number }[] = [];
       const itemProbes = new Map<number, string | undefined>();
       const deferred: SettledTool[] = [];
 
@@ -811,6 +853,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
 
         prefillPairs.push([a.branch, item.prefillTokens]);
         settledAgents.push(a);
+        settledOrder.push({ agentId: a.id, callId: item.callId, tokenCount: item.prefillTokens.length });
         if (item.probe) itemProbes.set(a.id, item.probe);
         headroom -= item.prefillTokens.length;
         const postSettle = new ContextPressure(ctx, pressureOpts);
@@ -829,6 +872,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         yield* call(() => store.prefill(prefillPairs));
         counters.warmPrefillCalls++;
         counters.warmPrefillBranches += prefillPairs.length;
+
+        // Fan-out determinism: record the canonical scatter order so the replay
+        // settle-order oracle can reproduce this exact interleaving. On the
+        // serial path this equals dispatch order; the event is emitted uniformly.
+        tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
+          type: 'tool:settle_order', batch: settledOrder });
 
         // Probe prefill from DISPATCH or nudge-replacement.
         const probePairs: [Branch, number[]][] = [];
@@ -868,7 +917,120 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       notBefore: number; attempt: number;
     }[] = [];
 
-    /** DISPATCH: execute tool calls sequentially, return settled items for next tick */
+    // ── Fan-out dispatch state ───────────────────────────────────
+    // A `Tool.fanout` tool runs on a child fiber OFF the loop fiber; its child
+    // pushes a ToolCompletion here on finish, and the loop fiber drains +
+    // post-processes them in the DRAIN phase. A plain array is the same
+    // cross-fiber rendezvous as pendingSpawns/pendingExtends — a child `push`
+    // is atomic w.r.t. the single-threaded event loop and only the loop fiber
+    // splices, so no lock is needed. Inline (`fanout` unset) tools never touch
+    // this; with no tool flagged the whole mechanism is inert (today's path).
+    const completedTools: ToolCompletion[] = [];
+    // agentId → its in-flight tool child (≤1 per agent: PRODUCE emits one call
+    // then parks the agent in awaiting_tool). Powers the termination guard now;
+    // targeted wind-down halt later.
+    const inflightTasks = new Map<number, Task<void>>();
+    // Fired by a child on completion so the all-parked nap wakes immediately.
+    const toolWake = createSignal<void, void>();
+    const permits = makePermits(MAX_CONCURRENT_TOOLS);
+    function* awaitToolCompletion(): Operation<void> {
+      const sub = yield* toolWake;
+      yield* sub.next();
+    }
+
+    /** Post-process one tool completion ON THE LOOP FIBER: tokenize the result,
+     *  send events, write traces, and return a SettledTool to prefill — or null
+     *  for a retry-park / error-kill. Shared by the inline path (called inline)
+     *  and DRAIN (called when a fan-out child's completion arrives). The body is
+     *  the relocated post-tool logic; relocating it onto the loop fiber is what
+     *  keeps the main-context tokenize/reads off the child fibers. */
+    function* processCompletion(c: ToolCompletion): Operation<SettledTool | null> {
+      const { agent, tc, callId, dispatchTraceId } = c;
+
+      if (c.kind === 'error') {
+        agent.transition('idle');
+        agent.setResult(`Tool error: ${c.err.message}`, 'tool_error');
+        tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
+          type: 'tool:error', agentId: agent.id, tool: tc.name,
+          error: c.err.message });
+        return null;
+      }
+
+      if (c.kind === 'retry') {
+        const attempt = c.retryAttempt;
+        // Strategy is the policy's: park-and-retry (optionally overriding the
+        // tool's delay estimate) or fail the call so the model can pivot. Hook
+        // absent → one retry at the tool's estimate.
+        const retryAction: ToolRetryAction =
+          policy.onToolRetry?.(agent, tc.name, c.err, attempt)
+            ?? (attempt <= 1 ? { type: 'retry' } : { type: 'fail' });
+        if (retryAction.type === 'retry') {
+          // Park: no SettledTool, nothing prefilled — the agent's KV never sees
+          // transient infrastructure weather. Emitted as an `agent:tool_retry`
+          // event (+ `tool:retry` trace) so a consumer can distinguish a
+          // waiting agent from a hung one.
+          const afterMs = retryAction.afterMs ?? c.err.retryAfterMs;
+          pendingRetries.push({
+            agent, tc, callId,
+            notBefore: performance.now() + afterMs,
+            attempt,
+          });
+          yield* poolChannel.send({
+            type: 'agent:tool_retry', agentId: agent.id, tool: tc.name,
+            retryAfterMs: afterMs, attempt,
+          });
+          tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
+            type: 'tool:retry', agentId: agent.id, tool: tc.name,
+            callId, retryAfterMs: afterMs, attempt });
+          return null;
+        }
+        // Policy chose fail — the outage is now a fact the model needs. Settle
+        // an honest, directive result through the normal path (NOT the
+        // tool_error path, which kills the agent's run).
+        const exhausted = {
+          error: retryAction.message
+            ?? `${tc.name} is currently unavailable (rate-limited; retry failed). ` +
+              `Do not call ${tc.name} again — use other sources or proceed with your current findings.`,
+        };
+        const resultStr = JSON.stringify(exhausted);
+        yield* poolChannel.send({ type: 'agent:tool_result', agentId: agent.id, tool: tc.name, result: resultStr });
+        const prefillTokens = buildToolResultDelta(ctx, resultStr, callId, { enableThinking: agent.fmt.enableThinking });
+        tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
+          type: 'tool:result', agentId: agent.id, tool: tc.name,
+          result: exhausted, prefillTokenCount: prefillTokens.length,
+          durationMs: performance.now() - c.toolT0 });
+        return { agentId: agent.id, prefillTokens, toolName: tc.name, callId, args: tc.arguments, probe: undefined };
+      }
+
+      // c.kind === 'result'
+      const result = c.result;
+      const tool = tools.get(tc.name);
+      const postToolPressure = new ContextPressure(ctx, pressureOpts);
+      const contextAvailablePercent = postToolPressure.percentAvailable;
+      if (result && typeof result === 'object' && !Array.isArray(result)) {
+        (result as Record<string, unknown>)._contextAvailablePercent = contextAvailablePercent;
+        const resultObj = result as Record<string, unknown>;
+        if (Array.isArray(resultObj.results)) {
+          agent.addNestedResults((resultObj.results as unknown[]).filter((f): f is string => typeof f === 'string'));
+        }
+        if (Array.isArray(resultObj.nestedResults)) {
+          agent.addNestedResults((resultObj.nestedResults as unknown[]).filter((f): f is string => typeof f === 'string'));
+        }
+      }
+      const resultStr = JSON.stringify(result);
+      yield* poolChannel.send({ type: 'agent:tool_result', agentId: agent.id, tool: tc.name, result: resultStr, contextAvailablePercent });
+      const prefillTokens = buildToolResultDelta(ctx, resultStr, callId, { enableThinking: agent.fmt.enableThinking });
+      const probe = tool?.probe(result) ?? undefined;
+      tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
+        type: 'tool:result', agentId: agent.id, tool: tc.name,
+        result, prefillTokenCount: prefillTokens.length,
+        durationMs: performance.now() - c.toolT0 });
+      return { agentId: agent.id, prefillTokens, toolName: tc.name, callId, args: tc.arguments, probe };
+    }
+
+    /** DISPATCH: run inline tools on the loop fiber, spawn fan-out tools off it.
+     *  Inline results return for next tick's SETTLE; fan-out completions arrive
+     *  via `completedTools` and are processed in DRAIN. */
     function* dispatch(calls: { agent: Agent; tc: ParsedToolCall; retryAttempt?: number; retryCallId?: string }[]): Operation<SettledTool[]> {
       const results: SettledTool[] = [];
 
@@ -913,6 +1075,50 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           peerHistory,
         };
 
+        // ── execute ──
+        if (tool?.fanout) {
+          // Fan-out: spawn OFF the loop fiber. The child runs ONLY execute() (a
+          // fanout tool issues no main-context op); the post-processing — which
+          // tokenizes/reads the main ctx — runs in DRAIN on the loop fiber. The
+          // agent stays awaiting_tool until its result settles. The child is a
+          // child task of the tick-loop task, so pool teardown / wind-down
+          // halts it (→ cancellableFetch aborts) for free.
+          const fanoutTool = tool;  // narrowed non-null by tool?.fanout
+          inflightTasks.set(agent.id, yield* spawn(function*() {
+            let took = false;
+            try {
+              yield* ensure(() => { if (took) permits.release(); });
+              yield* permits.acquire(); took = true;
+              // Per-tool TRACE/CALLER context set INSIDE the child so concurrent
+              // tools never clobber each other's (stronger isolation than the
+              // shared loop-fiber set the inline path uses).
+              yield* TraceParent.set(dispatchTraceId);
+              yield* CallingAgent.set(agent);
+              const result: unknown = yield* scoped(function*() {
+                return yield* call(() => fanoutTool.execute(toolArgs, toolContext));
+              });
+              completedTools.push({ kind: 'result', agent, tc, callId, dispatchTraceId, toolT0, result });
+            } catch (err) {
+              // A halt unwinds via ensure/finally, NOT catch — a halted child
+              // skips the push (its result correctly discarded); catch only ever
+              // sees real tool errors (incl. ToolRetryError).
+              if (err instanceof ToolRetryError) {
+                completedTools.push({ kind: 'retry', agent, tc, callId, dispatchTraceId, toolT0, retryAttempt: (retryAttempt ?? 0) + 1, err });
+              } else {
+                completedTools.push({ kind: 'error', agent, tc, callId, dispatchTraceId, err: err as Error });
+              }
+            } finally {
+              toolWake.send();
+            }
+          }));
+          continue;
+        }
+
+        // ── inline (default) ──
+        // Run execute + post-process now, on the loop fiber — functionally the
+        // pre-fan-out path. Required for any tool that decodes on the main
+        // context (delegate, plan) and for the unknown-tool fallback below.
+        let completion: ToolCompletion;
         try {
           yield* TraceParent.set(dispatchTraceId);
           yield* CallingAgent.set(agent);
@@ -933,83 +1139,14 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
               })
             );
           });
-
-          const postToolPressure = new ContextPressure(ctx, pressureOpts);
-          const contextAvailablePercent = postToolPressure.percentAvailable;
-          if (result && typeof result === 'object' && !Array.isArray(result)) {
-            (result as Record<string, unknown>)._contextAvailablePercent = contextAvailablePercent;
-            const resultObj = result as Record<string, unknown>;
-            if (Array.isArray(resultObj.results)) {
-              agent.addNestedResults((resultObj.results as unknown[]).filter((f): f is string => typeof f === 'string'));
-            }
-            if (Array.isArray(resultObj.nestedResults)) {
-              agent.addNestedResults((resultObj.nestedResults as unknown[]).filter((f): f is string => typeof f === 'string'));
-            }
-          }
-
-          const resultStr = JSON.stringify(result);
-          yield* poolChannel.send({ type: 'agent:tool_result', agentId: agent.id, tool: tc.name, result: resultStr, contextAvailablePercent });
-
-          const prefillTokens = buildToolResultDelta(ctx, resultStr, callId, { enableThinking: agent.fmt.enableThinking });
-          const probe = tool?.probe(result) ?? undefined;
-          results.push({ agentId: agent.id, prefillTokens, toolName: tc.name, callId, args: tc.arguments, probe });
-
-          tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
-            type: 'tool:result', agentId: agent.id, tool: tc.name,
-            result, prefillTokenCount: prefillTokens.length,
-            durationMs: performance.now() - toolT0 });
+          completion = { kind: 'result', agent, tc, callId, dispatchTraceId, toolT0, result };
         } catch (err) {
-          if (err instanceof ToolRetryError) {
-            const attempt = (retryAttempt ?? 0) + 1;
-            // Strategy is the policy's: park-and-retry (optionally overriding
-            // the tool's delay estimate) or fail the call so the model can
-            // pivot. Hook absent → one retry at the tool's estimate.
-            const retryAction: ToolRetryAction =
-              policy.onToolRetry?.(agent, tc.name, err, attempt)
-                ?? (attempt <= 1 ? { type: 'retry' } : { type: 'fail' });
-            if (retryAction.type === 'retry') {
-              // Park: no SettledTool, nothing prefilled — the agent's KV
-              // never sees transient infrastructure weather. Surfaced to
-              // the TUI + trace so a waiting agent reads as waiting, not hung.
-              const afterMs = retryAction.afterMs ?? err.retryAfterMs;
-              pendingRetries.push({
-                agent, tc, callId,
-                notBefore: performance.now() + afterMs,
-                attempt,
-              });
-              yield* poolChannel.send({
-                type: 'agent:tool_retry', agentId: agent.id, tool: tc.name,
-                retryAfterMs: afterMs, attempt,
-              });
-              tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
-                type: 'tool:retry', agentId: agent.id, tool: tc.name,
-                callId, retryAfterMs: afterMs, attempt });
-              continue;
-            }
-            // Policy chose fail — the outage is now a fact the model needs.
-            // Settle an honest, directive result through the normal path
-            // (NOT the tool_error path, which kills the agent's run).
-            const exhausted = {
-              error: retryAction.message
-                ?? `${tc.name} is currently unavailable (rate-limited; retry failed). ` +
-                  `Do not call ${tc.name} again — use other sources or proceed with your current findings.`,
-            };
-            const resultStr = JSON.stringify(exhausted);
-            yield* poolChannel.send({ type: 'agent:tool_result', agentId: agent.id, tool: tc.name, result: resultStr });
-            const prefillTokens = buildToolResultDelta(ctx, resultStr, callId, { enableThinking: agent.fmt.enableThinking });
-            results.push({ agentId: agent.id, prefillTokens, toolName: tc.name, callId, args: tc.arguments, probe: undefined });
-            tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
-              type: 'tool:result', agentId: agent.id, tool: tc.name,
-              result: exhausted, prefillTokenCount: prefillTokens.length,
-              durationMs: performance.now() - toolT0 });
-            continue;
-          }
-          agent.transition('idle');
-          agent.setResult(`Tool error: ${(err as Error).message}`, 'tool_error');
-          tw.write({ traceId: tw.nextId(), parentTraceId: dispatchTraceId, ts: performance.now(),
-            type: 'tool:error', agentId: agent.id, tool: tc.name,
-            error: (err as Error).message });
+          completion = err instanceof ToolRetryError
+            ? { kind: 'retry', agent, tc, callId, dispatchTraceId, toolT0, retryAttempt: (retryAttempt ?? 0) + 1, err }
+            : { kind: 'error', agent, tc, callId, dispatchTraceId, err: err as Error };
         }
+        const settled = yield* processCompletion(completion);
+        if (settled) results.push(settled);
       }
 
       return results;
@@ -1209,8 +1346,20 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         yield* poolChannel.send({ type: 'agent:tick', cellsUsed: commitPressure.cellsUsed, nCtx: commitPressure.nCtx });
       }
 
+      // -- Phase 2.5: DRAIN -- post-process fan-out tools that finished since
+      // the last tick, ON THE LOOP FIBER (their tokenize/ctx reads happen here,
+      // never in the child). Each becomes a SettledTool for THIS tick's SETTLE.
+      const newlySettled: SettledTool[] = [];
+      if (completedTools.length > 0) {
+        for (const c of completedTools.splice(0)) {
+          inflightTasks.delete(c.agent.id);
+          const settled = yield* processCompletion(c);
+          if (settled) newlySettled.push(settled);
+        }
+      }
+
       // -- Phase 3: SETTLE (settle what fits, defer what doesn't)
-      const toSettle = [...pendingSettled, ...nudges];
+      const toSettle = [...pendingSettled, ...nudges, ...newlySettled];
       const deferred = toSettle.length > 0 ? yield* settle(toSettle) : [];
 
       // Stall-breaker: `deferred` has items but no active siblings can free
@@ -1300,7 +1449,11 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       // -- Termination + recovery
       // Wait for the orchestrator to finish before closing — it may spawn more agents.
       const allIdle = agents.every(a => a.status === 'idle' || a.status === 'disposed');
-      if (allIdle && orchestratorDone) {
+      // Don't exit while a fan-out tool is still in flight or a completion is
+      // waiting to drain. An awaiting_tool agent already keeps allIdle false,
+      // but this guards the edge where its agent was killed mid-flight.
+      const fanoutQuiet = completedTools.length === 0 && inflightTasks.size === 0;
+      if (allIdle && orchestratorDone && fanoutQuiet) {
         if (!recoveryAttempted) {
           recoveryAttempted = true;
           // Recover any idle agents that weren't handled by inline recovery
@@ -1319,21 +1472,28 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         yield* sleep(1);
       }
 
-      // All-parked: nothing active, nothing to settle — only future retries.
-      // Without this the loop busy-spins until the earliest notBefore (parked
-      // agents are awaiting_tool, so the allIdle sleep above never fires).
-      // Cap the nap at 50ms so orchestrator spawns/extends are picked up
-      // promptly.
+      // All-parked: nothing active, nothing to settle/drain this tick — only
+      // outstanding retries and/or in-flight fan-out tools. Without this the
+      // loop busy-spins (parked agents are awaiting_tool, so the allIdle sleep
+      // above never fires). Cap the nap at 50ms so orchestrator spawns/extends
+      // are picked up promptly; wake early when a fan-out tool completes.
       if (
-        pendingRetries.length > 0
+        (pendingRetries.length > 0 || inflightTasks.size > 0)
         && pendingSettled.length === 0
+        && completedTools.length === 0
         && pendingSpawns.length === 0
         && pendingExtends.length === 0
         && !agents.some(a => a.status === 'active')
       ) {
-        const nextDue = Math.min(...pendingRetries.map(r => r.notBefore));
+        const nextDue = pendingRetries.length > 0
+          ? Math.min(...pendingRetries.map(r => r.notBefore))
+          : performance.now() + 50;
         const nap = Math.max(1, Math.min(50, nextDue - performance.now()));
-        yield* sleep(nap);
+        if (inflightTasks.size > 0) {
+          yield* race([sleep(nap), awaitToolCompletion()]);
+        } else {
+          yield* sleep(nap);
+        }
       }
     }
 

--- a/packages/agents/src/trace-types.ts
+++ b/packages/agents/src/trace-types.ts
@@ -202,6 +202,15 @@ export type TraceEvent =
       prefillTokenCount: number;
       durationMs: number;
     }
+  // Fan-out determinism: the ORDERED tool results scatter-prefilled in one
+  // SETTLE pass. Under inter-agent-concurrent dispatch, settle order = tool
+  // completion order (network-timing dependent); recording it lets the replay
+  // settle-order oracle reproduce the exact KV-prefill interleaving. On the
+  // serial path it equals dispatch order; emitted uniformly either way.
+  | TraceEventBase & {
+      type: 'tool:settle_order';
+      batch: Array<{ agentId: number; callId: string; tokenCount: number }>;
+    }
   | TraceEventBase & { type: 'tool:error'; agentId: number; tool: string; error: string }
   // Transient tool failure (ToolRetryError — e.g. provider rate-limited).
   // The agent is parked (awaiting_tool) and the call re-executes after

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -252,6 +252,11 @@ export interface AgentPoolOptions {
   params?: SamplingParams;
   /** Maximum tool-call turns per agent before forced termination */
   maxTurns?: number;
+  /** Max concurrent fan-out tool executions across the pool. Fan-out tools
+   *  ({@link Tool.fanout}) run off the loop fiber; this FIFO-gates how many
+   *  execute at once. Inline tools are unaffected — the loop fiber already
+   *  serializes them. @default 8 */
+  maxConcurrentTools?: number;
   /** Tool name that signals agent completion. When the model calls this tool,
    *  the result is extracted from its arguments and the agent is marked done.
    *  The tool's execute() code-path is not reached — the framework intercepts

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -103,6 +103,7 @@ export interface PoolSpec {
   toolsJson?: string;
   terminalTool?: string;
   maxTurns?: number;
+  maxConcurrentTools?: number;
   taskCount?: number;
   orchestrate?: Orchestrator;
   trace?: boolean;
@@ -214,6 +215,7 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
         tools: spec.tools ?? new Map(),
         policy: spec.policy,
         maxTurns: spec.maxTurns ?? 100,
+        maxConcurrentTools: spec.maxConcurrentTools,
         terminalToolName: spec.terminalToolName,
         trace: spec.trace ?? false,
         pruneOnReturn: spec.pruneOnReturn ?? false,

--- a/packages/agents/test/invariants/scenarios/fanout-bounds.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/fanout-bounds.scenario.test.ts
@@ -1,8 +1,9 @@
 /**
  * Scenario: fan-out dispatch stays bounded + single-fiber under load.
  *
- * With more parallel agents than MAX_CONCURRENT_TOOLS all calling a fan-out
- * tool at once: at most the cap run concurrently; the rest queue FIFO on the
+ * With more parallel agents than the configured concurrency cap
+ * (`maxConcurrentTools`) all calling a fan-out tool at once: at most the cap
+ * run concurrently; the rest queue FIFO on the
  * permit gate and run as permits free. No agent's tool is lost (anti-
  * starvation), and the single-fiber store discipline (I1) survives the burst
  * of concurrent completions draining through one SETTLE.
@@ -16,8 +17,12 @@ import type { AgentPolicy } from '../../../src/AgentPolicy';
 import { runPool, STOP } from '../harness';
 import { I1_nativeStoreSingleFiber, formatResult } from '../predicates';
 
-// Mirrors MAX_CONCURRENT_TOOLS in agent-pool.ts (module-private there).
-const CAP = 8;
+// The cap is INJECTED via opts (maxConcurrentTools) and asserted below — the
+// test configures the value it checks rather than mirroring a module-private
+// const. A non-default value (4 vs the framework default 8) also proves the
+// opt is actually wired: if it were ignored, up to 8 of the 12 agents would
+// run at once and `maxConcurrent <= CAP` would fail.
+const CAP = 4;
 
 /** Fan-out tool: sleeps, records peak concurrent executions + which agents ran. */
 class TrackingFanoutTool extends Tool<Record<string, unknown>> {
@@ -64,6 +69,7 @@ describe('scenario: fan-out concurrency cap', () => {
       policy,
       tools: new Map<string, Tool>([['slow', tool]]),
       maxTurns: 5,
+      maxConcurrentTools: CAP,
       taskCount: N,
     });
     // Safety: the permit gate never lets more than the cap run at once.

--- a/packages/agents/test/invariants/scenarios/fanout-bounds.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/fanout-bounds.scenario.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Scenario: fan-out dispatch stays bounded + single-fiber under load.
+ *
+ * With more parallel agents than MAX_CONCURRENT_TOOLS all calling a fan-out
+ * tool at once: at most the cap run concurrently; the rest queue FIFO on the
+ * permit gate and run as permits free. No agent's tool is lost (anti-
+ * starvation), and the single-fiber store discipline (I1) survives the burst
+ * of concurrent completions draining through one SETTLE.
+ */
+import { describe, it, expect } from 'vitest';
+import { sleep } from 'effection';
+import type { Operation } from 'effection';
+import { Tool } from '../../../src/Tool';
+import type { JsonSchema, ToolContext } from '../../../src/types';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+import { I1_nativeStoreSingleFiber, formatResult } from '../predicates';
+
+// Mirrors MAX_CONCURRENT_TOOLS in agent-pool.ts (module-private there).
+const CAP = 8;
+
+/** Fan-out tool: sleeps, records peak concurrent executions + which agents ran. */
+class TrackingFanoutTool extends Tool<Record<string, unknown>> {
+  readonly name = 'slow';
+  readonly description = 'sleeps; records peak concurrency + which agents ran';
+  readonly parameters: JsonSchema = { type: 'object', properties: {} };
+  readonly fanout = true;
+  concurrent = 0;
+  maxConcurrent = 0;
+  readonly agentsRun = new Set<number>();
+  constructor(private readonly ms: number) { super(); }
+  *execute(_args: Record<string, unknown>, context?: ToolContext): Operation<unknown> {
+    this.concurrent++;
+    this.maxConcurrent = Math.max(this.maxConcurrent, this.concurrent);
+    if (context) this.agentsRun.add(context.agentId);
+    yield* sleep(this.ms);
+    this.concurrent--;
+    return { results: ['ok'] };
+  }
+}
+
+// Each agent calls the tool exactly ONCE: first stop → tool_call, any later
+// stop → idle. Gating on toolCallCount keeps agents from looping the tool.
+const policy: AgentPolicy = {
+  onProduced: (agent, parsed) =>
+    parsed.toolCalls.length > 0 && agent.toolCallCount === 0
+      ? { type: 'tool_call', tc: parsed.toolCalls[0] }
+      : { type: 'idle', reason: 'free_text_stop' },
+  shouldExit: () => false,
+  onRecovery: () => ({ type: 'skip' }),
+};
+
+describe('scenario: fan-out concurrency cap', () => {
+  it('>cap agents calling a tool at once → at most cap run concurrently; all run; single-fiber holds', async () => {
+    const tool = new TrackingFanoutTool(15);
+    const N = 12; // > CAP
+    const run = await runPool({
+      nCtx: 8192,
+      cellsUsed: 200, // headroom is not the constraint here — the permit gate is
+      scripts: Array.from({ length: N }, () => ({
+        tokens: [1, STOP],
+        toolCall: { name: 'slow', arguments: '{}' },
+      })),
+      policy,
+      tools: new Map<string, Tool>([['slow', tool]]),
+      maxTurns: 5,
+      taskCount: N,
+    });
+    // Safety: the permit gate never lets more than the cap run at once.
+    expect(tool.maxConcurrent).toBeLessThanOrEqual(CAP);
+    // Concurrency actually engaged (not accidentally serial).
+    expect(tool.maxConcurrent).toBeGreaterThan(1);
+    // Anti-starvation: every one of the N agents' tools ran (FIFO drained all).
+    expect(tool.agentsRun.size).toBe(N);
+    // Single-fiber store discipline survives the N concurrent completions.
+    expect(formatResult('I1', I1_nativeStoreSingleFiber(run))).toBe('I1: ok');
+  });
+});

--- a/packages/agents/test/invariants/scenarios/fanout-concurrency.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/fanout-concurrency.scenario.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Scenario: fan-out dispatch — inter-agent concurrency + the intra-agent barrier.
+ *
+ * A `Tool.fanout` tool runs on a child fiber OFF the loop fiber, so one agent's
+ * slow tool no longer parks the whole pool. This locks the two halves of the
+ * target dispatch model:
+ *
+ *   (ii) inter-agent CONCURRENT — agent B keeps PRODUCING while agent A awaits a
+ *        slow fan-out tool. This is the batched-decode moat: a tool's network
+ *        I/O no longer idles the GPU for the other agents.
+ *   (i)  intra-agent SERIAL — agent A does NOT sample between its tool_call and
+ *        its tool_result. This is the one hard invariant (the barrier): the next
+ *        token is a hypothesis refined on the settled result.
+ *
+ * Plus: the single-fiber store discipline (I1) still holds — fan-out moves only
+ * tool.execute() off-fiber; every native store op stays on the loop fiber.
+ */
+import { describe, it, expect } from 'vitest';
+import { sleep } from 'effection';
+import type { Operation } from 'effection';
+import { Tool } from '../../../src/Tool';
+import type { JsonSchema } from '../../../src/types';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+import { I1_nativeStoreSingleFiber, formatResult } from '../predicates';
+
+/** A slow, fan-out-eligible tool: sleeps off the loop fiber, touches no ctx. */
+class SlowFanoutTool extends Tool<Record<string, unknown>> {
+  readonly name = 'slow_search';
+  readonly description = 'sleeps, then returns a small result';
+  readonly parameters: JsonSchema = { type: 'object', properties: {} };
+  readonly fanout = true;
+  constructor(private readonly ms: number) { super(); }
+  *execute(): Operation<unknown> {
+    yield* sleep(this.ms);
+    return { results: ['ok'] };
+  }
+}
+
+const policy: AgentPolicy = {
+  onProduced: (_a, parsed) =>
+    parsed.toolCalls.length > 0
+      ? { type: 'tool_call', tc: parsed.toolCalls[0] }
+      : { type: 'idle', reason: 'free_text_stop' },
+  onSettleReject: () => ({ type: 'nudge', message: 'Report now (within 50 words).' }),
+  shouldExit: () => false,
+  onRecovery: () => ({ type: 'skip' }),
+};
+
+function runFanout() {
+  return runPool({
+    nCtx: 4096,
+    cellsUsed: 100, // lots of headroom — keep pressure out of this test
+    scripts: [
+      // Agent A: one token, STOP → calls the slow fan-out tool. (maxTurns
+      // bounds the re-call loop; we only assert on A's FIRST tool window.)
+      { tokens: [1, STOP], toolCall: { name: 'slow_search', arguments: '{}', id: 'a1' } },
+      // Agent B: many tokens → keeps producing across ticks while A awaits.
+      { tokens: [1, 2, 3, 4, 5, 6, 7, 8, STOP] },
+    ],
+    policy,
+    tools: new Map<string, Tool>([['slow_search', new SlowFanoutTool(20)]]),
+    maxTurns: 3,
+    taskCount: 2,
+  });
+}
+
+/** A's first tool window in channel-event order: [tool_call .. tool_result). */
+function firstToolWindow(ev: readonly any[], aId: number): { lo: number; hi: number } {
+  const lo = ev.findIndex(e => e.type === 'agent:tool_call' && e.agentId === aId);
+  const hi = ev.findIndex((e, i) => i > lo && e.type === 'agent:tool_result' && e.agentId === aId);
+  return { lo, hi };
+}
+
+describe('scenario: fan-out dispatch concurrency', () => {
+  it('(ii) inter-agent: B keeps producing while A awaits a slow fan-out tool', async () => {
+    const run = await runFanout();
+    const ev = run.channelEvents as any[];
+    // A is whoever called the tool; B is the other agent.
+    const aId = (ev.find(e => e.type === 'agent:tool_call') as any).agentId;
+    const bId = run.result.agents.map(a => a.agentId).find(id => id !== aId)!;
+
+    const { lo, hi } = firstToolWindow(ev, aId);
+    expect(lo).toBeGreaterThanOrEqual(0);
+    expect(hi).toBeGreaterThan(lo);
+
+    // The moat: B emitted produce events WHILE A's tool was in flight. On the
+    // old serial path this would be 0 (A's inline execute parked the loop).
+    const bProduced = ev
+      .slice(lo + 1, hi)
+      .filter(e => e.type === 'agent:produce' && e.agentId === bId);
+    expect(bProduced.length).toBeGreaterThan(0);
+  });
+
+  it('(i) intra-agent barrier: A does not sample between its tool_call and tool_result', async () => {
+    const run = await runFanout();
+    const ev = run.channelEvents as any[];
+    const aId = (ev.find(e => e.type === 'agent:tool_call') as any).agentId;
+
+    const { lo, hi } = firstToolWindow(ev, aId);
+    const aProduced = ev
+      .slice(lo + 1, hi)
+      .filter(e => e.type === 'agent:produce' && e.agentId === aId);
+    expect(aProduced.length).toBe(0);
+  });
+
+  it('single-fiber store discipline (I1) holds under fan-out', async () => {
+    const run = await runFanout();
+    expect(formatResult('I1', I1_nativeStoreSingleFiber(run))).toBe('I1: ok');
+  });
+});

--- a/packages/agents/test/invariants/scenarios/fanout-failure.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/fanout-failure.scenario.test.ts
@@ -48,6 +48,17 @@ class ThrowingFanoutTool extends Tool<Record<string, unknown>> {
   *execute(): Operation<unknown> { throw new Error('boom'); }
 }
 
+/** Throws a NON-Error value — exercises the `toError` normalization so the
+ *  tool:error trace carries a usable message instead of `undefined`. */
+class NonErrorThrowTool extends Tool<Record<string, unknown>> {
+  readonly name = 'raw';
+  readonly description = 'throws a raw string (non-Error)';
+  readonly parameters: JsonSchema = { type: 'object', properties: {} };
+  readonly fanout = true;
+  // eslint-disable-next-line @typescript-eslint/no-throw-literal
+  *execute(): Operation<unknown> { throw 'rate limited'; }
+}
+
 describe('scenario: fan-out dispatch failure paths', () => {
   it('ToolRetryError on a fan-out tool → parks, re-dispatches (fan-out), then settles', async () => {
     const tool = new FlakyFanoutTool();
@@ -81,5 +92,23 @@ describe('scenario: fan-out dispatch failure paths', () => {
     });
     // The fan-out child's generic-error mapping → DRAIN → processCompletion error.
     expect(run.traceEvents.some(e => e.type === 'tool:error')).toBe(true);
+  });
+
+  it('a NON-Error throw is normalized → tool:error carries a usable message', async () => {
+    const tool = new NonErrorThrowTool();
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 100,
+      scripts: [{ tokens: [1, STOP], toolCall: { name: 'raw', arguments: '{}', id: 'r1' } }],
+      policy,
+      tools: new Map<string, Tool>([['raw', tool]]),
+      maxTurns: 5,
+      taskCount: 1,
+    });
+    const errEvents = run.traceEvents.filter(e => e.type === 'tool:error') as Array<{ error: string }>;
+    expect(errEvents.length).toBeGreaterThan(0);
+    // The thrown string survived normalization (`toError`) — the message is the
+    // value, not `undefined` (which an `err as Error` cast would have produced).
+    expect(errEvents[0].error).toBe('rate limited');
   });
 });

--- a/packages/agents/test/invariants/scenarios/fanout-failure.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/fanout-failure.scenario.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Scenario: fan-out dispatch failure paths.
+ *
+ * A fan-out tool runs on a child fiber, so its failures take a different route
+ * than the inline path: the child catches the throw, maps it to a `retry` or
+ * `error` ToolCompletion, and DRAIN feeds it through the SAME processCompletion
+ * the inline path uses. These lock the fan-out-specific halves:
+ *   - ToolRetryError on a fan-out tool → parked + re-dispatched (again fan-out),
+ *     then settles.
+ *   - A hard error on a fan-out tool → DRAIN kills the agent with a tool_error.
+ */
+import { describe, it, expect } from 'vitest';
+import type { Operation } from 'effection';
+import { Tool, ToolRetryError } from '../../../src/Tool';
+import type { JsonSchema } from '../../../src/types';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+
+const policy: AgentPolicy = {
+  onProduced: (agent, parsed) =>
+    parsed.toolCalls.length > 0 && agent.toolCallCount === 0
+      ? { type: 'tool_call', tc: parsed.toolCalls[0] }
+      : { type: 'idle', reason: 'free_text_stop' },
+  shouldExit: () => false,
+  onRecovery: () => ({ type: 'skip' }),
+};
+
+/** Rate-limits once (ToolRetryError), then succeeds. */
+class FlakyFanoutTool extends Tool<Record<string, unknown>> {
+  readonly name = 'flaky';
+  readonly description = 'throws ToolRetryError once, then succeeds';
+  readonly parameters: JsonSchema = { type: 'object', properties: {} };
+  readonly fanout = true;
+  calls = 0;
+  *execute(): Operation<unknown> {
+    this.calls++;
+    if (this.calls === 1) throw new ToolRetryError('rate limited', 5);
+    return { results: ['ok'] };
+  }
+}
+
+/** Throws a hard error every time. */
+class ThrowingFanoutTool extends Tool<Record<string, unknown>> {
+  readonly name = 'boom';
+  readonly description = 'throws a hard error';
+  readonly parameters: JsonSchema = { type: 'object', properties: {} };
+  readonly fanout = true;
+  *execute(): Operation<unknown> { throw new Error('boom'); }
+}
+
+describe('scenario: fan-out dispatch failure paths', () => {
+  it('ToolRetryError on a fan-out tool → parks, re-dispatches (fan-out), then settles', async () => {
+    const tool = new FlakyFanoutTool();
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 100,
+      scripts: [{ tokens: [1, STOP], toolCall: { name: 'flaky', arguments: '{}', id: 'f1' } }],
+      policy,
+      tools: new Map<string, Tool>([['flaky', tool]]),
+      maxTurns: 5,
+      taskCount: 1,
+    });
+    const ev = run.channelEvents as any[];
+    // The fan-out child mapped the throw to a retry → the agent parked.
+    expect(ev.some(e => e.type === 'agent:tool_retry')).toBe(true);
+    // The re-dispatched call (also fan-out) succeeded and settled.
+    expect(ev.some(e => e.type === 'agent:tool_result')).toBe(true);
+    expect(tool.calls).toBe(2); // threw once, succeeded on retry
+  });
+
+  it('hard error on a fan-out tool → DRAIN kills the agent with a tool_error', async () => {
+    const tool = new ThrowingFanoutTool();
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 100,
+      scripts: [{ tokens: [1, STOP], toolCall: { name: 'boom', arguments: '{}', id: 'b1' } }],
+      policy,
+      tools: new Map<string, Tool>([['boom', tool]]),
+      maxTurns: 5,
+      taskCount: 1,
+    });
+    // The fan-out child's generic-error mapping → DRAIN → processCompletion error.
+    expect(run.traceEvents.some(e => e.type === 'tool:error')).toBe(true);
+  });
+});

--- a/packages/apps/corpus/src/tools/search.ts
+++ b/packages/apps/corpus/src/tools/search.ts
@@ -80,6 +80,10 @@ const DEFAULT_FIRST_STAGE_K = 100;
 export class SearchTool extends Tool<{ query: string }> {
   readonly name = 'search';
   readonly protected = false;
+  // Reranker (its own llama_context, _inflight-serialized) + in-memory BM25 —
+  // no op on the MAIN context, so it runs off the loop fiber under concurrent
+  // dispatch. See Tool.fanout.
+  readonly fanout = true;
   readonly description = 'Search the knowledge base. Returns sections ranked by relevance with line ranges for read_file.';
   readonly parameters: JsonSchema = {
     type: 'object',

--- a/packages/apps/web/src/tools/fetch-page.ts
+++ b/packages/apps/web/src/tools/fetch-page.ts
@@ -72,6 +72,10 @@ function selectTopChunks(
 export class FetchPageTool extends Tool<{ url: string; query?: string }> {
   readonly name = "fetch_page";
   readonly protected = false;
+  // Network-only (HTTP fetch; optional reranker runs on its own context) — no
+  // main-context op, so it runs off the loop fiber under concurrent dispatch.
+  // See Tool.fanout.
+  readonly fanout = true;
   readonly description =
     "Fetch a web page and extract its article content. Returns readable text with title and excerpt. Pass a query to get only the most relevant sections.";
   readonly parameters: JsonSchema = {

--- a/packages/apps/web/src/tools/web-search.ts
+++ b/packages/apps/web/src/tools/web-search.ts
@@ -68,6 +68,9 @@ export class TavilyProvider implements SearchProvider {
 export class WebSearchTool extends Tool<{ query: string }> {
   readonly name = "web_search";
   readonly protected = false;
+  // Network-only (Tavily HTTP) — issues no op on the main llama_context, so it
+  // runs off the loop fiber under concurrent dispatch. See Tool.fanout.
+  readonly fanout = true;
   readonly description =
     "Search the web. Returns results with titles, snippets, and URLs.";
   readonly parameters: JsonSchema = {

--- a/packages/rig/src/tools/delegate.ts
+++ b/packages/rig/src/tools/delegate.ts
@@ -68,6 +68,12 @@ export class DelegateTool extends Tool<Record<string, unknown>> {
   readonly description: string;
   readonly parameters: JsonSchema;
 
+  // Decodes on the MAIN context: nests `agentPool()` which reads the ambient
+  // Ctx/Store and runs produceSync/commit/fork on the same llama_context as
+  // the loop. MUST stay inline on the loop fiber — fanning this out
+  // concurrently with the loop's decode would segfault. See Tool.fanout.
+  readonly fanout = false;
+
   private _poolOpts: Omit<CreateAgentPoolOpts, 'orchestrate'>;
   private _systemPrompt: string;
   private _extractTasks: (args: Record<string, unknown>) => string[];

--- a/packages/rig/src/tools/plan.ts
+++ b/packages/rig/src/tools/plan.ts
@@ -143,6 +143,11 @@ export class PlanTool extends Tool<{ query: string; context?: string }> {
     required: ['query'],
   };
 
+  // Decodes on the MAIN context: runs a nested `agent()`/useAgent over the
+  // session trunk on the ambient llama_context. MUST stay inline on the loop
+  // fiber. See Tool.fanout.
+  readonly fanout = false;
+
   private _prompt: { system: string; user: string };
   private _session: Session;
   private _maxTasks: number;


### PR DESCRIPTION
## What
Target-dispatch fan-out for the agent pool: **per-agent serial, inter-agent concurrent**. A fan-out-eligible tool runs on a child fiber off the tick-loop fiber, so one agent's slow/hung tool no longer parks the whole pool — realizing the batched-decode moat (no GPU idle during tool I/O; wall-clock → the slowest single agent's chain) and dissolving the parked-loop / hung-tool class.

## How
- **`Tool.fanout` flag** — default `false` = inline = byte-equivalent to serial dispatch. `delegate`/`plan` stay `false` (they decode on the main context via nested `agentPool`/`useAgent`); the pure-I/O tools (`web_search`, `fetch_page`, corpus `search`) opt in.
- **agent-pool** — fan-out tools `spawn` off-fiber; completions cross back via a `completedTools` rendezvous (same pattern as `pendingSpawns`) and post-process **on the loop fiber** in a new DRAIN phase. Both paths share one `processCompletion`. Queue-of-permits cap (8); wake-aware nap; termination guard.
- **Safety** — every native store op stays single-fiber; fan-out children touch only network I/O or the reranker's *separate*, self-serialized context. The conservative default means a mis-flagged tool degrades to parking the loop, never a SEGV.
- **Determinism** — `tool:settle_order` trace event records the scatter sequence (the replay-consumer oracle is a follow-on).

## Tests — 243/243 in `packages/agents`
- `fanout-concurrency` — inter-agent concurrency (peer produces while one awaits) + intra-agent barrier + I1 (single-fiber) under fan-out.
- `fanout-bounds` — concurrency cap holds with N>cap agents + anti-starvation.
- `fanout-failure` — fan-out retry (`ToolRetryError` → re-dispatch → settle) + hard-error (→ `tool_error`) completion paths.

**Flag-off is byte-equivalent to serial dispatch** (non-regression). Live-verified on a corpus run: a peer agent ran a turn during another agent's in-flight `search` — structurally impossible on the serial control (whose search windows showed zero peer activity) — and no recovery failure (the serial run had one).

## Deferred (tracked, not in this PR)
- **Phase 2 — graceful wind-down** (folded-in wrap-up): `_forcedStop` + `awaiting_tool` reap + `WindDownCtx` seam.
- **Release** — bump 3.1.1→3.2.0 + CI tag (after Phase 2).
- **Settle-order replay oracle** — recording lands here; consumer follows.
- **Third-party `fanout` trust hardening** — lloyal-ai/hdk#18 (framework) + lloyal-ai/lloyal-infra#7 (review pipeline).