### PR TITLE
feat(agents): graceful wind-down (drain) for the agent pool

### DIFF
--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -1190,8 +1190,16 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       yield* spawn(function*() {
         const sub = yield* wd;
         yield* sub.next();
-        windingDown = true;
+        // Halt the orchestrator BEFORE flipping windingDown. The reap branch is
+        // gated on windingDown, and a reap's idle-transition fires the agent's
+        // statusSignal — which would resume the orchestrator's waitFor and let it
+        // spawn/extend the next task. Halting first guarantees it's dead before
+        // any reap can fire (the SEGV invariant: orchestrator halted before any
+        // idle-transition). halt() resolves only after teardown completes (its
+        // `finally` sets orchestratorDone); windingDown + toolWake are then set
+        // synchronously (no yield between), so the woken loop always sees both.
         yield* orchestratorTask.halt();
+        windingDown = true;
         toolWake.send();
       });
     }

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -1,9 +1,9 @@
 import { resource, call, ensure, createSignal, createChannel, spawn, scoped, each, sleep, action, race } from 'effection';
-import type { Operation, Subscription, Task } from 'effection';
+import type { Operation, Subscription, Task, Signal } from 'effection';
 import type { Branch } from '@lloyal-labs/sdk';
 import { CHAT_FORMAT_CONTENT_ONLY, CHAT_FORMAT_GENERIC, GrammarTriggerType, type ParsedToolCall, type SessionContext } from '@lloyal-labs/sdk';
 import type { BranchStore } from '@lloyal-labs/sdk';
-import { Ctx, Store, Trace, TraceParent, CallingAgent, SpineFmt, GrantStoreCtx } from './context';
+import { Ctx, Store, Trace, TraceParent, CallingAgent, SpineFmt, GrantStoreCtx, WindDown } from './context';
 import type { FormatConfig } from './Agent';
 import { buildToolResultDelta, buildTurnDelta } from '@lloyal-labs/sdk';
 import { traceScope } from './trace-scope';
@@ -795,6 +795,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     const poolT0 = performance.now();
     let poolParentTraceId: number | null = null;
     try { const p = yield* TraceParent.get(); if (p != null) poolParentTraceId = p; } catch { /* top level */ }
+    // Optional graceful wind-down signal: the consumer `.send()`s it (e.g. a
+    // "Wrap up" command) to drain the pool to a fast best-effort answer — stop
+    // spawning, reap active agents, let in-flight tools settle, then fold. Absent
+    // ⇒ no wind-down (today's behaviour). See the WindDown context.
+    let windDownSignal: Signal<void, void> | null = null;
+    try { windDownSignal = (yield* WindDown.get()) ?? null; } catch { /* no wind-down provided */ }
     const poolScope = traceScope(tw, poolParentTraceId, 'pool', { maxTurns, terminalToolName });
 
     // Whether the pool's tool registry contains tools besides the terminal tool.
@@ -1038,7 +1044,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     // (orchestratorDone && all agents idle/disposed).
     let orchestratorDone = false;
     let orchestratorError: unknown = null;
