### PR TITLE
feat(agents): parallel recovery reap (recoveryShape: staggered | parallel)

### DIFF
--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -294,6 +294,17 @@ export interface AgentPolicy {
    * @param attempt - 1 on the first failure of a call, 2 after one retry, …
    */
   onToolRetry?(agent: Agent, tool: string, error: ToolRetryError, attempt: number): ToolRetryAction;
+
+  /**
+   * Recovery reap shape for the termination / wind-down sweep.
+   * `'staggered'` (default) — recover one agent at a time (`recoverInline`),
+   * pruning each before the next so every report gets the full freed headroom.
+   * `'parallel'` — batch the whole idle-no-result cohort: one prefill of all
+   * recovery prompts, then a batched decode across all branches (one native
+   * call per step). Downgrades to `'staggered'` when KV can't fit the cohort's
+   * prefill at once. Absent → `'staggered'`.
+   */
+  recoveryShape?: 'staggered' | 'parallel';
 }
 
 /**
@@ -359,7 +370,7 @@ export interface DefaultAgentPolicyOpts {
      *  applies when `budget.time.softLimit` is set. @default 0.5 */
     time?: number;
   };
-  /** Scratchpad recovery for agents killed without reporting.
+  /** Recovery extraction for agents killed without reporting.
    *  Policy decides per-agent via {@link AgentPolicy.onRecovery}. */
   recovery?: {
     prompt: { system: string; user: string };
@@ -368,6 +379,8 @@ export interface DefaultAgentPolicyOpts {
     /** Skip extraction for agents with fewer tool calls than this. @default 2 */
     minToolCalls?: number;
   };
+  /** Recovery reap shape — see {@link AgentPolicy.recoveryShape}. @default 'staggered' */
+  recoveryShape?: 'staggered' | 'parallel';
   /** Budget thresholds. softLimit = nudge, hardLimit = kill.
    *  Same naming pattern for both resource types.
    *  time budget is global across nesting levels (ms since policy creation). */
@@ -393,6 +406,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
   private _exploreTime: number;
   private _forceExploit = false;
   private _recovery: DefaultAgentPolicyOpts['recovery'] | null;
+  private _recoveryShape: 'staggered' | 'parallel';
   private _budget: DefaultAgentPolicyOpts['budget'] | null;
   private _terminalToolName: string | null;
   private _maxToolRetries: number;
@@ -407,6 +421,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
       ...(opts?.extraGuards ?? []),
     ];
     this._recovery = opts?.recovery ?? null;
+    this._recoveryShape = opts?.recoveryShape ?? 'staggered';
     this._budget = opts?.budget ?? null;
     this._terminalToolName = opts?.terminalToolName ?? null;
     this._maxToolRetries = opts?.maxToolRetries ?? 1;
@@ -440,6 +455,17 @@ export class DefaultAgentPolicy implements AgentPolicy {
       hardLimit: this._budget?.context?.hardLimit
         ?? ContextPressure.DEFAULT_HARD_LIMIT,
     };
+  }
+
+  /** Recovery reap shape. The pool reads this at the termination / wind-down
+   *  sweep to pick `recoverParallel` (parallel) vs per-agent `recoverInline`. */
+  get recoveryShape(): 'staggered' | 'parallel' {
+    return this._recoveryShape;
+  }
+
+  /** Flip the reap shape at runtime — wind-down (Phase 2b) sets `'parallel'`. */
+  setRecoveryShape(shape: 'staggered' | 'parallel'): void {
+    this._recoveryShape = shape;
   }
 
   onProduced(

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -199,6 +199,76 @@ export class ContextPressure {
   }
 }
 
