### PR TITLE
fix(agents): export WindDown from the package entry (#23 follow-up)

### DIFF
--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -8,6 +8,7 @@ export {
   AppRegistryCtx,
   AppConfigStoreCtx,
   GrantStoreCtx,
+  WindDown,
 } from './context';
 export { Tool, ToolRetryError } from './Tool';
 export { Agent } from './Agent';


### PR DESCRIPTION
## What

`#23` added the `WindDown` context to `context.ts` but did **not** re-export it from `index.ts`. The pool reads it via the relative `./context` import, but **consumers cannot `import { WindDown } from '@lloyal-labs/lloyal-agents'`** to provide the signal — so the graceful wind-down feature shipped but was not actually consumer-usable.

Add `WindDown` to the public package exports (one line).

Found while wiring the Artifact (`reasoning.run.desktop`) Wrap-up command against the local link.

## Tests
Additive export only. Build clean, 462 unit tests green.