### PR TITLE
feat(agents): fold-based parallel recovery — per-report budget + maxLength cap

### DIFF
--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -9,8 +9,8 @@ import { renderTemplate } from './prompt';
 // allocation for recoverInline: the prefill cost of the recovery prompt +
 // room for llama.cpp's batch workspace. Used to compute the budget
 // communicated to the model in its recovery prompt.
-const RECOVERY_PREFILL_OVERHEAD = 150;
-const BATCH_BUFFER = 512;
+export const RECOVERY_PREFILL_OVERHEAD = 150;
+export const BATCH_BUFFER = 512;
 
 /**
  * Convert a token budget to a conservative word count for the model-facing
@@ -19,7 +19,7 @@ const BATCH_BUFFER = 512;
  * typical ~0.75) to under-advertise the budget, rounds down to the nearest
  * 10, and floors at 10 so the model always has a non-zero target.
  */
-function tokenBudgetAsWords(budgetTokens: number): number {
+export function tokenBudgetAsWords(budgetTokens: number): number {
   return Math.max(10, Math.floor(budgetTokens * 0.7 / 10) * 10);
 }
 
@@ -279,8 +279,13 @@ export interface AgentPolicy {
    * Custom prompts must produce output matching this shape.
    *
    * Optional — defaults to skip when absent.
+   *
+   * `budgetTokens` (optional) overrides the pressure-derived report budget —
+   * the parallel recovery fold passes the per-report budget `b` so the prompt's
+   * advisory word count matches the grammar `maxLength` cap. Absent → the budget
+   * is derived from `pressure.remaining` as usual (staggered / per-agent).
    */
-  onRecovery?(agent: Agent, pressure: ContextPressure): RecoveryAction;
+  onRecovery?(agent: Agent, pressure: ContextPressure, budgetTokens?: number): RecoveryAction;
 
   /**
    * Transient tool failure (the tool threw {@link ToolRetryError}).
@@ -305,6 +310,11 @@ export interface AgentPolicy {
    * prefill at once. Absent → `'staggered'`.
    */
   recoveryShape?: 'staggered' | 'parallel';
+
+  /** Per-report token budget for the parallel recovery fold — advisory in the
+   *  recovery prompt + the grammar `maxLength` cap. Absent → uncapped
+   *  (staggered) / headroom-derived (fold). */
+  readonly reportBudget?: number;
 }
 
 /**
@@ -381,6 +391,12 @@ export interface DefaultAgentPolicyOpts {
   };
   /** Recovery reap shape — see {@link AgentPolicy.recoveryShape}. @default 'staggered' */
   recoveryShape?: 'staggered' | 'parallel';
+  /** Per-report token budget for the PARALLEL recovery fold — rendered into the
+   *  recovery prompt (advisory "within N words") AND used as the grammar
+   *  `maxLength` cap (hard). Unused by `staggered` (full-length reports). The
+   *  consumer sets it per Effort level. @default unset (fold falls back to
+   *  headroom-derived) */
+  reportBudget?: number;
   /** Budget thresholds. softLimit = nudge, hardLimit = kill.
    *  Same naming pattern for both resource types.
    *  time budget is global across nesting levels (ms since policy creation). */
@@ -407,6 +423,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
   private _forceExploit = false;
   private _recovery: DefaultAgentPolicyOpts['recovery'] | null;
   private _recoveryShape: 'staggered' | 'parallel';
+  private _reportBudget: number | null;
   private _budget: DefaultAgentPolicyOpts['budget'] | null;
   private _terminalToolName: string | null;
   private _maxToolRetries: number;
@@ -422,6 +439,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
     ];
     this._recovery = opts?.recovery ?? null;
     this._recoveryShape = opts?.recoveryShape ?? 'staggered';
+    this._reportBudget = opts?.reportBudget ?? null;
     this._budget = opts?.budget ?? null;
     this._terminalToolName = opts?.terminalToolName ?? null;
     this._maxToolRetries = opts?.maxToolRetries ?? 1;
@@ -463,9 +481,15 @@ export class DefaultAgentPolicy implements AgentPolicy {
     return this._recoveryShape;
   }
 
-  /** Flip the reap shape at runtime — wind-down (Phase 2b) sets `'parallel'`. */
+  /** Flip the reap shape at runtime — wind-down sets `'parallel'`. */
   setRecoveryShape(shape: 'staggered' | 'parallel'): void {
     this._recoveryShape = shape;
+  }
+
+  /** Per-report token budget for the parallel recovery fold (undefined = uncapped /
+   *  headroom-derived). The fold renders it into the prompt + caps the grammar. */
+  get reportBudget(): number | undefined {
+    return this._reportBudget ?? undefined;
   }
 
   onProduced(
@@ -635,7 +659,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
     this._nudgedThisTick = false;
   }
 