+/** Eager `{ result: string }` extraction grammar — constrains recovery output
+ *  from token 0. Shared by `recoverInline` and `recoverParallel`. */
+function* recoveryReportGrammar(ctx: SessionContext): Operation<string> {
+  return yield* call(() =>
+    ctx.jsonSchemaToGrammar(JSON.stringify({
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    })),
+  );
+}
+
+/** Tokenize the recovery prompt (the `onRecovery` system+user turn) into a
+ *  branch-prefill delta appended to the agent's existing conversation KV.
+ *  Shared by both reap shapes. */
+function recoveryPromptTokens(
+  ctx: SessionContext,
+  recovery: { prompt: { system: string; user: string } },
+): number[] {
+  const { prompt } = ctx.formatChatSync(
+    JSON.stringify([
+      { role: 'system', content: recovery.prompt.system },
+      { role: 'user', content: recovery.prompt.user },
+    ]), { enableThinking: false },
+  );
+  return [...ctx.getTurnSeparator(), ...ctx.tokenizeSync(prompt, false)];
+}
+
+/** Parse a finished recovery branch's output, set the agent's result (source
+ *  `'recovery'`), emit `agent:recovered`, and write the recovery traces.
+ *  Returns true iff a result was extracted. Shared by both reap shapes. */
+function* finishRecovery(
+  agent: Agent,
+  output: string,
+  producedTokens: number,
+  events: EventSender,
+  tw: TraceWriter,
+  parentTraceId: number,
+): Operation<boolean> {
+  tw.write({
+    traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+    type: 'pool:recoveryProduce', agentId: agent.id,
+    tokenCount: producedTokens, outputLength: output.length,
+  });
+  let failureReason: string | null = null;
+  try {
+    const parsed = JSON.parse(output) as { result: string };
+    if (parsed?.result) {
+      agent.setResult(stripDanglingToolCall(parsed.result), 'recovery');
+      yield* events.send({ type: 'agent:recovered', agentId: agent.id, result: agent.result! });
+      tw.write({
+        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+        type: 'pool:recoveryReturn', agentId: agent.id,
+        resultLength: parsed.result.length,
+      });
+      return true;
+    }
+    failureReason = 'no_result_field';
+  } catch (e) {
+    failureReason = `parse_error: ${(e as Error).message ?? 'unknown'}`;
+  }
+  tw.write({
+    traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+    type: 'pool:recoveryFailed', agentId: agent.id,
+    reason: failureReason ?? 'unknown',
+    outputExcerpt: output.slice(0, 200),
+  });
+  return false;
+}
+
 /**
  * Inline recovery for a single killed agent (trailing stop).
  *
@@ -227,36 +297,15 @@ function* recoverInline(
     return false;
   }
 
-  // Build the nudge prompt — a minimal turn injection that triggers
-  // report behavior. The agent's KV already contains the full
-  // conversation context; the prompt is just a nudge.
-  const { prompt } = ctx.formatChatSync(
-    JSON.stringify([
-      { role: 'system', content: recovery.prompt.system },
-      { role: 'user', content: recovery.prompt.user },
-    ]), { enableThinking: false },
-  );
-  const sep = ctx.getTurnSeparator();
-  const delta = ctx.tokenizeSync(prompt, false);
-  const tokens = [...sep, ...delta];
+  const tokens = recoveryPromptTokens(ctx, recovery);
+  const reportGrammar = yield* recoveryReportGrammar(ctx);
 
-  // Eager report grammar — forces { result: string } output
-  const reportGrammar: string = yield* call(() =>
-    ctx.jsonSchemaToGrammar(JSON.stringify({
-      type: 'object',
-      properties: { result: { type: 'string' } },
-      required: ['result'],
-    })),
-  );
-
-  // Recovery runs in its own scope — if prefill or decode fails
-  // (KV exhaustion), the scope tears down cleanly. Diagnostic trace
-  // events (pool:recoveryProduce + recoveryReport/recoveryFailed) make
-  // silent recovery failures observable in traces.
+  // Recovery runs in its own scope — if prefill or decode fails (KV
+  // exhaustion), the scope tears down cleanly. The recoveryProduce/Return/
+  // Failed traces make silent recovery failures observable.
   let reported = false;
   let output = '';
   let producedTokens = 0;
-  let failureReason: string | null = null;
   try {
     yield* scoped(function*() {
       yield* call(() => store.prefill([[agent.branch, tokens]]));
@@ -278,46 +327,147 @@ function* recoverInline(
         yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: producedTokens });
       }
 
-      tw.write({
-        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-        type: 'pool:recoveryProduce', agentId: agent.id,
-        tokenCount: producedTokens, outputLength: output.length,
-      });
-
-      // Parse + return (recovery path — emits agent:recovered, NOT agent:return)
-      try {
-        const parsed = JSON.parse(output) as { result: string };
-        if (parsed?.result) {
-          agent.setResult(stripDanglingToolCall(parsed.result), 'recovery');
-          yield* events.send({ type: 'agent:recovered', agentId: agent.id, result: agent.result! });
-          reported = true;
-          tw.write({
-            traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-            type: 'pool:recoveryReturn', agentId: agent.id,
-            resultLength: parsed.result.length,
-          });
-        } else {
-          failureReason = 'no_result_field';
-        }
-      } catch (e) {
-        failureReason = `parse_error: ${(e as Error).message ?? 'unknown'}`;
-      }
+      reported = yield* finishRecovery(agent, output, producedTokens, events, tw, parentTraceId);
     });
   } catch (e) {
-    failureReason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
-  }
-
-  if (!reported) {
+    // Scope teardown (KV exhaustion during prefill/decode) — finishRecovery
+    // never ran, so emit the failure trace here.
     tw.write({
       traceId: tw.nextId(), parentTraceId, ts: performance.now(),
       type: 'pool:recoveryFailed', agentId: agent.id,
-      reason: failureReason ?? 'unknown',
+      reason: `scope_error: ${(e as Error).message ?? 'unknown'}`,
       outputExcerpt: output.slice(0, 200),
     });
   }
 
   // Always prune after scope exits (success or failure)
   if (!agent.branch.disposed) agent.branch.pruneSync();
+
+  // Emit tick so TUI updates pressure percentage after prune
+  const postPressure = new ContextPressure(ctx);
+  yield* events.send({ type: 'agent:tick', cellsUsed: postPressure.cellsUsed, nCtx: postPressure.nCtx });
+
+  return reported;
+}
+
+/**
+ * Parallel recovery — extract reports from the whole idle/unreported cohort in
+ * one batched pass: a single `store.prefill` of every recovery prompt, then a
+ * batched decode (one `store.commit` per step across all live branches —
+ * MOAT #1). Wall-clock ≈ the longest single report rather than Σ of all N,
+ * which is what makes a multi-agent wind-down feel instant.
+ *
+ * Up-front pressure gate: if KV can't fit the whole cohort's combined prefill
+ * at once, falls back to `staggered` (per-agent `recoverInline`, pruning
+ * between) — the headroom tradeoff staggering was introduced for (824e63a).
+ *
+ * Like `recoverInline`, this MUST run entirely on the loop fiber and finish
+ * before any agent transitions to 'idle' / the orchestrator wakes — a
+ * concurrent native call on the shared llama_context would SEGV.
+ *
+ * Returns the number of agents that reported.
+ */
+function* recoverParallel(
+  cohort: Agent[],
+  policy: AgentPolicy,
+  ctx: SessionContext,
+  store: BranchStore,
+  tw: TraceWriter,
+  parentTraceId: number,
+  events: EventSender,
+  pressureOpts: PressureThresholds,
+): Operation<number> {
+  // Build the cohort: idle, unreported, undisposed agents the policy opts to
+  // recover. A skip prunes that branch now — freeing KV for the batch.
+  const prefillPairs: [Branch, number[]][] = [];
+  const recovering: Agent[] = [];
+  for (const agent of cohort) {
+    if (agent.status !== 'idle' || agent.result || agent.branch.disposed) continue;
+    const recovery = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
+    if (!recovery || recovery.type === 'skip') {
+      if (!agent.branch.disposed) agent.branch.pruneSync();
+      continue;
+    }
+    prefillPairs.push([agent.branch, recoveryPromptTokens(ctx, recovery)]);
+    recovering.push(agent);
+  }
+  if (recovering.length === 0) return 0;
+
+  // Up-front pressure gate. Raw `remaining` (not headroom) — the hardLimit
+  // reserve exists precisely for recovery. If the whole cohort's prefill won't
+  // fit at once, recover staggered so each report gets the full freed headroom.
+  const pressure = new ContextPressure(ctx, pressureOpts);
+  const totalPrefill = prefillPairs.reduce((sum, [, t]) => sum + t.length, 0);
+  if (pressure.remaining < totalPrefill) {
+    let reported = 0;
+    for (const agent of recovering) {
+      if (yield* recoverInline(agent, policy, ctx, store, tw, parentTraceId, events, pressureOpts)) {
+        reported++;
+      }
+    }
+    return reported;
+  }
+
+  const reportGrammar = yield* recoveryReportGrammar(ctx);
+  const output = new Map<Agent, string>();
+  const produced = new Map<Agent, number>();
+  const done = new Set<Agent>();
+  for (const agent of recovering) { output.set(agent, ''); produced.set(agent, 0); }
+
+  let reported = 0;
+  try {
+    yield* scoped(function*() {
+      // One batched prefill of every extraction prompt, then per-branch grammar.
+      yield* call(() => store.prefill(prefillPairs));
+      for (let i = 0; i < recovering.length; i++) {
+        const agent = recovering[i];
+        agent.branch.setGrammar(reportGrammar);
+        tw.write({
+          traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+          type: 'branch:prefill', branchHandle: agent.id,
+          tokenCount: prefillPairs[i][1].length, role: 'recovery',
+        });
+      }
+
+      // Batched produce/commit — one native commit per step across all live
+      // branches. A stop drops that agent from the batch and extracts its report.
+      while (done.size < recovering.length) {
+        const entries: [Branch, number][] = [];
+        for (const agent of recovering) {
+          if (done.has(agent)) continue;
+          const { token, text, isStop } = agent.branch.produceSync();
+          if (isStop) {
+            done.add(agent);
+            if (yield* finishRecovery(agent, output.get(agent)!, produced.get(agent)!, events, tw, parentTraceId)) {
+              reported++;
+            }
+            continue;
+          }
+          output.set(agent, output.get(agent)! + text);
+          produced.set(agent, produced.get(agent)! + 1);
+          entries.push([agent.branch, token]);
+          yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: produced.get(agent)! });
+        }
+        if (entries.length === 0) break;
+        yield* call(() => store.commit(entries));
+      }
+    });
+  } catch (e) {
+    // KV exhaustion mid-batch — mark every agent that hadn't finished failed.
+    const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
+    for (const agent of recovering) {
+      if (done.has(agent)) continue;
+      tw.write({
+        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+        type: 'pool:recoveryFailed', agentId: agent.id,
+        reason, outputExcerpt: output.get(agent)!.slice(0, 200),
+      });
+    }
+  }
+
+  for (const agent of recovering) {
+    if (!agent.branch.disposed) agent.branch.pruneSync();
+  }
 
   // Emit tick so TUI updates pressure percentage after prune
   const postPressure = new ContextPressure(ctx);