-    yield* spawn(function*() {
+    const orchestratorTask = yield* spawn(function*() {
       try {
         yield* orchestrate(poolContext);
       } catch (e) {
@@ -1170,6 +1176,24 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     function* awaitToolCompletion(): Operation<void> {
       const sub = yield* toolWake;
       yield* sub.next();
+    }
+
+    // ── Graceful wind-down (drain) ──────────────────────────────────────
+    // A pool-local flag the PRODUCE reap-branch + termination sweep read. The
+    // watcher flips it ONCE when the consumer's WindDown signal fires, halts the
+    // orchestrator (stop spawning — its `finally` sets orchestratorDone), and
+    // wakes any all-parked nap via toolWake. The reap is pool-internal (no policy
+    // surface); in-flight tools are NOT halted (they drain) — only `halt` aborts.
+    let windingDown = false;
+    if (windDownSignal) {
+      const wd = windDownSignal;
+      yield* spawn(function*() {
+        const sub = yield* wd;
+        yield* sub.next();
+        windingDown = true;
+        yield* orchestratorTask.halt();
+        toolWake.send();
+      });
     }
 
     /** Post-process one tool completion ON THE LOOP FIBER: tokenize the result,
@@ -1491,6 +1515,20 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       for (const a of agents) {
         if (a.status !== 'active') continue;
 
+        // Wind-down (drain): drop active agents to idle so the termination sweep
+        // folds the whole cohort fast. An agent mid-terminal-tool (emitting its
+        // voluntary report) is left to finish — same guard as shouldExit's terminal
+        // protection. NO inline recovery (defer to the fold) and NO tool abort.
+        // SEGV-safe: the orchestrator was halted before windingDown flipped, so no
+        // concurrent spawn/prefill races this idle-transition.
+        if (windingDown && !(terminalToolName && a.currentTool === terminalToolName)) {
+          tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
+            type: 'pool:agentDrop', agentId: a.id, reason: 'wind_down' });
+          yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
+          a.transition('idle');
+          continue;
+        }
+
         const policyExit = policy.shouldExit?.(a, pressure);
         if (policyExit ?? pressure.critical) {
           const exitReason = pressure.critical ? 'pressure_critical' as const
@@ -1703,7 +1741,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           // `parallel` batches the whole cohort (one prefill + batched decode —
           // wall-clock ≈ the slowest single report); `staggered` (default)
           // recovers them one at a time for maximum per-report headroom.
-          if (policy.recoveryShape === 'parallel') {
+          if (policy.recoveryShape === 'parallel' || windingDown) {
             yield* recoverParallel(agents, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
           } else {
             for (const a of agents) {

--- a/packages/agents/src/context.ts
+++ b/packages/agents/src/context.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'effection';
 import type { SessionContext } from '@lloyal-labs/sdk';
 import type { BranchStore, Branch } from '@lloyal-labs/sdk';
-import type { Channel } from 'effection';
+import type { Channel, Signal } from 'effection';
 import type { AgentEvent } from './types';
 import type { TraceWriter } from './trace-writer';
 import type { TraceId } from './trace-types';
@@ -162,3 +162,22 @@ export const AppConfigStoreCtx = createContext<AppConfigStore>('lloyal.appConfig
  * @category Contract
  */
 export const GrantStoreCtx = createContext<GrantStore>('lloyal.grantStore');
+
+/**
+ * Effection context holding an optional wind-down {@link Signal}.
+ *
+ * A consumer that wants graceful "wrap up now" provides a `createSignal<void, void>()`
+ * in the pool's run scope and `.send()`s it on its Stop/Wrap-up command. The pool
+ * reads it at boot (`yield* WindDown.get()`); on emission it stops spawning new
+ * agents, reaps active ones to recovery, and lets in-flight tool calls **drain**
+ * (complete + settle) before reaping — then the termination sweep runs each
+ * policy's `onRecovery`. Answer-agnostic: what recovery yields (a report, or
+ * `skip`) is the policy's call.
+ *
+ * This is NOT abort — aborting everything (including in-flight tools) is `halt()`'s
+ * job (kill the run scope). Absent context = no wind-down capability (the pool runs
+ * to natural completion).
+ *
+ * @category Agents
+ */
+export const WindDown = createContext<Signal<void, void>>('lloyal.windDown');

--- a/packages/agents/src/trace-types.ts
+++ b/packages/agents/src/trace-types.ts
@@ -128,7 +128,8 @@ export type TraceEvent =
         | 'policy_exit'
         | 'maxTurns'
         | 'tool_error'
-        | 'stop_token';
+        | 'stop_token'
+        | 'wind_down';
     }
   | TraceEventBase & {
       type: 'pool:agentNudge';

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -101,6 +101,14 @@ export interface PoolSpec {
   policy: AgentPolicy;
   tools?: Map<string, Tool>;
   toolsJson?: string;
+  /** The pool's terminal tool name — read by `runPool`. */
+  terminalToolName?: string;
+  /**
+   * @deprecated Dead field — `runPool` reads `terminalToolName`, not this. Kept so
+   * the 6 existing call sites (authGuard-rejection, xss-cross-app-prose) still
+   * type-check; migrating them to `terminalToolName` changes their behaviour and is
+   * tracked in lloyal-ai/hdk#24.
+   */
   terminalTool?: string;
   maxTurns?: number;
   maxConcurrentTools?: number;

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -1,4 +1,4 @@
-import { run, createChannel, scoped } from 'effection';
+import { run, createChannel, scoped, createSignal } from 'effection';
 import type { Channel } from 'effection';
 import { MockSessionContext } from '../../../sdk/test/MockSessionContext';
 import { Branch } from '../../../sdk/src/Branch';
@@ -7,7 +7,7 @@ import type { ChatFormat, ParseChatOutputOptions, ParseChatOutputResult } from '
 import { useAgentPool } from '../../src/agent-pool';
 import type { Orchestrator } from '../../src/orchestrators';
 import { parallel, chain } from '../../src/orchestrators';
-import { Ctx, Store, Events, Trace } from '../../src/context';
+import { Ctx, Store, Events, Trace, WindDown } from '../../src/context';
 import type { AgentPolicy } from '../../src/AgentPolicy';
 import type { AgentPoolResult, AgentEvent } from '../../src/types';
 import type { TraceEvent } from '../../src/trace-types';
@@ -110,6 +110,13 @@ export interface PoolSpec {
   pruneOnReturn?: boolean;
   /** See `AgentPoolOptions.enableThinking`. @default false */
   enableThinking?: boolean;
+  /**
+   * If set, the harness provides a `WindDown` signal to the pool and `.send()`s
+   * it from the drain loop the FIRST time this predicate returns true for a
+   * channel event (`count` = 1-based event index). Drives the graceful-wind-down
+   * scenarios — e.g. fire on the first `agent:spawn` to reap the active cohort.
+   */
+  windDownAfter?: (ev: AgentEvent, count: number) => boolean;
 }
 
 /**
@@ -198,6 +205,8 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
     const events: Channel<AgentEvent, void> = createChannel();
     yield* Events.set(events as any);
     yield* Trace.set(trace);
+    const windDownSignal = createSignal<void, void>();
+    if (spec.windDownAfter) yield* WindDown.set(windDownSignal);
 
     const taskCount = spec.taskCount ?? spec.scripts.length;
     const taskSpecs = Array.from({ length: taskCount }, (_, i) => ({
@@ -222,8 +231,15 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
         enableThinking: spec.enableThinking,
       });
       let next = yield* sub.next();
+      let evCount = 0;
+      let windDownFired = false;
       while (!next.done) {
         channelEvents.push(next.value);
+        evCount++;
+        if (!windDownFired && spec.windDownAfter?.(next.value, evCount)) {
+          windDownFired = true;
+          windDownSignal.send();
+        }
         next = yield* sub.next();
       }
       return next.value;

--- a/packages/agents/test/invariants/scenarios/wind-down.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/wind-down.scenario.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP, chain } from '../harness';
+import type { PoolRun } from '../harness';
+import { I1_nativeStoreSingleFiber } from '../predicates';
+
+const N = 3;
+
+/**
+ * A policy whose agents never voluntarily exit within the test window — long
+ * token scripts keep them `active` so a `WindDown` signal reaps them mid-flight
+ * (drain). `recoveryShape` is a parameter so the tests can prove wind-down forces
+ * the fold REGARDLESS of the configured shape. `onRecovery` always extracts.
+ */
+function activePolicy(shape: 'staggered' | 'parallel'): AgentPolicy {
+  return {
+    onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+    onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+    onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+    shouldExit: () => false,
+    recoveryShape: shape,
+  };
+}
+
+// Long scripts: enough produce-tokens that agents are still `active` when the
+// wind-down trigger fires (on the first agent:spawn), then exhaust to STOP so a
+// NON-wind-down baseline still terminates (and staggers its recovery).
+const activeScriptsN = (n: number) =>
+  Array.from({ length: n }, () => ({ tokens: [...Array(8).fill(1), STOP], content: 'partial findings' }));
+
+const windDownDrops = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'pool:agentDrop' && (e as { reason?: string }).reason === 'wind_down');
+const recoveryPrefills = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
+const spawnEvents = (r: PoolRun) =>
+  r.channelEvents.filter(e => e.type === 'agent:spawn');
+const prefillCount = (r: PoolRun) => r.nativeCalls.filter(c => c.op === 'prefill').length;
+const onFirstSpawn = (ev: { type: string }) => ev.type === 'agent:spawn';
+
+describe('scenario: graceful wind-down (drain)', () => {
+  it('reaps the whole active cohort on WindDown and recovers via the fold', async () => {
+    const run = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: activeScriptsN(N),
+      policy: activePolicy('staggered'),
+      windDownAfter: onFirstSpawn,
+    });
+    // Every active agent was reaped SPECIFICALLY by wind-down (a distinct reason
+    // from pressure/time/maxTurns), and reaped in one tick (no stagger).
+    expect(windDownDrops(run).length).toBe(N);
+    // Every reaped agent was recovered (idle-no-result → onRecovery extract).
+    expect(recoveryPrefills(run).length).toBe(N);
+    // The batched recovery decode holds the single-fiber SEGV invariant.
+    expect(I1_nativeStoreSingleFiber(run).ok).toBe(true);
+    // The run terminated cleanly with a result.
+    expect(run.result).toBeDefined();
+  });
+
+  it('FORCES the fold even when recoveryShape is staggered (wind-down overrides the shape)', async () => {
+    const windStag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('staggered'), windDownAfter: onFirstSpawn });
+    const windPar  = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('parallel'),  windDownAfter: onFirstSpawn });
+    // Baseline: the SAME staggered policy WITHOUT wind-down — agents run to STOP,
+    // land idle-no-result, and the sweep recovers them one-at-a-time (staggered).
+    const baseStag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('staggered') });
+
+    // All three recover every agent…
+    expect(recoveryPrefills(windStag).length).toBe(N);
+    expect(recoveryPrefills(windPar).length).toBe(N);
+    expect(recoveryPrefills(baseStag).length).toBe(N);
+
+    // …but wind-down with the STAGGERED shape takes the SAME native-prefill path
+    // as the PARALLEL shape (it folded), and strictly FEWER prefills than the
+    // staggered baseline that actually staggered. ⇒ wind-down forced the fold.
+    expect(prefillCount(windStag)).toBe(prefillCount(windPar));
+    expect(prefillCount(windStag)).toBeLessThan(prefillCount(baseStag));
+  });
+
+  it('leaves an agent mid-terminal-tool to finish its voluntary report; reaps its free-text sibling', async () => {
+    // Agent 0 latches currentTool=report (partialToolCall) on its first observe(),
+    // so the reap-branch terminal guard protects it — it runs on to STOP and emits
+    // its voluntary report. Agent 1 is free-text → reaped by wind-down. Fire AFTER
+    // the first produce so the latch has happened. (Uses `terminalToolName`, the
+    // field the harness actually reads; the declared `PoolSpec.terminalTool` is a
+    // pre-existing dead field.)
+    const run = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      terminalToolName: 'report',
+      scripts: [
+        { tokens: [...Array(12).fill(1), STOP], partialToolCall: { name: 'report', arguments: '{"result":"done"}' }, toolCall: { name: 'report', arguments: '{"result":"done"}' } },
+        { tokens: [...Array(8).fill(1), STOP], content: 'partial findings' },
+      ],
+      policy: activePolicy('staggered'),
+      windDownAfter: ev => ev.type === 'agent:produce',
+    });
+    const dropped = new Set(windDownDrops(run).map(e => (e as { agentId: number }).agentId));
+    // Exactly one agent was wind-down-reaped — the free-text one, NOT the reporter.
+    expect(dropped.size).toBe(1);
+    expect(dropped.has(0)).toBe(false);
+    expect(run.result).toBeDefined();
+  });
+
+  it('stops spawning: a chain orchestrator does NOT spawn the next step after WindDown', async () => {
+    // chain() spawns task 0, waits for it, then spawns task 1… On wind-down the
+    // orchestrator is halted, so reaping task 0 must NOT cascade into task 1.
+    const run = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: activeScriptsN(3),
+      orchestrate: chain([0, 1, 2], (i) => ({ task: { content: `Task ${i}`, systemPrompt: 'You are an agent.', seed: i } })),
+      policy: activePolicy('staggered'),
+      windDownAfter: ev => ev.type === 'agent:produce',
+    });
+    // Only the first chain step ever spawned — the orchestrator was halted before
+    // the second could be issued.
+    expect(spawnEvents(run).length).toBe(1);
+    expect(windDownDrops(run).length).toBe(1);
+    expect(run.result).toBeDefined();
+  });
+
+  it('default-off: no WindDown provided ⇒ no wind-down reaps (today\'s termination)', async () => {
+    const run = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: activeScriptsN(N),
+      policy: activePolicy('staggered'),
+      // no windDownAfter ⇒ no WindDown context provided at all
+    });
+    expect(windDownDrops(run).length).toBe(0);
+    expect(run.result).toBeDefined();
+  });
+});