-  onRecovery(agent: Agent, pressure: ContextPressure): RecoveryAction {
+  onRecovery(agent: Agent, pressure: ContextPressure, budgetTokensOverride?: number): RecoveryAction {
     if (!this._recovery) return { type: 'skip' };
     const minTokens = this._recovery.minTokens ?? 100;
     const minToolCalls = this._recovery.minToolCalls ?? 2;
@@ -647,7 +671,10 @@ export class DefaultAgentPolicy implements AgentPolicy {
     // (not tokens) and under-advertised so the model has slack — tokenizers
     // vary across models but words are universal. Rendered into the prompt
     // as `it.budget` so authors can reference it via `<%= it.budget %>`.
-    const budgetTokens = Math.max(50, pressure.remaining - RECOVERY_PREFILL_OVERHEAD - BATCH_BUFFER);
+    // The parallel fold overrides this with its fixed per-report budget `b` so
+    // the advisory matches the grammar `maxLength` cap (graceful, not a guillotine).
+    const budgetTokens = budgetTokensOverride
+      ?? Math.max(50, pressure.remaining - RECOVERY_PREFILL_OVERHEAD - BATCH_BUFFER);
     const budget = tokenBudgetAsWords(budgetTokens);
     const tctx = { budget };
     return {

--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -294,6 +294,17 @@ export interface AgentPolicy {
    * @param attempt - 1 on the first failure of a call, 2 after one retry, …
    */
   onToolRetry?(agent: Agent, tool: string, error: ToolRetryError, attempt: number): ToolRetryAction;
+
+  /**
+   * Recovery reap shape for the termination / wind-down sweep.
+   * `'staggered'` (default) — recover one agent at a time (`recoverInline`),
+   * pruning each before the next so every report gets the full freed headroom.
+   * `'parallel'` — batch the whole idle-no-result cohort: one prefill of all
+   * recovery prompts, then a batched decode across all branches (one native
+   * call per step). Downgrades to `'staggered'` when KV can't fit the cohort's
+   * prefill at once. Absent → `'staggered'`.
+   */
+  recoveryShape?: 'staggered' | 'parallel';
 }
 
 /**
@@ -359,7 +370,7 @@ export interface DefaultAgentPolicyOpts {
      *  applies when `budget.time.softLimit` is set. @default 0.5 */
     time?: number;
   };
-  /** Scratchpad recovery for agents killed without reporting.
+  /** Recovery extraction for agents killed without reporting.
    *  Policy decides per-agent via {@link AgentPolicy.onRecovery}. */
   recovery?: {
     prompt: { system: string; user: string };
@@ -368,6 +379,8 @@ export interface DefaultAgentPolicyOpts {
     /** Skip extraction for agents with fewer tool calls than this. @default 2 */
     minToolCalls?: number;
   };
+  /** Recovery reap shape — see {@link AgentPolicy.recoveryShape}. @default 'staggered' */
+  recoveryShape?: 'staggered' | 'parallel';
   /** Budget thresholds. softLimit = nudge, hardLimit = kill.
    *  Same naming pattern for both resource types.
    *  time budget is global across nesting levels (ms since policy creation). */
@@ -393,6 +406,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
   private _exploreTime: number;
   private _forceExploit = false;
   private _recovery: DefaultAgentPolicyOpts['recovery'] | null;
+  private _recoveryShape: 'staggered' | 'parallel';
   private _budget: DefaultAgentPolicyOpts['budget'] | null;
   private _terminalToolName: string | null;
   private _maxToolRetries: number;
@@ -407,6 +421,7 @@ export class DefaultAgentPolicy implements AgentPolicy {
       ...(opts?.extraGuards ?? []),
     ];
     this._recovery = opts?.recovery ?? null;
+    this._recoveryShape = opts?.recoveryShape ?? 'staggered';
     this._budget = opts?.budget ?? null;
     this._terminalToolName = opts?.terminalToolName ?? null;
     this._maxToolRetries = opts?.maxToolRetries ?? 1;
@@ -440,6 +455,17 @@ export class DefaultAgentPolicy implements AgentPolicy {
       hardLimit: this._budget?.context?.hardLimit
         ?? ContextPressure.DEFAULT_HARD_LIMIT,
     };
+  }
+
+  /** Recovery reap shape. The pool reads this at the termination / wind-down
+   *  sweep to pick `recoverParallel` (parallel) vs per-agent `recoverInline`. */
+  get recoveryShape(): 'staggered' | 'parallel' {
+    return this._recoveryShape;
+  }
+
+  /** Flip the reap shape at runtime — wind-down (Phase 2b) sets `'parallel'`. */
+  setRecoveryShape(shape: 'staggered' | 'parallel'): void {
+    this._recoveryShape = shape;
   }
 
   onProduced(

--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -304,10 +304,13 @@ export interface AgentPolicy {
    * Recovery reap shape for the termination / wind-down sweep.
    * `'staggered'` (default) — recover one agent at a time (`recoverInline`),
    * pruning each before the next so every report gets the full freed headroom.
-   * `'parallel'` — batch the whole idle-no-result cohort: one prefill of all
-   * recovery prompts, then a batched decode across all branches (one native
-   * call per step). Downgrades to `'staggered'` when KV can't fit the cohort's
-   * prefill at once. Absent → `'staggered'`.
+   * `'parallel'` — recover the idle-no-result cohort as a bounded FOLD: each step
+   * takes the largest GROUP that fits in current KV at a fixed per-report budget
+   * (a fair share of headroom, or {@link reportBudget}), batches its prefill +
+   * decode (one native call per step), prunes it to replenish KV, and recurses —
+   * group size flexes 1..N with headroom (down to one-at-a-time under pressure),
+   * never switching modes. The per-report budget is enforced as a grammar
+   * `maxLength` cap. Absent → `'staggered'`.
    */
   recoveryShape?: 'staggered' | 'parallel';
 

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -10,7 +10,7 @@ import { traceScope } from './trace-scope';
 import type { TraceWriter } from './trace-writer';
 import type { AgentPolicy, IdleReason, ToolRetryAction } from './AgentPolicy';
 import { Agent } from './Agent';
-import { DefaultAgentPolicy } from './AgentPolicy';
+import { DefaultAgentPolicy, tokenBudgetAsWords, RECOVERY_PREFILL_OVERHEAD, BATCH_BUFFER } from './AgentPolicy';
 import type { PolicyConfig } from './AgentPolicy';
 import { Tool, ToolRetryError } from './Tool';
 import type {
@@ -200,12 +200,21 @@ export class ContextPressure {
 }
 
 /** Eager `{ result: string }` extraction grammar — constrains recovery output
- *  from token 0. Shared by `recoverInline` and `recoverParallel`. */
-function* recoveryReportGrammar(ctx: SessionContext): Operation<string> {
+ *  from token 0. Shared by `recoverInline` (uncapped) and the parallel fold.
+ *
+ *  `maxChars` (when set) caps the `result` string via JSON-Schema `maxLength` —
+ *  the binding emits `char{0,N}` and forces the closing quote, so the report is
+ *  hard-bounded AND the JSON always parses. Used by the parallel fold to fit N
+ *  concurrent reports in shared KV; staggered passes none (full-length reports). */
+function* recoveryReportGrammar(ctx: SessionContext, maxChars?: number): Operation<string> {
   return yield* call(() =>
     ctx.jsonSchemaToGrammar(JSON.stringify({
       type: 'object',
-      properties: { result: { type: 'string' } },
+      properties: {
+        result: maxChars != null
+          ? { type: 'string', maxLength: maxChars }
+          : { type: 'string' },
+      },
       required: ['result'],
     })),
   );
@@ -350,90 +359,62 @@ function* recoverInline(
   return reported;
 }
 
-/**
- * Parallel recovery — extract reports from the whole idle/unreported cohort in
- * one batched pass: a single `store.prefill` of every recovery prompt, then a
- * batched decode (one `store.commit` per step across all live branches —
- * MOAT #1). Wall-clock ≈ the longest single report rather than Σ of all N,
- * which is what makes a multi-agent wind-down feel instant.
- *
- * Up-front pressure gate: if KV can't fit the whole cohort's combined prefill
- * at once, falls back to `staggered` (per-agent `recoverInline`, pruning
- * between) — the headroom tradeoff staggering was introduced for (824e63a).
- *
- * Like `recoverInline`, this MUST run entirely on the loop fiber and finish
- * before any agent transitions to 'idle' / the orchestrator wakes — a
- * concurrent native call on the shared llama_context would SEGV.
- *
- * Returns the number of agents that reported.
- */
-function* recoverParallel(
-  cohort: Agent[],
-  policy: AgentPolicy,
-  ctx: SessionContext,
+// Per-report budget bounds (tokens) for the headroom-derived fold budget, used
+// when no fixed `policy.reportBudget` is set (e.g. wind-down). MIN keeps a report
+// usable; MAX stops an ample-KV wind-down from writing essays.
+const MIN_REPORT_BUDGET = 128;
+const MAX_REPORT_BUDGET = 2048;
+
+/** Prune a finished recovery branch, skipping it if it still has live children —
+ *  `pruneSync` throws on children (RESTRICT mode), which a delegate parent could
+ *  hit (a sub-agent forks off the calling agent's branch). A skipped parent's KV
+ *  is reclaimed at pool teardown; in practice delegate sub-pools complete + prune
+ *  before the termination sweep, so this guard rarely fires. */
+function safePrune(branch: Branch): void {
+  if (!branch.disposed && branch.children.length === 0) branch.pruneSync();
+}
+
+/** Recover one fold group in a single batched pass: one `store.prefill` of every
+ *  prompt, then a batched decode (one `store.commit` per step across all live
+ *  branches — MOAT #1), extract on stop, then `safePrune` each (freeing KV for the
+ *  next group). The grammar is `maxLength`-capped so the group fits the budget the
+ *  fold reserved for it. Runs on the loop fiber inside a scope so a mid-batch KV
+ *  exhaustion tears down cleanly. Returns how many agents reported. */
+function* recoverGroup(
+  group: Agent[],
+  groupTokens: number[][],
+  reportGrammar: string,
   store: BranchStore,
   tw: TraceWriter,
   parentTraceId: number,
   events: EventSender,
-  pressureOpts: PressureThresholds,
 ): Operation<number> {
-  // Build the cohort: idle, unreported, undisposed agents the policy opts to
-  // recover. A skip prunes that branch now — freeing KV for the batch.
-  const prefillPairs: [Branch, number[]][] = [];
-  const recovering: Agent[] = [];
-  for (const agent of cohort) {
-    if (agent.status !== 'idle' || agent.result || agent.branch.disposed) continue;
-    const recovery = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
-    if (!recovery || recovery.type === 'skip') {
-      if (!agent.branch.disposed) agent.branch.pruneSync();
-      continue;
-    }
-    prefillPairs.push([agent.branch, recoveryPromptTokens(ctx, recovery)]);
-    recovering.push(agent);
-  }
-  if (recovering.length === 0) return 0;
-
-  // Up-front pressure gate. Raw `remaining` (not headroom) — the hardLimit
-  // reserve exists precisely for recovery. If the whole cohort's prefill won't
-  // fit at once, recover staggered so each report gets the full freed headroom.
-  const pressure = new ContextPressure(ctx, pressureOpts);
-  const totalPrefill = prefillPairs.reduce((sum, [, t]) => sum + t.length, 0);
-  if (pressure.remaining < totalPrefill) {
-    let reported = 0;
-    for (const agent of recovering) {
-      if (yield* recoverInline(agent, policy, ctx, store, tw, parentTraceId, events, pressureOpts)) {
-        reported++;
-      }
-    }
-    return reported;
-  }
-
-  const reportGrammar = yield* recoveryReportGrammar(ctx);
+  const prefillPairs: [Branch, number[]][] = group.map((a, i) => [a.branch, groupTokens[i]]);
   const output = new Map<Agent, string>();
   const produced = new Map<Agent, number>();
   const done = new Set<Agent>();
-  for (const agent of recovering) { output.set(agent, ''); produced.set(agent, 0); }
+  for (const agent of group) { output.set(agent, ''); produced.set(agent, 0); }
 
   let reported = 0;
   try {
     yield* scoped(function*() {
       // One batched prefill of every extraction prompt, then per-branch grammar.
       yield* call(() => store.prefill(prefillPairs));
-      for (let i = 0; i < recovering.length; i++) {
-        const agent = recovering[i];
-        agent.branch.setGrammar(reportGrammar);
+      for (let i = 0; i < group.length; i++) {
+        group[i].branch.setGrammar(reportGrammar);
         tw.write({
           traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-          type: 'branch:prefill', branchHandle: agent.id,
-          tokenCount: prefillPairs[i][1].length, role: 'recovery',
+          type: 'branch:prefill', branchHandle: group[i].id,
+          tokenCount: groupTokens[i].length, role: 'recovery',
         });
       }
 
-      // Batched produce/commit — one native commit per step across all live
-      // branches. A stop drops that agent from the batch and extracts its report.
-      while (done.size < recovering.length) {
+      // Batched produce/commit — one `store.commit` per step (which packs all
+      // branches into a single llama_decode internally — MOAT #1). A stop drops
+      // that agent from the group and extracts its report.
+      while (done.size < group.length) {
         const entries: [Branch, number][] = [];
-        for (const agent of recovering) {
+        for (const agent of group) {
           if (done.has(agent)) continue;
           const { token, text, isStop } = agent.branch.produceSync();
           if (isStop) {
@@ -455,7 +436,7 @@ function* recoverParallel(
   } catch (e) {
     // KV exhaustion mid-batch — mark every agent that hadn't finished failed.
     const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
-    for (const agent of recovering) {
+    for (const agent of group) {
       if (done.has(agent)) continue;
       tw.write({
         traceId: tw.nextId(), parentTraceId, ts: performance.now(),
@@ -465,11 +446,100 @@ function* recoverParallel(
     }
   }
 
-  for (const agent of recovering) {
-    if (!agent.branch.disposed) agent.branch.pruneSync();
+  for (const agent of group) safePrune(agent.branch);
+  return reported;
+}
+
+/**
+ * Parallel recovery — extract reports from the whole idle/unreported cohort as a
+ * bounded FOLD. Each step recovers the largest group that fits in current KV at a
+ * fixed per-report budget `b`, then prunes it (freeing KV) and recurses over the
+ * rest. The group size `k` flexes 1..N with available headroom — k=N (one batched
+ * pass) when KV is ample, k=1 (effectively staggered) when it's tight — and grows
+ * again as pruning replenishes KV. The partition IS the decision: no mode flag.
+ *
+ * `b` (tokens) is FIXED for the fold: `policy.reportBudget` when set (the configured
+ * cap, e.g. low effort), else a fair share of current headroom computed once. It
+ * bounds each report two ways — rendered into the recovery prompt as the advisory
+ * word count (via the `onRecovery` budget override) AND enforced as the grammar
+ * `maxLength` cap (the hard backstop). This is what fixes the pool-wide-budget bug:
+ * every agent is told `b`, not the whole KV, so N concurrent reports can't
+ * collectively exhaust it.
+ *
+ * Like `recoverInline`, this MUST run entirely on the loop fiber and finish before
+ * any agent transitions to 'idle' / the orchestrator wakes — a concurrent native
+ * call on the shared llama_context would SEGV.
+ *
+ * Returns the number of agents that reported.
+ */
+function* recoverParallel(
+  cohort: Agent[],
+  policy: AgentPolicy,
+  ctx: SessionContext,
+  store: BranchStore,
+  tw: TraceWriter,
+  parentTraceId: number,
+  events: EventSender,
+  pressureOpts: PressureThresholds,
+): Operation<number> {
+  // Eligibility pass: keep idle, unreported, undisposed agents the policy opts to
+  // recover; skip-prune the rest now (frees their KV for the fold). The prompt from
+  // this probe is discarded — the fold re-renders each prompt with the fixed `b`.
+  const queue: Agent[] = [];
+  for (const agent of cohort) {
+    if (agent.status !== 'idle' || agent.result || agent.branch.disposed) continue;
+    const probe = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
+    if (!probe || probe.type === 'skip') {
+      safePrune(agent.branch);
+      continue;
+    }
+    queue.push(agent);
+  }
+  if (queue.length === 0) return 0;
+
+  // Fixed per-report budget `b` (tokens): the configured cap, else a fair share of
+  // current headroom, computed ONCE. RESERVE matches `onRecovery`'s own accounting.
+  const RESERVE = RECOVERY_PREFILL_OVERHEAD + BATCH_BUFFER;
+  const remaining0 = new ContextPressure(ctx, pressureOpts).remaining;
+  const b = policy.reportBudget
+    ?? Math.min(MAX_REPORT_BUDGET, Math.max(MIN_REPORT_BUDGET, Math.floor((remaining0 - RESERVE) / queue.length)));
+  // Grammar cap is in CHARS, `b` is in tokens: words(b) × ~6 chars × 1.2 headroom,
+  // so the model concludes within `b` on its own and the cap is a silent backstop.
+  const bChars = Math.ceil(tokenBudgetAsWords(b) * 6 * 1.2);
+  const reportGrammar = yield* recoveryReportGrammar(ctx, bChars);
+
+  // Render + tokenize every recovery prompt ONCE at the fixed budget `b` — the
+  // prompt is identical across groups since `b` is fixed, so a boundary agent is
+  // never re-rendered/re-tokenized. A skip here prunes that branch now.
+  const entries: { agent: Agent; tokens: number[] }[] = [];
+  for (const agent of queue) {
+    const recovery = policy.onRecovery!(agent, new ContextPressure(ctx, pressureOpts), b);
+    if (!recovery || recovery.type === 'skip') { safePrune(agent.branch); continue; }
+    entries.push({ agent, tokens: recoveryPromptTokens(ctx, recovery) });
   }
 
-  // Emit tick so TUI updates pressure percentage after prune
+  // The fold: pack the largest prefix that fits at (promptTokens + b) per report
+  // into each group (always ≥ 1), recover it, prune (replenishes KV), re-read
+  // headroom, recurse over the rest. `k` flexes 1..N; the partition IS the decision.
+  let reported = 0;
+  let i = 0;
+  while (i < entries.length) {
+    const budget = new ContextPressure(ctx, pressureOpts).remaining - RESERVE;
+    const group: Agent[] = [];
+    const groupTokens: number[][] = [];
+    let used = 0;
+    while (i < entries.length) {
+      const cost = entries[i].tokens.length + b;
+      if (group.length > 0 && used + cost > budget) break; // group full — recover it, prune, re-read KV
+      group.push(entries[i].agent);
+      groupTokens.push(entries[i].tokens);
+      used += cost;
+      i++;
+    }
+    reported += yield* recoverGroup(group, groupTokens, reportGrammar, store, tw, parentTraceId, events);
+  }
+
+  // Emit tick so TUI updates pressure percentage after the final prune.
   const postPressure = new ContextPressure(ctx);
   yield* events.send({ type: 'agent:tick', cellsUsed: postPressure.cellsUsed, nCtx: postPressure.nCtx });
 

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -199,6 +199,76 @@ export class ContextPressure {
   }
 }
 
+/** Eager `{ result: string }` extraction grammar — constrains recovery output
+ *  from token 0. Shared by `recoverInline` and `recoverParallel`. */
+function* recoveryReportGrammar(ctx: SessionContext): Operation<string> {
+  return yield* call(() =>
+    ctx.jsonSchemaToGrammar(JSON.stringify({
+      type: 'object',
+      properties: { result: { type: 'string' } },
+      required: ['result'],
+    })),
+  );
+}
+
+/** Tokenize the recovery prompt (the `onRecovery` system+user turn) into a
+ *  branch-prefill delta appended to the agent's existing conversation KV.
+ *  Shared by both reap shapes. */
+function recoveryPromptTokens(
+  ctx: SessionContext,
+  recovery: { prompt: { system: string; user: string } },
+): number[] {
+  const { prompt } = ctx.formatChatSync(
+    JSON.stringify([
+      { role: 'system', content: recovery.prompt.system },
+      { role: 'user', content: recovery.prompt.user },
+    ]), { enableThinking: false },
+  );
+  return [...ctx.getTurnSeparator(), ...ctx.tokenizeSync(prompt, false)];
+}
+
+/** Parse a finished recovery branch's output, set the agent's result (source
+ *  `'recovery'`), emit `agent:recovered`, and write the recovery traces.
+ *  Returns true iff a result was extracted. Shared by both reap shapes. */
+function* finishRecovery(
+  agent: Agent,
+  output: string,
+  producedTokens: number,
+  events: EventSender,
+  tw: TraceWriter,
+  parentTraceId: number,
+): Operation<boolean> {
+  tw.write({
+    traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+    type: 'pool:recoveryProduce', agentId: agent.id,
+    tokenCount: producedTokens, outputLength: output.length,
+  });
+  let failureReason: string | null = null;
+  try {
+    const parsed = JSON.parse(output) as { result: string };
+    if (parsed?.result) {
+      agent.setResult(stripDanglingToolCall(parsed.result), 'recovery');
+      yield* events.send({ type: 'agent:recovered', agentId: agent.id, result: agent.result! });
+      tw.write({
+        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+        type: 'pool:recoveryReturn', agentId: agent.id,
+        resultLength: parsed.result.length,
+      });
+      return true;
+    }
+    failureReason = 'no_result_field';
+  } catch (e) {
+    failureReason = `parse_error: ${(e as Error).message ?? 'unknown'}`;
+  }
+  tw.write({
+    traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+    type: 'pool:recoveryFailed', agentId: agent.id,
+    reason: failureReason ?? 'unknown',
+    outputExcerpt: output.slice(0, 200),
+  });
+  return false;
+}
+
 /**
  * Inline recovery for a single killed agent (trailing stop).
  *
@@ -227,36 +297,15 @@ function* recoverInline(
     return false;
   }
 
-  // Build the nudge prompt — a minimal turn injection that triggers
-  // report behavior. The agent's KV already contains the full
-  // conversation context; the prompt is just a nudge.
-  const { prompt } = ctx.formatChatSync(
-    JSON.stringify([
-      { role: 'system', content: recovery.prompt.system },
-      { role: 'user', content: recovery.prompt.user },
-    ]), { enableThinking: false },
-  );
-  const sep = ctx.getTurnSeparator();
-  const delta = ctx.tokenizeSync(prompt, false);
-  const tokens = [...sep, ...delta];
+  const tokens = recoveryPromptTokens(ctx, recovery);
+  const reportGrammar = yield* recoveryReportGrammar(ctx);
 
-  // Eager report grammar — forces { result: string } output
-  const reportGrammar: string = yield* call(() =>
-    ctx.jsonSchemaToGrammar(JSON.stringify({
-      type: 'object',
-      properties: { result: { type: 'string' } },
-      required: ['result'],
-    })),
-  );
-
-  // Recovery runs in its own scope — if prefill or decode fails
-  // (KV exhaustion), the scope tears down cleanly. Diagnostic trace
-  // events (pool:recoveryProduce + recoveryReport/recoveryFailed) make
-  // silent recovery failures observable in traces.
+  // Recovery runs in its own scope — if prefill or decode fails (KV
+  // exhaustion), the scope tears down cleanly. The recoveryProduce/Return/
+  // Failed traces make silent recovery failures observable.
   let reported = false;
   let output = '';
   let producedTokens = 0;
-  let failureReason: string | null = null;
   try {
     yield* scoped(function*() {
       yield* call(() => store.prefill([[agent.branch, tokens]]));
@@ -278,46 +327,147 @@ function* recoverInline(
         yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: producedTokens });
       }
 
-      tw.write({
-        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-        type: 'pool:recoveryProduce', agentId: agent.id,
-        tokenCount: producedTokens, outputLength: output.length,
-      });
-
-      // Parse + return (recovery path — emits agent:recovered, NOT agent:return)
-      try {
-        const parsed = JSON.parse(output) as { result: string };
-        if (parsed?.result) {
-          agent.setResult(stripDanglingToolCall(parsed.result), 'recovery');
-          yield* events.send({ type: 'agent:recovered', agentId: agent.id, result: agent.result! });
-          reported = true;
-          tw.write({
-            traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-            type: 'pool:recoveryReturn', agentId: agent.id,
-            resultLength: parsed.result.length,
-          });
-        } else {
-          failureReason = 'no_result_field';
-        }
-      } catch (e) {
-        failureReason = `parse_error: ${(e as Error).message ?? 'unknown'}`;
-      }
+      reported = yield* finishRecovery(agent, output, producedTokens, events, tw, parentTraceId);
     });
   } catch (e) {
-    failureReason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
-  }
-
-  if (!reported) {
+    // Scope teardown (KV exhaustion during prefill/decode) — finishRecovery
+    // never ran, so emit the failure trace here.
     tw.write({
       traceId: tw.nextId(), parentTraceId, ts: performance.now(),
       type: 'pool:recoveryFailed', agentId: agent.id,
-      reason: failureReason ?? 'unknown',
+      reason: `scope_error: ${(e as Error).message ?? 'unknown'}`,
       outputExcerpt: output.slice(0, 200),
     });
   }
 
   // Always prune after scope exits (success or failure)
   if (!agent.branch.disposed) agent.branch.pruneSync();
+
+  // Emit tick so TUI updates pressure percentage after prune
+  const postPressure = new ContextPressure(ctx);
+  yield* events.send({ type: 'agent:tick', cellsUsed: postPressure.cellsUsed, nCtx: postPressure.nCtx });
+
+  return reported;
+}
+
+/**
+ * Parallel recovery — extract reports from the whole idle/unreported cohort in
+ * one batched pass: a single `store.prefill` of every recovery prompt, then a
+ * batched decode (one `store.commit` per step across all live branches —
+ * MOAT #1). Wall-clock ≈ the longest single report rather than Σ of all N,
+ * which is what makes a multi-agent wind-down feel instant.
+ *
+ * Up-front pressure gate: if KV can't fit the whole cohort's combined prefill
+ * at once, falls back to `staggered` (per-agent `recoverInline`, pruning
+ * between) — the headroom tradeoff staggering was introduced for (824e63a).
+ *
+ * Like `recoverInline`, this MUST run entirely on the loop fiber and finish
+ * before any agent transitions to 'idle' / the orchestrator wakes — a
+ * concurrent native call on the shared llama_context would SEGV.
+ *
+ * Returns the number of agents that reported.
+ */
+function* recoverParallel(
+  cohort: Agent[],
+  policy: AgentPolicy,
+  ctx: SessionContext,
+  store: BranchStore,
+  tw: TraceWriter,
+  parentTraceId: number,
+  events: EventSender,
+  pressureOpts: PressureThresholds,
+): Operation<number> {
+  // Build the cohort: idle, unreported, undisposed agents the policy opts to
+  // recover. A skip prunes that branch now — freeing KV for the batch.
+  const prefillPairs: [Branch, number[]][] = [];
+  const recovering: Agent[] = [];
+  for (const agent of cohort) {
+    if (agent.status !== 'idle' || agent.result || agent.branch.disposed) continue;
+    const recovery = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
+    if (!recovery || recovery.type === 'skip') {
+      if (!agent.branch.disposed) agent.branch.pruneSync();
+      continue;
+    }
+    prefillPairs.push([agent.branch, recoveryPromptTokens(ctx, recovery)]);
+    recovering.push(agent);
+  }
+  if (recovering.length === 0) return 0;
+
+  // Up-front pressure gate. Raw `remaining` (not headroom) — the hardLimit
+  // reserve exists precisely for recovery. If the whole cohort's prefill won't
+  // fit at once, recover staggered so each report gets the full freed headroom.
+  const pressure = new ContextPressure(ctx, pressureOpts);
+  const totalPrefill = prefillPairs.reduce((sum, [, t]) => sum + t.length, 0);
+  if (pressure.remaining < totalPrefill) {
+    let reported = 0;
+    for (const agent of recovering) {
+      if (yield* recoverInline(agent, policy, ctx, store, tw, parentTraceId, events, pressureOpts)) {
+        reported++;
+      }
+    }
+    return reported;
+  }
+
+  const reportGrammar = yield* recoveryReportGrammar(ctx);
+  const output = new Map<Agent, string>();
+  const produced = new Map<Agent, number>();
+  const done = new Set<Agent>();
+  for (const agent of recovering) { output.set(agent, ''); produced.set(agent, 0); }
+
+  let reported = 0;
+  try {
+    yield* scoped(function*() {
+      // One batched prefill of every extraction prompt, then per-branch grammar.
+      yield* call(() => store.prefill(prefillPairs));
+      for (let i = 0; i < recovering.length; i++) {
+        const agent = recovering[i];
+        agent.branch.setGrammar(reportGrammar);
+        tw.write({
+          traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+          type: 'branch:prefill', branchHandle: agent.id,
+          tokenCount: prefillPairs[i][1].length, role: 'recovery',
+        });
+      }
+
+      // Batched produce/commit — one native commit per step across all live
+      // branches. A stop drops that agent from the batch and extracts its report.
+      while (done.size < recovering.length) {
+        const entries: [Branch, number][] = [];
+        for (const agent of recovering) {
+          if (done.has(agent)) continue;
+          const { token, text, isStop } = agent.branch.produceSync();
+          if (isStop) {
+            done.add(agent);
+            if (yield* finishRecovery(agent, output.get(agent)!, produced.get(agent)!, events, tw, parentTraceId)) {
+              reported++;
+            }
+            continue;
+          }
+          output.set(agent, output.get(agent)! + text);
+          produced.set(agent, produced.get(agent)! + 1);
+          entries.push([agent.branch, token]);
+          yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: produced.get(agent)! });
+        }
+        if (entries.length === 0) break;
+        yield* call(() => store.commit(entries));
+      }
+    });
+  } catch (e) {
+    // KV exhaustion mid-batch — mark every agent that hadn't finished failed.
+    const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
+    for (const agent of recovering) {
+      if (done.has(agent)) continue;
+      tw.write({
+        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+        type: 'pool:recoveryFailed', agentId: agent.id,
+        reason, outputExcerpt: output.get(agent)!.slice(0, 200),
+      });
+    }
+  }
+
+  for (const agent of recovering) {
+    if (!agent.branch.disposed) agent.branch.pruneSync();
+  }
 
   // Emit tick so TUI updates pressure percentage after prune
   const postPressure = new ContextPressure(ctx);
@@ -1474,10 +1624,17 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         if (!recoveryAttempted) {
           recoveryAttempted = true;
           // Recover any idle agents that weren't handled by inline recovery
-          // (e.g., killed by max_turns, time budget, or free_text_stop)
-          for (const a of agents) {
-            if (a.status === 'idle' && !a.result && !a.branch.disposed) {
-              yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+          // (e.g., killed by max_turns, time budget, or free_text_stop).
+          // `parallel` batches the whole cohort (one prefill + batched decode —
+          // wall-clock ≈ the slowest single report); `staggered` (default)
+          // recovers them one at a time for maximum per-report headroom.
+          if (policy.recoveryShape === 'parallel') {
+            yield* recoverParallel(agents, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+          } else {
+            for (const a of agents) {
+              if (a.status === 'idle' && !a.result && !a.branch.disposed) {
+                yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
+              }
             }
           }
         }

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -510,7 +510,12 @@ function* recoverParallel(
 
   // Render + tokenize every recovery prompt ONCE at the fixed budget `b` — the
   // prompt is identical across groups since `b` is fixed, so a boundary agent is
-  // never re-rendered/re-tokenized. A skip here prunes that branch now.
+  // never re-rendered/re-tokenized. This pass re-runs onRecovery only to bind `b`
+  // into the prompt; its skip is budget-independent (decided before the budget
+  // calc, on agent state unchanged since the eligibility probe), so it drops no one
+  // the probe kept and `b` stays the true fair share over `queue.length`. (A custom
+  // policy that DID skip here would only under-budget — shorter reports — never
+  // over-budget/exhaust.)
   const entries: { agent: Agent; tokens: number[] }[] = [];
   for (const agent of queue) {
     const recovery = policy.onRecovery!(agent, new ContextPressure(ctx, pressureOpts), b);

--- a/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+import type { PoolRun } from '../harness';
+import { I1_nativeStoreSingleFiber, I29_recoveryDiagnostic } from '../predicates';
+
+const N = 3;
+
+/**
+ * Every agent drops to idle WITHOUT a result on its first stop
+ * (`free_text_stop`, not `free_text_return`), so all N land in the
+ * termination-sweep recovery cohort. `onRecovery` always extracts (no
+ * min-token/min-tool gates), and `recoveryShape` selects the reap path under
+ * test. The recovery prompt is a parameter so the pressure-downgrade test can
+ * make Σ(prefill) dwarf the available headroom.
+ */
+function idleNoResultPolicy(
+  shape: 'staggered' | 'parallel',
+  recoveryPrompt: { system: string; user: string },
+): AgentPolicy {
+  return {
+    onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+    onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+    onRecovery: () => ({ type: 'extract', prompt: recoveryPrompt }),
+    shouldExit: () => false,
+    recoveryShape: shape,
+  };
+}
+
+const recoveryPrefills = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
+const prefillCount = (r: PoolRun) =>
+  r.nativeCalls.filter(c => c.op === 'prefill').length;
+
+// Each agent: main turn [1, STOP], then recovery decode [2, STOP]. The mock
+// emits non-JSON text from token 2 → recovery lands on `pool:recoveryFailed`
+// (we assert the batching *shape*, not parse success — the mock can't produce
+// grammar-valid JSON).
+const idleScripts = () =>
+  Array.from({ length: N }, () => ({ tokens: [1, STOP, 2, STOP], content: 'prose findings' }));
+
+describe('scenario: parallel recovery (recoveryShape)', () => {
+  it('parallel batches the whole idle-no-result cohort into ONE prefill (vs N staggered)', async () => {
+    // Small recovery prompt + generous nCtx → the up-front pressure gate passes
+    // → the batched path runs. Same scripts/policy except the reap shape, so
+    // root + spawn prefills are identical between the two runs.
+    const prompt = { system: 's', user: 'u' };
+    const par = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
+    const stag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+
+    // Both shapes recover every agent (one recovery prefill trace each).
+    expect(recoveryPrefills(par).length).toBe(N);
+    expect(recoveryPrefills(stag).length).toBe(N);
+
+    // THE batching proof: the only difference between the runs is the reap
+    // shape, so parallel collapsing N recovery prefills into one batched
+    // `store.prefill` shows up as exactly (N-1) fewer native prefill calls.
+    expect(prefillCount(par)).toBe(prefillCount(stag) - (N - 1));
+
+    // The batched decode must hold the single-fiber invariant (the SEGV guard)…
+    expect(I1_nativeStoreSingleFiber(par).ok).toBe(true);
+    // …and every recovering agent still gets exactly one diagnostic (no loss).
+    expect(I29_recoveryDiagnostic(par).ok).toBe(true);
+  });
+
+  it('parallel downgrades to staggered when the cohort prefill exceeds headroom', async () => {
+    // Huge recovery prompt → Σ(prefill) far exceeds `remaining`, so the
+    // up-front pressure gate forces the per-agent staggered fallback even
+    // though recoveryShape is 'parallel'. Nothing is lost.
+    const big = 'x'.repeat(4000); // ~1000 tokens each; ~6000 across the cohort
+    const prompt = { system: big, user: big };
+    const parPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
+    const stagPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+
+    // Downgrade ⇒ parallel ran the staggered path ⇒ identical native prefill
+    // count to the staggered baseline (no N→1 collapse).
+    expect(prefillCount(parPressure)).toBe(prefillCount(stagPressure));
+
+    // Every agent still recovered — the downgrade loses no reports.
+    expect(recoveryPrefills(parPressure).length).toBe(N);
+    expect(I29_recoveryDiagnostic(parPressure).ok).toBe(true);
+  });
+});

--- a/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
@@ -11,8 +11,8 @@ const N = 3;
  * (`free_text_stop`, not `free_text_return`), so all N land in the
  * termination-sweep recovery cohort. `onRecovery` always extracts (no
  * min-token/min-tool gates), and `recoveryShape` selects the reap path under
- * test. The recovery prompt is a parameter so the pressure-downgrade test can
- * make Σ(prefill) dwarf the available headroom.
+ * test. The recovery prompt is a parameter so the pressure tests can make
+ * Σ(prefill) dwarf the available headroom.
  */
 function idleNoResultPolicy(
   shape: 'staggered' | 'parallel',
@@ -27,6 +27,28 @@ function idleNoResultPolicy(
   };
 }
 
+/**
+ * A `'parallel'` policy that records the per-report budget the fold hands each
+ * agent — the fold's recovery pass calls `onRecovery(agent, pressure, b)` WITH a
+ * budget, while the eligibility probe calls it WITHOUT one, so recording only the
+ * defined-`budgetTokens` calls captures the fold's actual per-report budgets.
+ * Optionally pins a fixed `reportBudget` (the low-effort path) instead of the
+ * headroom-derived default.
+ */
+function recordingParallelPolicy(sink: number[], reportBudget?: number): AgentPolicy {
+  return {
+    onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+    onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+    onRecovery: (_a, _pressure, budgetTokens) => {
+      if (budgetTokens !== undefined) sink.push(budgetTokens);
+      return { type: 'extract', prompt: { system: 's', user: 'u' } };
+    },
+    shouldExit: () => false,
+    recoveryShape: 'parallel',
+    ...(reportBudget !== undefined ? { reportBudget } : {}),
+  };
+}
+
 const recoveryPrefills = (r: PoolRun) =>
   r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
 const prefillCount = (r: PoolRun) =>
@@ -34,16 +56,33 @@ const prefillCount = (r: PoolRun) =>
 
 // Each agent: main turn [1, STOP], then recovery decode [2, STOP]. The mock
 // emits non-JSON text from token 2 → recovery lands on `pool:recoveryFailed`
-// (we assert the batching *shape*, not parse success — the mock can't produce
-// grammar-valid JSON).
-const idleScripts = () =>
-  Array.from({ length: N }, () => ({ tokens: [1, STOP, 2, STOP], content: 'prose findings' }));
+// (we assert the batching *shape* + budget, not parse success — the mock can't
+// produce grammar-valid JSON, and ignores the maxLength grammar entirely).
+const idleScriptsN = (n: number) =>
+  Array.from({ length: n }, () => ({ tokens: [1, STOP, 2, STOP], content: 'prose findings' }));
+const idleScripts = () => idleScriptsN(N);
 
-describe('scenario: parallel recovery (recoveryShape)', () => {
-  it('parallel batches the whole idle-no-result cohort into ONE prefill (vs N staggered)', async () => {
-    // Small recovery prompt + generous nCtx → the up-front pressure gate passes
-    // → the batched path runs. Same scripts/policy except the reap shape, so
-    // root + spawn prefills are identical between the two runs.
+// Group count of a parallel fold run, derived from the prefill delta vs a
+// staggered baseline: staggered does one recovery prefill per agent (M), the fold
+// does one per group (G), and root+spawn prefills (S) are identical between runs —
+// so prefillCount(par) − prefillCount(stag) = (S+G) − (S+M) = G − M.
+const groupCount = (par: PoolRun, stag: PoolRun, m: number) =>
+  prefillCount(par) - prefillCount(stag) + m;
+
+/**
+ * Parallel recovery is a bounded FOLD: each step recovers the largest group of
+ * the cohort that fits in current KV at a fixed per-report budget `b`, prunes it
+ * (freeing KV), and recurses. `k` (group size) flexes 1..N with headroom — k=N
+ * (one batched pass) when KV is ample, k=1 (one report at a time) when it's tight,
+ * intermediate when moderate. The maxLength report cap itself is verified against
+ * the real model (the grammar probe — `result ::= "\"" char{0,N} "\"" space`);
+ * here the mock ignores the grammar, so we assert the fold's *packing* + *budget*.
+ */
+describe('scenario: parallel recovery (the fold)', () => {
+  it('packs the whole cohort into ONE batched pass when KV is ample (k=N)', async () => {
+    // Small recovery prompt + generous nCtx → all N reports fit at once, so the
+    // fold takes one group = one batched prefill. Same scripts/policy except the
+    // reap shape, so root + spawn prefills are identical between the two runs.
     const prompt = { system: 's', user: 'u' };
     const par = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
     const stag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
@@ -52,32 +91,95 @@ describe('scenario: parallel recovery (recoveryShape)', () => {
     expect(recoveryPrefills(par).length).toBe(N);
     expect(recoveryPrefills(stag).length).toBe(N);
 
-    // THE batching proof: the only difference between the runs is the reap
-    // shape, so parallel collapsing N recovery prefills into one batched
-    // `store.prefill` shows up as exactly (N-1) fewer native prefill calls.
+    // THE batching proof: the only difference between the runs is the reap shape,
+    // so the fold collapsing N recovery prefills into one batched `store.prefill`
+    // shows up as exactly (N-1) fewer native prefill calls.
     expect(prefillCount(par)).toBe(prefillCount(stag) - (N - 1));
 
-    // The batched decode must hold the single-fiber invariant (the SEGV guard)…
+    // The batched decode holds the single-fiber invariant (the SEGV guard)…
     expect(I1_nativeStoreSingleFiber(par).ok).toBe(true);
     // …and every recovering agent still gets exactly one diagnostic (no loss).
     expect(I29_recoveryDiagnostic(par).ok).toBe(true);
   });
 
-  it('parallel downgrades to staggered when the cohort prefill exceeds headroom', async () => {
-    // Huge recovery prompt → Σ(prefill) far exceeds `remaining`, so the
-    // up-front pressure gate forces the per-agent staggered fallback even
-    // though recoveryShape is 'parallel'. Nothing is lost.
-    const big = 'x'.repeat(4000); // ~1000 tokens each; ~6000 across the cohort
+  it('shrinks to k=1 under pressure — one report at a time, none lost', async () => {
+    // Huge recovery prompt → at most one (prompt + report) fits per step, so the
+    // fold groups into N singletons: same native-prefill count as staggered, but
+    // reached by the fold partitioning, not a binary gate. Prune-between frees KV
+    // for the next singleton; every report still lands.
+    const big = 'x'.repeat(4000); // ~1000 tokens each; ~3000 across the cohort
     const prompt = { system: big, user: big };
     const parPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
     const stagPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
 
-    // Downgrade ⇒ parallel ran the staggered path ⇒ identical native prefill
-    // count to the staggered baseline (no N→1 collapse).
+    // k=1 ⇒ the fold's per-step prefills match the staggered baseline (no N→1 collapse).
     expect(prefillCount(parPressure)).toBe(prefillCount(stagPressure));
 
-    // Every agent still recovered — the downgrade loses no reports.
+    // Every agent still recovered — the grouping loses no reports.
     expect(recoveryPrefills(parPressure).length).toBe(N);
     expect(I29_recoveryDiagnostic(parPressure).ok).toBe(true);
+  });
+
+  it('folds into intermediate groups (1 < k < N) under moderate pressure — the partition branch', async () => {
+    // Headroom-derived budget: fitting all M at once is impossible (the prompts add
+    // overhead beyond the M×b the budget reserves), but several fit — so the fold
+    // takes a partial first group, then recovers the rest after pruning replenishes
+    // KV. This exercises the `used + cost > budget` break — the packing branch that
+    // k=N and k=1 never reach.
+    const M = 4;
+    const prompt = { system: 's', user: 'u' };
+    const par = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScriptsN(M), policy: idleNoResultPolicy('parallel', prompt) });
+    const stag = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScriptsN(M), policy: idleNoResultPolicy('staggered', prompt) });
+
+    const groups = groupCount(par, stag, M);
+    expect(groups).toBeGreaterThan(1);   // not one all-at-once pass…
+    expect(groups).toBeLessThan(M);      // …and not M singletons either
+
+    // Every agent still recovered — partitioning loses nothing.
+    expect(recoveryPrefills(par).length).toBe(M);
+    expect(I29_recoveryDiagnostic(par).ok).toBe(true);
+  });
+
+  it('budgets each report at a SHARE of KV, never the whole pool (the pool-wide-budget fix)', async () => {
+    // The bug the fold fixes: the old batched recovery told every concurrent agent
+    // it owned the full remaining KV → N reports collectively exhausted it. The fold
+    // passes a per-report budget `b` (a fair share of headroom) via the onRecovery
+    // override. Record what the fold hands each report and assert it's a share, not
+    // the pool. nCtx 4096 keeps the share below the MAX_REPORT_BUDGET cap so we see
+    // the division, not the clamp.
+    const foldBudgets: number[] = [];
+    const nCtx = 4096;
+    const run = await runPool({ nCtx, cellsUsed: 0, scripts: idleScripts(), policy: recordingParallelPolicy(foldBudgets) });
+
+    // Every agent was budgeted exactly once during the fold.
+    expect(foldBudgets.length).toBe(N);
+    // Each report's budget is a SHARE — comfortably under half the pool even at
+    // N=3 (it shrinks further as the cohort grows), and strictly positive. This is
+    // the structural fix: N concurrent reports can't collectively exhaust KV.
+    for (const b of foldBudgets) {
+      expect(b).toBeGreaterThan(0);
+      expect(b).toBeLessThan(nCtx / 2);
+    }
+    expect(I1_nativeStoreSingleFiber(run).ok).toBe(true);
+  });
+
+  it('honors an explicit reportBudget as a fixed cap, bypassing headroom division (the low-effort path)', async () => {
+    // With ample KV the headroom-derived budget would clamp to MAX_REPORT_BUDGET
+    // (2048); an explicit reportBudget must win verbatim so a `quick`-effort run gets
+    // the short reports it asked for regardless of how much KV happens to be free.
+    const foldBudgets: number[] = [];
+    await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: recordingParallelPolicy(foldBudgets, 256) });
+    expect(foldBudgets.length).toBe(N);
+    for (const b of foldBudgets) expect(b).toBe(256); // exact — not headroom-divided, not the 2048 cap
+  });
+
+  it('clamps the headroom-derived budget to MAX_REPORT_BUDGET (no report bloat under ample KV)', async () => {
+    // One agent + a large context → headroom/N would be many thousands of tokens;
+    // the fold caps it at MAX_REPORT_BUDGET (2048) so an early-Stop wind-down with
+    // plenty of KV still doesn't ask the model for an essay.
+    const foldBudgets: number[] = [];
+    await runPool({ nCtx: 16384, cellsUsed: 0, scripts: idleScriptsN(1), policy: recordingParallelPolicy(foldBudgets) });
+    expect(foldBudgets.length).toBe(1);
+    expect(foldBudgets[0]).toBe(2048); // MAX_REPORT_BUDGET ceiling
   });
 });

--- a/packages/agents/test/invariants/scenarios/recovery-prompt-budget-substitution.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-prompt-budget-substitution.scenario.test.ts
@@ -22,7 +22,7 @@ function mkPressure(remaining: number): ContextPressure {
     {
       _storeKvPressure: () => ({ nCtx: 16384, cellsUsed: 16384 - remaining, remaining }),
     } as any,
-    { softLimit: 1024, hardLimit: 128, absoluteFloor: 512 },
+    { softLimit: 1024, hardLimit: 128 },
   );
 }
 
@@ -75,5 +75,35 @@ describe('scenario: recovery prompt budget substitution', () => {
     const action = policy.onRecovery(agent, mkPressure(100));
     const extract = action as { type: 'extract'; prompt: { system: string; user: string } };
     expect(extract.prompt.system).toBe('Budget: 30');
+  });
+
+  it('renders the budgetTokens override (the fold path), not the pressure-derived budget', () => {
+    const policy = new DefaultAgentPolicy({
+      terminalToolName: 'report',
+      recovery: {
+        prompt: {
+          system: 'You have <%= it.budget %> words to report.',
+          user: 'Report.',
+        },
+        minTokens: 0,
+        minToolCalls: 0,
+      },
+    });
+
+    const agent: any = { tokenCount: 200, toolCallCount: 5 };
+
+    // The parallel fold passes its fixed per-report budget `b` as onRecovery's 3rd
+    // arg so the prompt advisory matches the grammar maxLength cap. b=200 →
+    // words = floor(200 * 0.7 / 10) * 10 = 140 (NOT the pressure-derived ~5130).
+    const overridden = policy.onRecovery(agent, mkPressure(8000), 200) as
+      { type: 'extract'; prompt: { system: string; user: string } };
+    expect(overridden.prompt.system).toBe('You have 140 words to report.');
+
+    // At the SAME pressure the pressure-derived budget is far larger — proving the
+    // override took effect. Without it the model is told to write ~5000 words while
+    // the grammar caps it at ~140: exactly the over-generation the override fixes.
+    const pressureDerived = policy.onRecovery(agent, mkPressure(8000)) as
+      { type: 'extract'; prompt: { system: string } };
+    expect(pressureDerived.prompt.system).not.toBe(overridden.prompt.system);
   });
 });


### PR DESCRIPTION
## What

Reworks parallel recovery from a binary all-or-nothing gate into a **bounded fold**, and adds the per-report budget enforcement primitives. This is the framework half (step 1) of the run-Effort feature; graceful wind-down (step 2) and the consumer Effort presets follow.

### The fold
`recoverParallel` now recovers the idle-no-result cohort in **groups**: each step takes the largest group that fits in current KV at a fixed per-report budget `b`, recovers it (one batched `store.prefill` + a batched decode — MOAT #1), prunes it (replenishing KV), and recurses. Group size `k` flexes 1..N with headroom — `k=N` when ample, `k=1` under pressure, intermediate between. The partition is the decision; no mode flag.

### The pool-wide-budget fix
The old batched recovery told every concurrent agent it owned the whole remaining KV, so N reports could collectively exhaust it. The fold hands each report a **fair share `b`** (headroom-derived, clamped `[128, 2048]`; or a fixed `reportBudget` for the low-effort path), surfaced via a new `onRecovery(agent, pressure, budgetTokens?)` override and enforced as a grammar `maxLength` cap so the prompt advisory matches the hard limit (graceful truncation, not a guillotine).

- `recoveryReportGrammar(ctx, maxChars?)` — optional JSON-Schema `maxLength` cap
- `reportBudget` knob on `DefaultAgentPolicyOpts`
- `safePrune` guards the delegate-lineage child-prune edge (`childSafeSort` was speculative — dropped)
- `recoverInline` (staggered) and the `staggered` default are byte-for-byte unchanged

## Tests
Fold `k=N` / `k=1` / intermediate-`k`, `reportBudget` fixed-cap, MAX clamp, and override-renders-into-prompt. **457 unit tests green.** The `maxLength` cap mechanism itself is verified against the real model (grammar probe).

## Supersedes #21
This branch was cut from #21's branch; commit `f2e94c0` is #21's binary-gate `recoverParallel`, reworked here into the fold. The net diff (Files changed) is the final fold. Close #21 in favor of this.