@@ -1474,10 +1624,17 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         if (!recoveryAttempted) {
           recoveryAttempted = true;
           // Recover any idle agents that weren't handled by inline recovery
-          // (e.g., killed by max_turns, time budget, or free_text_stop)
-          for (const a of agents) {
-            if (a.status === 'idle' && !a.result && !a.branch.disposed) {
-              yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+          // (e.g., killed by max_turns, time budget, or free_text_stop).
+          // `parallel` batches the whole cohort (one prefill + batched decode —
+          // wall-clock ≈ the slowest single report); `staggered` (default)
+          // recovers them one at a time for maximum per-report headroom.
+          if (policy.recoveryShape === 'parallel') {
+            yield* recoverParallel(agents, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+          } else {
+            for (const a of agents) {
+              if (a.status === 'idle' && !a.result && !a.branch.disposed) {
+                yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+              }
             }
           }
         }

--- a/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+import type { PoolRun } from '../harness';
+import { I1_nativeStoreSingleFiber, I29_recoveryDiagnostic } from '../predicates';
+
+const N = 3;
+
+/**
+ * Every agent drops to idle WITHOUT a result on its first stop
+ * (`free_text_stop`, not `free_text_return`), so all N land in the
+ * termination-sweep recovery cohort. `onRecovery` always extracts (no
+ * min-token/min-tool gates), and `recoveryShape` selects the reap path under
+ * test. The recovery prompt is a parameter so the pressure-downgrade test can
+ * make Σ(prefill) dwarf the available headroom.
+ */
+function idleNoResultPolicy(
+  shape: 'staggered' | 'parallel',
+  recoveryPrompt: { system: string; user: string },
+): AgentPolicy {
+  return {
+    onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+    onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+    onRecovery: () => ({ type: 'extract', prompt: recoveryPrompt }),
+    shouldExit: () => false,
+    recoveryShape: shape,
+  };
+}
+
+const recoveryPrefills = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
+const prefillCount = (r: PoolRun) =>
+  r.nativeCalls.filter(c => c.op === 'prefill').length;
+
+// Each agent: main turn [1, STOP], then recovery decode [2, STOP]. The mock
+// emits non-JSON text from token 2 → recovery lands on `pool:recoveryFailed`
+// (we assert the batching *shape*, not parse success — the mock can't produce
+// grammar-valid JSON).
+const idleScripts = () =>
+  Array.from({ length: N }, () => ({ tokens: [1, STOP, 2, STOP], content: 'prose findings' }));
+
+describe('scenario: parallel recovery (recoveryShape)', () => {
+  it('parallel batches the whole idle-no-result cohort into ONE prefill (vs N staggered)', async () => {
+    // Small recovery prompt + generous nCtx → the up-front pressure gate passes
+    // → the batched path runs. Same scripts/policy except the reap shape, so
+    // root + spawn prefills are identical between the two runs.
+    const prompt = { system: 's', user: 'u' };
+    const par = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
+    const stag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+
+    // Both shapes recover every agent (one recovery prefill trace each).
+    expect(recoveryPrefills(par).length).toBe(N);
+    expect(recoveryPrefills(stag).length).toBe(N);
+
+    // THE batching proof: the only difference between the runs is the reap
+    // shape, so parallel collapsing N recovery prefills into one batched
+    // `store.prefill` shows up as exactly (N-1) fewer native prefill calls.
+    expect(prefillCount(par)).toBe(prefillCount(stag) - (N - 1));
+
+    // The batched decode must hold the single-fiber invariant (the SEGV guard)…
+    expect(I1_nativeStoreSingleFiber(par).ok).toBe(true);
+    // …and every recovering agent still gets exactly one diagnostic (no loss).
+    expect(I29_recoveryDiagnostic(par).ok).toBe(true);
+  });
+
+  it('parallel downgrades to staggered when the cohort prefill exceeds headroom', async () => {
+    // Huge recovery prompt → Σ(prefill) far exceeds `remaining`, so the
+    // up-front pressure gate forces the per-agent staggered fallback even
+    // though recoveryShape is 'parallel'. Nothing is lost.
+    const big = 'x'.repeat(4000); // ~1000 tokens each; ~6000 across the cohort
+    const prompt = { system: big, user: big };
+    const parPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
+    const stagPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+
+    // Downgrade ⇒ parallel ran the staggered path ⇒ identical native prefill
+    // count to the staggered baseline (no N→1 collapse).
+    expect(prefillCount(parPressure)).toBe(prefillCount(stagPressure));
+
+    // Every agent still recovered — the downgrade loses no reports.
+    expect(recoveryPrefills(parPressure).length).toBe(N);
+    expect(I29_recoveryDiagnostic(parPressure).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Phase 2a — Parallel recovery (the foundation for graceful wind-down)

Restores the batched recovery-extraction loop the pool originally used, as a `recoveryShape: 'staggered' | 'parallel'` policy knob (default `'staggered'` — **no behaviour change** until a consumer opts in).

### Why
After the fan-out work made *tool I/O* concurrent, the recovery reap was still serial: `recoverInline` writes each dropped agent's report on its own branch, one at a time, so N reports cost ≈ Σ of each report's decode — the exact serial-decode hog fan-out had just removed. A staggered-only wind-down would re-introduce it, so parallel recovery is the **foundation** the wind-down (Phase 2b) depends on, not an optimisation.

### What
- **`recoverParallel`** — batches the whole idle-no-result cohort: one `store.prefill` of every recovery prompt, then a batched decode (one `store.commit` per step across all live branches), so wall-clock ≈ the slowest single report instead of Σ.
- **Up-front pressure gate** — if the cohort's combined prefill exceeds remaining KV, fall back to per-agent `recoverInline` (each report gets the full freed headroom). This is the tradeoff staggering was introduced for; an up-front decision, not a mid-recovery switch.
- **3 shared helpers** (`recoveryReportGrammar` / `recoveryPromptTokens` / `finishRecovery`) — both shapes reuse the prompt build, grammar, and `parse → setResult('recovery') → agent:recovered → traces` path. `recoverInline` is refactored onto them (and the stale "just a nudge" comment dropped — it's the recovery prompt, not a nudge).
- **SEGV / loop-fiber invariant** — the whole batch runs on the loop fiber and finishes before any `idle` transition / orchestrator wake; a concurrent native call on the shared `llama_context` would crash.
- Wired at the **termination sweep** behind `policy.recoveryShape === 'parallel'`; per-drop kill sites stay staggered (single agent, often under pressure).

### Tests
`packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts`:
- **batched gather** — N idle-no-result agents under `parallel` collapse N recovery prefills into one (asserted as exactly N−1 fewer native prefills than staggered); the batched decode holds the `I1` single-fiber invariant; every agent diagnosed (`I29`).
- **pressure downgrade** — a cohort prefill exceeding headroom falls back to staggered (identical native-prefill count to the staggered baseline) with no report lost.

### Verification
`npm run build` clean; `test:unit` → **452 passed / 2 skipped**. The staggered default path is byte-for-byte unchanged.

Phase 2b (graceful wind-down) consumes this and sets `recoveryShape='parallel'` for the fast Stop gather; both ship together as agents `3.2.0`.