### PR DESCRIPTION
## What

Framework step 2 of the run-Effort feature: **graceful wind-down (drain)** for the agent pool. A consumer that wants a "Wrap up" command provides a `WindDown` signal in the pool's run scope and `.send()`s it. The pool then drains to a fast best-effort answer:

- **stop spawning** — halt the orchestrator fiber
- **reap active agents** — drop to idle (an agent mid-terminal-tool finishes its voluntary report)
- **let in-flight tools settle** — no abort (drain, not `halt`)
- **gather** — the termination sweep forces the merged recovery fold (#22)

## Design (source-verified)

**One new framework concept** — the `WindDown` context (sibling of `Store`/`Events`/`Trace`). The reap is **pool-internal**: no `AgentPolicy` surface, `shouldExit` untouched. Wind-down is a pool concern, not a per-agent policy decision. On signal, a watcher (mirroring the `toolWake` pattern) flips a pool-local `windingDown` flag, halts the orchestrator, and wakes the loop; the PRODUCE phase drops active agents to idle; the sweep folds.

Distinct from — and composing with — `halt`: `halt` tears the scope down from outside and aborts in-flight; wind-down lets the run conclude itself from inside, then unwinds normally. `halt` stays the abort/escalation path.

## Changes

- `context.ts` — `WindDown` context (optional; absent ⇒ today's behaviour)
- `agent-pool.ts` — signal watcher (`windingDown` + orchestrator halt + wake); PRODUCE reap branch (terminal guard mirrors `shouldExit`); sweep `|| windingDown` forces the fold
- `trace-types.ts` — `wind_down` agentDrop reason
- invariant harness — `windDownAfter` hook to fire the signal mid-run

## Tests

5 scenario tests: reap→fold, fold forced over `staggered`, mid-`report` terminal protection, chain stop-spawning, default-off. **462 unit tests green**; default-off is byte-for-byte today.

## Follow-up

Surfaced a pre-existing invariant-harness bug (filed separately): `PoolSpec.terminalTool` is dead — `runPool` reads `terminalToolName` — so `authGuard-rejection` and `xss-cross-app-prose` (6 cases) have been running with no terminal tool wired.