### PR TITLE
feat(agents): recovery-as-turn — in-loop parallel recovery via the nu…

### DIFF
--- a/packages/agents/src/Agent.ts
+++ b/packages/agents/src/Agent.ts
@@ -143,6 +143,17 @@ export class Agent {
   private _currentTool: string | null = null;
   private _toolObserved = false;
   private _parsed: ParseChatOutputResult | null = null;
+  // True while the agent produces its forced recovery report (the in-loop
+  // `parallel` recovery path): PRODUCE routes its isStop to finishRecovery
+  // instead of onProduced, and the kill/reap guards skip it.
+  private _extracting = false;
+  // Per-report cap for the in-loop recovery report. `_recoveryBudget` is the token
+  // target the pool set (policy.reportBudget, else a headroom share across the live
+  // agents); the token-stop fires once the report's own tokens reach it.
+  // `_recoveryTokenBase` snapshots the cumulative `_tokenCount` at recovery entry so
+  // the cap counts ONLY the report's tokens (resetTurn clears rawOutput, not _tokenCount).
+  private _recoveryBudget = 0;
+  private _recoveryTokenBase = 0;
 
   /** The agent that called the tool which spawned this agent's pool (null for top-level) */
   readonly parent: Agent | null = null;
@@ -222,6 +233,19 @@ export class Agent {
   get traceBuffer(): TraceToken[] { return this._traceBuffer; }
   get currentTool(): string | null { return this._currentTool; }
   get parsed(): ParseChatOutputResult | null { return this._parsed; }
+  /** Whether this agent is mid forced-recovery-report (in-loop parallel path). */
+  get extracting(): boolean { return this._extracting; }
+  /** The fixed per-report token cap for this recovery (set at {@link markExtracting}). */
+  get recoveryBudget(): number { return this._recoveryBudget; }
+  /** Tokens produced SINCE recovery entry — what the token-stop backstop checks. */
+  get recoveryTokens(): number { return this._tokenCount - this._recoveryTokenBase; }
+  /** Mark the agent as producing its recovery report (idempotent, one-way). Records
+   *  the per-report budget `b` and snapshots the token base for the cap. */
+  markExtracting(budget: number): void {
+    this._extracting = true;
+    this._recoveryBudget = budget;
+    this._recoveryTokenBase = this._tokenCount;
+  }
 
   /** Accumulate generated token text into the current turn */
   accumulateToken(text: string): void {

--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -12,6 +12,7 @@ import { renderTemplate } from './prompt';
 export const RECOVERY_PREFILL_OVERHEAD = 150;
 export const BATCH_BUFFER = 512;
 
+
 /**
  * Convert a token budget to a conservative word count for the model-facing
  * prompt. Tokens are tokenizer-specific; words are universal and better
@@ -281,9 +282,10 @@ export interface AgentPolicy {
    * Optional — defaults to skip when absent.
    *
    * `budgetTokens` (optional) overrides the pressure-derived report budget —
-   * the parallel recovery fold passes the per-report budget `b` so the prompt's
-   * advisory word count matches the grammar `maxLength` cap. Absent → the budget
-   * is derived from `pressure.remaining` as usual (staggered / per-agent).
+   * the in-loop (parallel / wind-down) recovery passes the per-report budget `b`
+   * so the prompt's advisory word count matches the pool's token-stop. Absent →
+   * the budget is derived from `pressure.remaining` (the staggered / full-headroom
+   * per-agent path).
    */
   onRecovery?(agent: Agent, pressure: ContextPressure, budgetTokens?: number): RecoveryAction;
 
@@ -301,22 +303,23 @@ export interface AgentPolicy {
   onToolRetry?(agent: Agent, tool: string, error: ToolRetryError, attempt: number): ToolRetryAction;
 
   /**
-   * Recovery reap shape for the termination / wind-down sweep.
+   * Recovery reap shape.
    * `'staggered'` (default) — recover one agent at a time (`recoverInline`),
-   * pruning each before the next so every report gets the full freed headroom.
-   * `'parallel'` — recover the idle-no-result cohort as a bounded FOLD: each step
-   * takes the largest GROUP that fits in current KV at a fixed per-report budget
-   * (a fair share of headroom, or {@link reportBudget}), batches its prefill +
-   * decode (one native call per step), prunes it to replenish KV, and recurses —
-   * group size flexes 1..N with headroom (down to one-at-a-time under pressure),
-   * never switching modes. The per-report budget is enforced as a grammar
-   * `maxLength` cap. Absent → `'staggered'`.
+   * pruning each before the next so every report gets the full freed headroom
+   * (uncapped, lossless; the high-effort path).
+   * `'parallel'` — recover killed-without-result agents IN-LOOP: the recovery turn
+   * is bin-packed into the tick loop alongside live siblings, capped at a per-report
+   * budget `b` (the prompt's word advisory + the pool's token-stop), and SETTLE
+   * admits only as many reports as fit `(prompt + b)` in current KV — the rest wave
+   * to the next tick once the admitted ones prune. Wind-down always uses this shape
+   * regardless of the setting. Absent → `'staggered'`.
    */
   recoveryShape?: 'staggered' | 'parallel';
 
-  /** Per-report token budget for the parallel recovery fold — advisory in the
-   *  recovery prompt + the grammar `maxLength` cap. Absent → uncapped
-   *  (staggered) / headroom-derived (fold). */
+  /** Explicit per-report token budget for in-loop (parallel / wind-down) recovery —
+   *  the prompt's word advisory + the pool's token-stop. Absent → adaptive: a fair
+   *  share of current headroom across the live agents, clamped to a [min, max].
+   *  Unused by `staggered` (full-length reports). */
   readonly reportBudget?: number;
 }
 
@@ -394,17 +397,24 @@ export interface DefaultAgentPolicyOpts {
   };
   /** Recovery reap shape — see {@link AgentPolicy.recoveryShape}. @default 'staggered' */
   recoveryShape?: 'staggered' | 'parallel';
-  /** Per-report token budget for the PARALLEL recovery fold — rendered into the
-   *  recovery prompt (advisory "within N words") AND used as the grammar
-   *  `maxLength` cap (hard). Unused by `staggered` (full-length reports). The
-   *  consumer sets it per Effort level. @default unset (fold falls back to
-   *  headroom-derived) */
+  /** Explicit per-report token budget for in-loop (PARALLEL / wind-down) recovery —
+   *  rendered into the recovery prompt (advisory "within N words") AND enforced by
+   *  the pool's token-stop (hard). Unused by `staggered` (full-length reports). The
+   *  consumer sets it per Effort level. @default unset → adaptive (a fair share of
+   *  current headroom across the live agents, clamped). */
   reportBudget?: number;
   /** Budget thresholds. softLimit = nudge, hardLimit = kill.
    *  Same naming pattern for both resource types.
    *  time budget is global across nesting levels (ms since policy creation). */
   budget?: {
-    /** KV context budget (tokens remaining). */
+    /** KV context budget (tokens remaining). softLimit = nudge floor, hardLimit = kill floor.
+     *  COUPLING (non-obvious): `softLimit` also sizes RECOVERY. The forced-report budget
+     *  `b` is an adaptive share of `headroom = remaining − softLimit` across the live
+     *  agents (see {@link AgentPolicy.onRecovery} + agent-pool `handleRecover`). So
+     *  RAISING `softLimit` SHORTENS recovery reports, and a `softLimit` large enough that
+     *  `headroom < aliveCount·(prompt + MIN_REPORT_BUDGET)` forces the reaped cohort onto
+     *  the serial `recoverInline` fallback instead of one-tick parallel recovery. Tune it
+     *  for the downstream reserve you need, aware it trades against recovery report length. */
     context?: { softLimit?: number; hardLimit?: number };
     /** Wall-time budget (ms since policy creation). */
     time?: { softLimit?: number; hardLimit?: number };
@@ -478,8 +488,8 @@ export class DefaultAgentPolicy implements AgentPolicy {
     };
   }
 
-  /** Recovery reap shape. The pool reads this at the termination / wind-down
-   *  sweep to pick `recoverParallel` (parallel) vs per-agent `recoverInline`. */
+  /** Recovery reap shape. The pool reads this to pick in-loop bin-packed recovery
+   *  (`parallel`) vs the blocking per-agent `recoverInline` (`staggered`). */
   get recoveryShape(): 'staggered' | 'parallel' {
     return this._recoveryShape;
   }
@@ -489,8 +499,9 @@ export class DefaultAgentPolicy implements AgentPolicy {
     this._recoveryShape = shape;
   }
 
-  /** Per-report token budget for the parallel recovery fold (undefined = uncapped /
-   *  headroom-derived). The fold renders it into the prompt + caps the grammar. */
+  /** Explicit per-report token budget for in-loop recovery (undefined = adaptive,
+   *  a headroom share across live agents). Rendered into the prompt + enforced by
+   *  the pool's token-stop. */
   get reportBudget(): number | undefined {
     return this._reportBudget ?? undefined;
   }
@@ -674,8 +685,9 @@ export class DefaultAgentPolicy implements AgentPolicy {
     // (not tokens) and under-advertised so the model has slack — tokenizers
     // vary across models but words are universal. Rendered into the prompt
     // as `it.budget` so authors can reference it via `<%= it.budget %>`.
-    // The parallel fold overrides this with its fixed per-report budget `b` so
-    // the advisory matches the grammar `maxLength` cap (graceful, not a guillotine).
+    // In-loop recovery overrides this with its per-report budget `b` (a headroom
+    // share across live agents) so the advisory matches the pool's token-stop
+    // (graceful self-conclusion, not a guillotine).
     const budgetTokens = budgetTokensOverride
       ?? Math.max(50, pressure.remaining - RECOVERY_PREFILL_OVERHEAD - BATCH_BUFFER);
     const budget = tokenBudgetAsWords(budgetTokens);

--- a/packages/agents/src/AgentPolicy.ts
+++ b/packages/agents/src/AgentPolicy.ts
@@ -270,14 +270,17 @@ export interface AgentPolicy {
   resetTick?(): void;
 
   /**
-   * Post-loop: should we extract findings from this killed agent?
+   * Recovery: should we force a report from this reaped agent (no result)?
    *
-   * Called for each idle agent without a result after the tick loop ends.
-   * Return `extract` with a prompt to fork from the agent's branch and
-   * generate grammar-constrained findings. Return `skip` to prune.
-   *
-   * The pool owns the extraction grammar (`{ "result": "..." }` schema).
-   * Custom prompts must produce output matching this shape.
+   * Called when an agent is reaped without a voluntary result. Return
+   * `extract` with a recovery prompt to inject as an in-loop forced
+   * terminal-tool turn; return `skip` to prune. The pool forces the native
+   * terminal-tool grammar (built from the designated terminal tool's schema
+   * via `formatChat`, `toolChoice:'auto'`) and extracts the result via
+   * `parseChatOutput` → `toolCalls` → the terminal tool's argument — generic
+   * over the designated terminal (`report`/`submit`/…), not a hand-emitted
+   * `{result}` JSON. The prompt is your recovery instruction; the grammar
+   * (not the prompt) shapes the output.
    *
    * Optional — defaults to skip when absent.
    *
@@ -408,13 +411,13 @@ export interface DefaultAgentPolicyOpts {
    *  time budget is global across nesting levels (ms since policy creation). */
   budget?: {
     /** KV context budget (tokens remaining). softLimit = nudge floor, hardLimit = kill floor.
-     *  COUPLING (non-obvious): `softLimit` also sizes RECOVERY. The forced-report budget
-     *  `b` is an adaptive share of `headroom = remaining − softLimit` across the live
-     *  agents (see {@link AgentPolicy.onRecovery} + agent-pool `handleRecover`). So
-     *  RAISING `softLimit` SHORTENS recovery reports, and a `softLimit` large enough that
-     *  `headroom < aliveCount·(prompt + MIN_REPORT_BUDGET)` forces the reaped cohort onto
-     *  the serial `recoverInline` fallback instead of one-tick parallel recovery. Tune it
-     *  for the downstream reserve you need, aware it trades against recovery report length. */
+     *  COUPLING (non-obvious): RECOVERY budgets from the `hardLimit` RESERVE, not `softLimit`.
+     *  The forced-report budget `b` and the SETTLE admission for an extracting agent draw from
+     *  `remaining − hardLimit` (see {@link AgentPolicy.onRecovery} + agent-pool `handleRecover`),
+     *  so recovery may decode the soft reserve down to `hardLimit`. `softLimit` is the model
+     *  NUDGE floor, reserved for downstream work (synth) — raising it nudges EARLIER but does
+     *  NOT shorten recovery reports. (`softLimit` is advisory: it gates the wrap-up nudge +
+     *  tool-result deferral, never a kill; `hardLimit` is the only mechanical floor.) */
     context?: { softLimit?: number; hardLimit?: number };
     /** Wall-time budget (ms since policy creation). */
     time?: { softLimit?: number; hardLimit?: number };

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -302,7 +302,12 @@ function* finishRecovery(
     generationPrompt: agent.fmt.generationPrompt,
     parser: agent.fmt.parser,
   });
-  const call = parsed.toolCalls.find(c => c.name === terminalToolName) ?? parsed.toolCalls[0];
+  // When a terminal tool is designated, the report MUST be that tool's call — never fall
+  // back to a non-terminal call (that would set the result from the wrong args). With no
+  // terminal tool, take whatever the model produced (matches `_handleTerminalTool`).
+  const call = terminalToolName
+    ? parsed.toolCalls.find(c => c.name === terminalToolName)
+    : parsed.toolCalls[0];
   if (call) {
     const result = extractTerminalResult(call.arguments);
     if (result) {
@@ -766,8 +771,10 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
 
     // The eager terminal-tool grammar that forces a recovered agent to emit a
     // schema-valid terminal call (whatever the harness designated as terminal).
-    // Computed once from the terminal tool's schema; `null` when there is no
-    // terminal tool (recovery has no structured result to force, so it no-ops).
+    // Computed once from the terminal tool's schema; `null` when there is no terminal
+    // tool — recovery still runs, but with no grammar to force a schema-valid call the
+    // agent decodes unconstrained and `finishRecovery` extracts via `parseChatOutput`
+    // (or emits `agent:failed` when no call is parseable). It does NOT no-op.
     const terminalTool = terminalToolName ? tools.get(terminalToolName) : undefined;
     const terminalGrammar = terminalTool ? buildTerminalGrammar(ctx, terminalTool) : null;
     const policy = opts.policy ?? new DefaultAgentPolicy();
@@ -1549,7 +1556,10 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
             // then re-decodes into the already-exhausted KV and fails. Salvage the
             // partial terminal call it has already emitted (parseChatOutput handles the
             // truncation); no further decode is needed.
-            yield* finishRecovery(a, a.rawOutput, a.tokenCount, poolChannel, tw, poolScope.traceId, ctx, terminalToolName);
+            // producedTokens = the report turn's tokens, not cumulative: `resetTurn`
+            // clears `rawOutput` (not `tokenCount`), so `rawOutput` is just the in-flight
+            // report — report-scoped + consistent with the in-loop path's `recoveryTokens`.
+            yield* finishRecovery(a, a.rawOutput, ctx.tokenizeSync(a.rawOutput, false).length, poolChannel, tw, poolScope.traceId, ctx, terminalToolName);
             a.transition('idle');
             safePrune(a.branch);
           } else if (policy.recoveryShape === 'parallel') {

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -1679,7 +1679,24 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
 
       // -- Phase 2: COMMIT -- batch-decode produced tokens
       if (entries.length > 0) {
-        yield* call(() => store.commit(entries));
+        try {
+          yield* call(() => store.commit(entries));
+        } catch (e) {
+          // Decode OOM (concurrent in-loop reports exhausted KV) tears down the pool.
+          // This batch is where admitted extractors decode their reports; unlike the
+          // blocking `recoverInline` path (its own scope_error catch), an in-loop
+          // extractor here would be orphaned with NO terminal event → eternal "writing
+          // report" spinner. Announce each in-flight extractor failed BEFORE propagating
+          // (the KV is exhausted — the run can't continue, so rethrow after).
+          const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
+          for (const a of agents) {
+            if (!a.extracting || a.status !== 'active') continue;
+            tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
+              type: 'pool:recoveryFailed', agentId: a.id, reason, outputExcerpt: a.rawOutput.slice(0, 200) });
+            yield* poolChannel.send({ type: 'agent:failed', agentId: a.id, reason });
+          }
+          throw e;
+        }
         steps++;
         const commitPressure = new ContextPressure(ctx, pressureOpts);
         yield* poolChannel.send({ type: 'agent:tick', cellsUsed: commitPressure.cellsUsed, nCtx: commitPressure.nCtx });
@@ -1759,7 +1776,11 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
             traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
             type: 'pool:agentDrop', agentId: a.id, reason,
           });
-          yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
+          // `agent:done` is one-shot. An already-`extracting` agent got here via the
+          // critical-kill path, which ALREADY emitted `agent:done` at the kill; its
+          // recovery turn deferred and re-surfaced at the stall-break. Re-announcing it
+          // done would double-emit (violating the invariant `agent-pool.test.ts` asserts).
+          if (!a.extracting) yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
           if (policy.recoveryShape === 'parallel' && !a.extracting) {
             // In-loop (first attempt): queue the recovery turn for next tick's
             // SETTLE (alongside the surviving nudges). Agent is awaiting_tool → no

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -883,6 +883,13 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     // watcher fiber, so it can't race the tick's native store work.
     const pendingCancels: number[] = [];
 
+    // Agents that received a terminal agent:failed(user_cancel). Downstream phases must
+    // treat them as fully DISCARDED: the termination sweep must not force-recover a
+    // cancelled agent whose branch couldn't be pruned (non-leaf/recursed → safePrune
+    // no-op), and DRAIN must not emit tool events for a completion that lands after the
+    // cancel. Both consumption points check this set.
+    const cancelledIds = new Set<number>();
+
     // Pool-level branch cleanup — ensures orphan-branch cleanup even when
     // spawns are lazy and the orchestrator's spawn scope exits early.
     yield* ensure(() => {
@@ -1252,6 +1259,11 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     function* processCompletion(c: ToolCompletion): Operation<SettledTool | null> {
       const { agent, tc, callId, dispatchTraceId } = c;
 
+      // Discarded by a user cancel while this tool was in flight: drop the completion
+      // silently — no tool:result / agent:tool_result, no result set. The agent already
+      // got its terminal agent:failed(user_cancel); a late tool event would contradict it.
+      if (cancelledIds.has(agent.id)) return null;
+
       if (c.kind === 'error') {
         agent.transition('idle');
         agent.setResult(`Tool error: ${c.err.message}`, 'tool_error');
@@ -1568,6 +1580,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
             type: 'pool:agentDrop', agentId: id, reason: 'user_cancel' });
           yield* poolChannel.send({ type: 'agent:failed', agentId: id, reason: 'user_cancel' });
+          cancelledIds.add(id);
           a.transition('idle');
           safePrune(a.branch);
         }
@@ -1906,7 +1919,9 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           // is a no-op for them. One at a time → maximum per-report headroom
           // (the lossless path).
           for (const a of agents) {
-            if (a.status === 'idle' && !a.result && !a.branch.disposed) {
+            // A user-cancelled agent is DISCARDED — never force-recover it, even if its
+            // branch couldn't be pruned (non-leaf/recursed → safePrune no-op'd).
+            if (a.status === 'idle' && !a.result && !a.branch.disposed && !cancelledIds.has(a.id)) {
               yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts, terminalGrammar, terminalToolName);
             }
           }

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -378,6 +378,13 @@ function* recoverInline(
   // (reflected in the rendered prompt via `<%= it.budget %>`).
   const recovery = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
   if (!recovery || recovery.type === 'skip') {
+    // Skip = policy judged the agent too thin to force a report. `agent:done` already
+    // fired at the drop, so emit a terminal event here too — else the agent orphans (no
+    // report row ever streams, timer never freezes). Nothing to salvage; fail it cleanly.
+    const reason = 'recovery_skipped';
+    tw.write({ traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+      type: 'pool:recoveryFailed', agentId: agent.id, reason, outputExcerpt: agent.rawOutput.slice(0, 200) });
+    yield* events.send({ type: 'agent:failed', agentId: agent.id, reason });
     safePrune(agent.branch);
     return false;
   }
@@ -537,6 +544,7 @@ function isEmittingTerminal(agent: Agent, terminalToolName: string | undefined):
 function* handleRecover(
   a: Agent, policy: AgentPolicy, ctx: SessionContext,
   pressureOpts: PressureThresholds, aliveCount: number,
+  events: EventSender, tw: TraceWriter, parentTraceId: number,
 ): Operation<SettledTool | null> {
   // Per-report budget `b`: the prompt advisory (onRecovery's budget arg) and the
   // token-stop backstop share it. Size it so the WHOLE cohort's prefill+decode fits the
@@ -561,6 +569,15 @@ function* handleRecover(
     : Math.min(MAX_REPORT_BUDGET, Math.max(MIN_REPORT_BUDGET, fits));
   const recovery = policy.onRecovery?.(a, pressure, b);
   if (!recovery || recovery.type === 'skip') {
+    // Recovery skipped — the policy judged the agent too thin to force a report
+    // (e.g. `DefaultAgentPolicy` skips below its minTokens/minToolCalls floor). But
+    // `agent:done` ALREADY fired at the drop, so we MUST still emit a terminal event
+    // here — otherwise the consumer orphans the agent (eternal "recovering" state, no
+    // report row, timer never freezes). There's nothing to salvage; fail it cleanly.
+    const reason = 'recovery_skipped';
+    tw.write({ traceId: tw.nextId(), parentTraceId, ts: performance.now(),
+      type: 'pool:recoveryFailed', agentId: a.id, reason, outputExcerpt: a.rawOutput.slice(0, 200) });
+    yield* events.send({ type: 'agent:failed', agentId: a.id, reason });
     safePrune(a.branch);
     a.transition('idle');
     return null;
@@ -1532,7 +1549,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
             type: 'pool:agentDrop', agentId: a.id, reason: 'wind_down' });
           yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
-          const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+          const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount, poolChannel, tw, poolScope.traceId);
           if (settled) nudges.push(settled);
           continue;
         }
@@ -1565,7 +1582,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           } else if (policy.recoveryShape === 'parallel') {
             // In-loop: inject the recovery turn; SETTLE re-activates it (capped
             // report grammar) and the report decodes bin-packed with live agents.
-            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount, poolChannel, tw, poolScope.traceId);
             if (settled) nudges.push(settled);
           } else {
             // Staggered: blocking recoverInline, BEFORE the idle transition —
@@ -1624,7 +1641,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
                     reason: action.reason === 'max_turns' ? 'maxTurns' : 'pressure_softcut' });
                 }
                 yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
-                const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+                const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount, poolChannel, tw, poolScope.traceId);
                 if (settled) nudges.push(settled);
               } else {
                 yield* handleIdleDrop(a, action.reason, poolChannel, tw, poolScope.traceId);
@@ -1785,7 +1802,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
             // In-loop (first attempt): queue the recovery turn for next tick's
             // SETTLE (alongside the surviving nudges). Agent is awaiting_tool → no
             // transition.
-            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount, poolChannel, tw, poolScope.traceId);
             if (settled) resolved.push(settled);
           } else {
             // Staggered — OR a parallel agent ALREADY extracting whose recovery

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -565,7 +565,11 @@ function* handleRecover(
   if (a.status === 'active') a.transition('awaiting_tool');
   a.markExtracting(b);
   a.resetTurn();
-  return { agentId: a.id, prefillTokens, toolName: '', callId: '', args: '' };
+  // Synthetic but identifiable settle identifiers. A recovery turn isn't a real tool
+  // call, but blank toolName/callId would emit a blank `tool:settle_order` entry and a
+  // blank ToolHistoryEntry; label them so the trace + history are self-describing
+  // (callId is unique per agent → keeps any callId-keyed replay oracle deterministic).
+  return { agentId: a.id, prefillTokens, toolName: 'recovery', callId: `recovery:${a.id}`, args: '' };
 }
 
 /**

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -3,7 +3,7 @@ import type { Operation, Subscription, Task, Signal } from 'effection';
 import type { Branch } from '@lloyal-labs/sdk';
 import { CHAT_FORMAT_CONTENT_ONLY, CHAT_FORMAT_GENERIC, GrammarTriggerType, type ParsedToolCall, type SessionContext } from '@lloyal-labs/sdk';
 import type { BranchStore } from '@lloyal-labs/sdk';
-import { Ctx, Store, Trace, TraceParent, CallingAgent, SpineFmt, GrantStoreCtx, WindDown } from './context';
+import { Ctx, Store, Trace, TraceParent, CallingAgent, SpineFmt, GrantStoreCtx, WindDown, CancelAgent } from './context';
 import type { FormatConfig } from './Agent';
 import { buildToolResultDelta, buildTurnDelta, buildUserDelta } from '@lloyal-labs/sdk';
 import { traceScope } from './trace-scope';
@@ -772,6 +772,11 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     // ⇒ no wind-down (today's behaviour). See the WindDown context.
     let windDownSignal: Signal<void, void> | null = null;
     try { windDownSignal = (yield* WindDown.get()) ?? null; } catch { /* no wind-down provided */ }
+    // Optional per-agent cancel signal: the consumer `.send({agentId})`s it (e.g. a
+    // per-card ×) to discard ONE live agent — halt its in-flight tool, emit a terminal
+    // agent:failed (user_cancel), prune its branch to reclaim KV. Absent ⇒ no cancel.
+    let cancelSignal: Signal<{ agentId: number }, void> | null = null;
+    try { cancelSignal = (yield* CancelAgent.get()) ?? null; } catch { /* no cancel provided */ }
     const poolScope = traceScope(tw, poolParentTraceId, 'pool', { maxTurns, terminalToolName });
 
     // Whether the pool's tool registry contains tools besides the terminal tool.
@@ -871,6 +876,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       discarded: boolean;
     }
     const pendingExtends: PendingExtend[] = [];
+
+    // Pending cancels — agentIds enqueued by the CancelAgent watcher, drained on the
+    // loop fiber before PRODUCE (a stable point: spawns settled, no decode in flight).
+    // Single-fiber discipline: the halt + prune runs on the tick, never from the
+    // watcher fiber, so it can't race the tick's native store work.
+    const pendingCancels: number[] = [];
 
     // Pool-level branch cleanup — ensures orphan-branch cleanup even when
     // spawns are lazy and the orchestrator's spawn scope exits early.
@@ -1213,6 +1224,25 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       });
     }
 
+    // ── Targeted cancel (per-agent) ─────────────────────────────────────
+    // The consumer `.send({agentId})`s CancelAgent (e.g. a per-card ×). Each emission
+    // enqueues onto pendingCancels + wakes the loop; the tick drains it (below) →
+    // halt that agent's in-flight tool + emit a terminal agent:failed + prune. Fires
+    // repeatedly for individual agents, unlike WindDown (fire-once, whole cohort). The
+    // orchestrator is NOT halted — siblings keep running.
+    if (cancelSignal) {
+      const cs = cancelSignal;
+      yield* spawn(function*() {
+        const sub = yield* cs;
+        for (;;) {
+          const next = yield* sub.next();
+          if (next.done) break;
+          pendingCancels.push(next.value.agentId);
+          toolWake.send();
+        }
+      });
+    }
+
     /** Post-process one tool completion ON THE LOOP FIBER: tokenize the result,
      *  send events, write traces, and return a SettledTool to prefill — or null
      *  for a retry-park / error-kill. Shared by the inline path (called inline)
@@ -1520,6 +1550,28 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       // If all we had was pending spawns, and none of them activated (shouldn't happen
       // normally — SPAWN always transitions to active), nothing to produce. Loop back.
       if (agents.length === 0) continue;
+
+      // -- Targeted cancel (user_cancel): discard one agent, reclaim its KV ---------
+      // Drained here (loop fiber, before PRODUCE) so teardown lands at a stable point,
+      // never mid-decode/mid-settle. Cancel = DISCARD: halt the agent's in-flight tool
+      // (aborting the fetch; its `ensure` removes it from inflightTasks), emit a terminal
+      // agent:failed (NO recovery — the user killed it deliberately), then idle + prune to
+      // free KV for siblings. Only agent:failed is emitted (no preceding agent:done) so the
+      // UI resolves straight to "cancelled" with no recovering flash. safePrune only reclaims
+      // childless leaves — a parent/chain agent no-ops (its findings still feed dependents).
+      if (pendingCancels.length > 0) {
+        for (const id of pendingCancels.splice(0)) {
+          const a = agentById.get(id);
+          if (!a || (a.status !== 'active' && a.status !== 'awaiting_tool')) continue;
+          const tool = inflightTasks.get(id);
+          if (tool) yield* tool.halt();
+          tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
+            type: 'pool:agentDrop', agentId: id, reason: 'user_cancel' });
+          yield* poolChannel.send({ type: 'agent:failed', agentId: id, reason: 'user_cancel' });
+          a.transition('idle');
+          safePrune(a.branch);
+        }
+      }
 
       // -- Phase 1: PRODUCE -- sample from active agents, collect tool calls
       policy.resetTick?.();

--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -5,12 +5,12 @@ import { CHAT_FORMAT_CONTENT_ONLY, CHAT_FORMAT_GENERIC, GrammarTriggerType, type
 import type { BranchStore } from '@lloyal-labs/sdk';
 import { Ctx, Store, Trace, TraceParent, CallingAgent, SpineFmt, GrantStoreCtx, WindDown } from './context';
 import type { FormatConfig } from './Agent';
-import { buildToolResultDelta, buildTurnDelta } from '@lloyal-labs/sdk';
+import { buildToolResultDelta, buildTurnDelta, buildUserDelta } from '@lloyal-labs/sdk';
 import { traceScope } from './trace-scope';
 import type { TraceWriter } from './trace-writer';
 import type { AgentPolicy, IdleReason, ToolRetryAction } from './AgentPolicy';
 import { Agent } from './Agent';
-import { DefaultAgentPolicy, tokenBudgetAsWords, RECOVERY_PREFILL_OVERHEAD, BATCH_BUFFER } from './AgentPolicy';
+import { DefaultAgentPolicy, RECOVERY_PREFILL_OVERHEAD, BATCH_BUFFER } from './AgentPolicy';
 import type { PolicyConfig } from './AgentPolicy';
 import { Tool, ToolRetryError } from './Tool';
 import type {
@@ -199,41 +199,79 @@ export class ContextPressure {
   }
 }
 
-/** Eager `{ result: string }` extraction grammar — constrains recovery output
- *  from token 0. Shared by `recoverInline` (uncapped) and the parallel fold.
+/** The grammar that forces an agent's recovery output to be a valid call to the
+ *  pool's TERMINAL tool — whatever the harness designated (`report`, `submit`,
+ *  `finish`, …; the framework never assumes a specific tool). Same native path
+ *  every other call uses: `formatChat`'s tool grammar constrains generation, and
+ *  `parseChatOutput` (chat_out / `common_chat_parse`) decodes the resulting Hermes
+ *  tool-call into `{ name, arguments }`. Computed once per pool from the terminal
+ *  tool's schema; `null` when the pool has no terminal tool (then recovery is a
+ *  no-op — there is no structured result to force).
  *
- *  `maxChars` (when set) caps the `result` string via JSON-Schema `maxLength` —
- *  the binding emits `char{0,N}` and forces the closing quote, so the report is
- *  hard-bounded AND the JSON always parses. Used by the parallel fold to fit N
- *  concurrent reports in shared KV; staggered passes none (full-length reports). */
-function* recoveryReportGrammar(ctx: SessionContext, maxChars?: number): Operation<string> {
-  return yield* call(() =>
-    ctx.jsonSchemaToGrammar(JSON.stringify({
-      type: 'object',
-      properties: {
-        result: maxChars != null
-          ? { type: 'string', maxLength: maxChars }
-          : { type: 'string' },
-      },
-      required: ['result'],
-    })),
-  );
+ *  Built with `toolChoice: 'auto'` (root rule = the bare tool-call) and applied
+ *  EAGERLY via `branch.setGrammar` at recovery — that forces a valid terminal call
+ *  from token 0. `'required'` is WRONG here: it prefixes the grammar's root with the
+ *  generation prompt (`"<|im_start|>assistant\n" …`), and since the recovery turn has
+ *  already prefilled that prompt, a required grammar double-emits it and the model
+ *  wanders into raw template tokens. Verified against the real model: required-eager
+ *  → `<|im_start|>assistant…<think>…` prose; auto-eager → `<tool_call><function=…>`. */
+type TerminalGrammar = string;
+
+function buildTerminalGrammar(ctx: SessionContext, terminalTool: Tool): TerminalGrammar {
+  return ctx.formatChatSync(
+    JSON.stringify([{ role: 'system', content: '' }, { role: 'user', content: '' }]),
+    { tools: JSON.stringify([terminalTool.schema]), toolChoice: 'auto', enableThinking: false },
+  ).grammar;
 }
 
-/** Tokenize the recovery prompt (the `onRecovery` system+user turn) into a
- *  branch-prefill delta appended to the agent's existing conversation KV.
- *  Shared by both reap shapes. */
+// Adaptive per-report budget bounds for in-loop recovery when no explicit
+// `policy.reportBudget` is set: `b` = a fair share of current headroom across the
+// live agents, clamped to [MIN, MAX]. MIN keeps a forced report from being uselessly
+// short under pressure; MAX stops one agent with a huge context from being told to
+// write an essay.
+const MIN_REPORT_BUDGET = 128;
+const MAX_REPORT_BUDGET = 2048;
+
+/** Prune a branch only when it is a childless leaf. `Branch.pruneSync` is
+ *  RESTRICT-mode (`Branch.ts`: throws when the branch has live children — they
+ *  still need its KV prefix), so a recovered agent that sub-spawned must NOT be
+ *  pruned: skip it and let the children's own teardown reclaim the lineage. */
+function safePrune(branch: Branch): void {
+  if (!branch.disposed && branch.children.length === 0) branch.pruneSync();
+}
+
+/** Extract the terminal-tool result string from a parsed (possibly TRUNCATED)
+ *  tool call. A clean call's `arguments` is valid JSON → `.result`. The token-stop
+ *  backstop cuts mid-call, so `parseChatOutput` yields unclosed JSON like
+ *  `{"result":"…partial` → `JSON.parse` throws; recover the `result` body from the
+ *  partial and JSON-unescape it (dropping a dangling backslash) rather than leaking
+ *  the `{"result":"` wrapper into the finding. Falls back to the raw arguments when
+ *  there is no `result` key (a non-`{result}` terminal tool — matches
+ *  `DefaultAgentPolicy._handleTerminalTool`). */
+function extractTerminalResult(args: string): string {
+  try {
+    const r = JSON.parse(args).result;
+    if (typeof r === 'string') return r;
+  } catch { /* truncated or non-JSON — salvage the partial below */ }
+  const m = args.match(/"result"\s*:\s*"((?:[^"\\]|\\.)*)/);
+  if (m) {
+    try { return JSON.parse(`"${m[1].replace(/\\+$/, '')}"`); } catch { /* fall through to raw */ }
+  }
+  return args;
+}
+
+/** The recovery turn (`onRecovery`'s system+user prompt) as a branch-prefill
+ *  delta — a thin alias over the shared `buildUserDelta` builder (system + user
+ *  turn, no thinking). Used by `recoverInline` (staggered) and `handleRecover`
+ *  (the in-loop parallel path). */
 function recoveryPromptTokens(
   ctx: SessionContext,
   recovery: { prompt: { system: string; user: string } },
 ): number[] {
-  const { prompt } = ctx.formatChatSync(
-    JSON.stringify([
-      { role: 'system', content: recovery.prompt.system },
-      { role: 'user', content: recovery.prompt.user },
-    ]), { enableThinking: false },
-  );
-  return [...ctx.getTurnSeparator(), ...ctx.tokenizeSync(prompt, false)];
+  return buildUserDelta(ctx, recovery.prompt.user, {
+    system: recovery.prompt.system,
+    enableThinking: false,
+  });
 }
 
 /** Parse a finished recovery branch's output, set the agent's result (source
@@ -246,47 +284,78 @@ function* finishRecovery(
   events: EventSender,
   tw: TraceWriter,
   parentTraceId: number,
+  ctx: SessionContext,
+  terminalToolName: string | undefined,
 ): Operation<boolean> {
   tw.write({
     traceId: tw.nextId(), parentTraceId, ts: performance.now(),
     type: 'pool:recoveryProduce', agentId: agent.id,
     tokenCount: producedTokens, outputLength: output.length,
   });
-  let failureReason: string | null = null;
-  try {
-    const parsed = JSON.parse(output) as { result: string };
-    if (parsed?.result) {
-      agent.setResult(stripDanglingToolCall(parsed.result), 'recovery');
+  // The forced recovery output is a TERMINAL-tool call in the model's native
+  // Hermes syntax — decode it with the same parser the agent uses for every turn,
+  // and extract the result with the same convention as a voluntary terminal return
+  // (the `result` arg, falling back to the raw arguments), never assuming a specific
+  // tool's shape. See AgentPolicy `_handleTerminalTool`.
+  const parsed = ctx.parseChatOutput(output, agent.fmt.format, {
+    reasoningFormat: agent.fmt.reasoningFormat,
+    generationPrompt: agent.fmt.generationPrompt,
+    parser: agent.fmt.parser,
+  });
+  const call = parsed.toolCalls.find(c => c.name === terminalToolName) ?? parsed.toolCalls[0];
+  if (call) {
+    const result = extractTerminalResult(call.arguments);
+    if (result) {
+      agent.setResult(stripDanglingToolCall(result), 'recovery');
       yield* events.send({ type: 'agent:recovered', agentId: agent.id, result: agent.result! });
       tw.write({
         traceId: tw.nextId(), parentTraceId, ts: performance.now(),
         type: 'pool:recoveryReturn', agentId: agent.id,
-        resultLength: parsed.result.length,
+        resultLength: result.length,
       });
       return true;
     }
-    failureReason = 'no_result_field';
-  } catch (e) {
-    failureReason = `parse_error: ${(e as Error).message ?? 'unknown'}`;
   }
+  const reason = call ? 'empty_terminal_result' : 'no_terminal_call';
   tw.write({
     traceId: tw.nextId(), parentTraceId, ts: performance.now(),
     type: 'pool:recoveryFailed', agentId: agent.id,
-    reason: failureReason ?? 'unknown',
+    reason,
     outputExcerpt: output.slice(0, 200),
   });
+  // Terminal UI signal: the agent stopped at the drop (`agent:done`) and is shown
+  // "writing report"; without this it never leaves that state (eternal spinner).
+  // `agent:failed` is the failure twin of `agent:recovered` — the consumer marks
+  // the task failed instead of hanging. See trace `pool:recoveryFailed`.
+  yield* events.send({ type: 'agent:failed', agentId: agent.id, reason });
   return false;
+}
+
+/** Finish an in-loop (`parallel`) recovery report — both the normal stop token and
+ *  the token-stop backstop land here: extract + set the result, idle the agent,
+ *  child-safe-prune the dead branch (freeing its KV for siblings), and tick the
+ *  UI. `producedTokens` = the report's OWN tokens (`recoveryTokens`), since the
+ *  cumulative `tokenCount` includes the agent's whole research run. */
+function* completeExtraction(
+  a: Agent, events: EventSender, tw: TraceWriter, parentTraceId: number,
+  ctx: SessionContext, pressureOpts: PressureThresholds, terminalToolName: string | undefined,
+): Operation<void> {
+  yield* finishRecovery(a, a.rawOutput, a.recoveryTokens, events, tw, parentTraceId, ctx, terminalToolName);
+  a.transition('idle');
+  safePrune(a.branch);
+  const postPressure = new ContextPressure(ctx, pressureOpts);
+  yield* events.send({ type: 'agent:tick', cellsUsed: postPressure.cellsUsed, nCtx: postPressure.nCtx });
 }
 
 /**
  * Inline recovery for a single killed agent (trailing stop).
  *
- * Prefills the extraction prompt into the agent's own branch, sets eager
- * report grammar, generates to stop token, parses JSON, reports result,
- * and prunes the branch — all before the tick loop continues. The freed
- * KV lets remaining agents keep researching.
+ * Prefills the recovery prompt into the agent's own branch, forces the eager
+ * terminal-tool grammar, generates to stop token, extracts the result via
+ * `parseChatOutput`, and prunes the branch — all before the tick loop continues.
+ * The freed KV lets remaining agents keep researching.
  *
- * Returns true if the agent reported findings.
+ * Returns true if the agent produced a result.
  */
 function* recoverInline(
   agent: Agent,
@@ -297,17 +366,18 @@ function* recoverInline(
   parentTraceId: number,
   events: EventSender,
   pressureOpts: PressureThresholds,
+  terminalGrammar: TerminalGrammar | null,
+  terminalToolName: string | undefined,
 ): Operation<boolean> {
   // Fresh snapshot — the policy uses this to compute the recovery budget
   // (reflected in the rendered prompt via `<%= it.budget %>`).
   const recovery = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
   if (!recovery || recovery.type === 'skip') {
-    if (!agent.branch.disposed) agent.branch.pruneSync();
+    safePrune(agent.branch);
     return false;
   }
 
   const tokens = recoveryPromptTokens(ctx, recovery);
-  const reportGrammar = yield* recoveryReportGrammar(ctx);
 
   // Recovery runs in its own scope — if prefill or decode fails (KV
   // exhaustion), the scope tears down cleanly. The recoveryProduce/Return/
@@ -318,7 +388,7 @@ function* recoverInline(
   try {
     yield* scoped(function*() {
       yield* call(() => store.prefill([[agent.branch, tokens]]));
-      agent.branch.setGrammar(reportGrammar);
+      if (terminalGrammar) agent.branch.setGrammar(terminalGrammar);
 
       tw.write({
         traceId: tw.nextId(), parentTraceId, ts: performance.now(),
@@ -336,21 +406,25 @@ function* recoverInline(
         yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: producedTokens });
       }
 
-      reported = yield* finishRecovery(agent, output, producedTokens, events, tw, parentTraceId);
+      reported = yield* finishRecovery(agent, output, producedTokens, events, tw, parentTraceId, ctx, terminalToolName);
     });
   } catch (e) {
     // Scope teardown (KV exhaustion during prefill/decode) — finishRecovery
-    // never ran, so emit the failure trace here.
+    // never ran, so emit the failure trace + the terminal UI signal here.
+    const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
     tw.write({
       traceId: tw.nextId(), parentTraceId, ts: performance.now(),
       type: 'pool:recoveryFailed', agentId: agent.id,
-      reason: `scope_error: ${(e as Error).message ?? 'unknown'}`,
+      reason,
       outputExcerpt: output.slice(0, 200),
     });
+    // The agent is already shown "writing report" (agent:done fired at the drop);
+    // mark it failed so the UI renders a terminal state instead of an eternal spinner.
+    yield* events.send({ type: 'agent:failed', agentId: agent.id, reason });
   }
 
-  // Always prune after scope exits (success or failure)
-  if (!agent.branch.disposed) agent.branch.pruneSync();
+  // Always prune after scope exits (success or failure) — child-safe.
+  safePrune(agent.branch);
 
   // Emit tick so TUI updates pressure percentage after prune
   const postPressure = new ContextPressure(ctx);
@@ -358,199 +432,6 @@ function* recoverInline(
 
   return reported;
 }
-
-// Per-report budget bounds (tokens) for the headroom-derived fold budget, used
-// when no fixed `policy.reportBudget` is set (e.g. wind-down). MIN keeps a report
-// usable; MAX stops an ample-KV wind-down from writing essays.
-const MIN_REPORT_BUDGET = 128;
-const MAX_REPORT_BUDGET = 2048;
-
-/** Prune a finished recovery branch, skipping it if it still has live children —
- *  `pruneSync` throws on children (RESTRICT mode), which a delegate parent could
- *  hit (a sub-agent forks off the calling agent's branch). A skipped parent's KV
- *  is reclaimed at pool teardown; in practice delegate sub-pools complete + prune
- *  before the termination sweep, so this guard rarely fires. */
-function safePrune(branch: Branch): void {
-  if (!branch.disposed && branch.children.length === 0) branch.pruneSync();
-}
-
-/** Recover one fold group in a single batched pass: one `store.prefill` of every
- *  prompt, then a batched decode (one `store.commit` per step across all live
- *  branches — MOAT #1), extract on stop, then `safePrune` each (freeing KV for the
- *  next group). The grammar is `maxLength`-capped so the group fits the budget the
- *  fold reserved for it. Runs on the loop fiber inside a scope so a mid-batch KV
- *  exhaustion tears down cleanly. Returns how many agents reported. */
-function* recoverGroup(
-  group: Agent[],
-  groupTokens: number[][],
-  reportGrammar: string,
-  store: BranchStore,
-  tw: TraceWriter,
-  parentTraceId: number,
-  events: EventSender,
-): Operation<number> {
-  const prefillPairs: [Branch, number[]][] = group.map((a, i) => [a.branch, groupTokens[i]]);
-  const output = new Map<Agent, string>();
-  const produced = new Map<Agent, number>();
-  const done = new Set<Agent>();
-  for (const agent of group) { output.set(agent, ''); produced.set(agent, 0); }
-
-  let reported = 0;
-  try {
-    yield* scoped(function*() {
-      // One batched prefill of every extraction prompt, then per-branch grammar.
-      yield* call(() => store.prefill(prefillPairs));
-      for (let i = 0; i < group.length; i++) {
-        group[i].branch.setGrammar(reportGrammar);
-        tw.write({
-          traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-          type: 'branch:prefill', branchHandle: group[i].id,
-          tokenCount: groupTokens[i].length, role: 'recovery',
-        });
-      }
-
-      // Batched produce/commit — one `store.commit` per step (which packs all
-      // branches into a single llama_decode internally — MOAT #1). A stop drops
-      // that agent from the group and extracts its report.
-      while (done.size < group.length) {
-        const entries: [Branch, number][] = [];
-        for (const agent of group) {
-          if (done.has(agent)) continue;
-          const { token, text, isStop } = agent.branch.produceSync();
-          if (isStop) {
-            done.add(agent);
-            if (yield* finishRecovery(agent, output.get(agent)!, produced.get(agent)!, events, tw, parentTraceId)) {
-              reported++;
-            }
-            continue;
-          }
-          output.set(agent, output.get(agent)! + text);
-          produced.set(agent, produced.get(agent)! + 1);
-          entries.push([agent.branch, token]);
-          yield* events.send({ type: 'agent:produce', agentId: agent.id, text, tokenCount: produced.get(agent)! });
-        }
-        if (entries.length === 0) break;
-        yield* call(() => store.commit(entries));
-      }
-    });
-  } catch (e) {
-    // KV exhaustion mid-batch — mark every agent that hadn't finished failed.
-    const reason = `scope_error: ${(e as Error).message ?? 'unknown'}`;
-    for (const agent of group) {
-      if (done.has(agent)) continue;
-      tw.write({
-        traceId: tw.nextId(), parentTraceId, ts: performance.now(),
-        type: 'pool:recoveryFailed', agentId: agent.id,
-        reason, outputExcerpt: output.get(agent)!.slice(0, 200),
-      });
-    }
-  }
-
-  for (const agent of group) safePrune(agent.branch);
-  return reported;
-}
-
-/**
- * Parallel recovery — extract reports from the whole idle/unreported cohort as a
- * bounded FOLD. Each step recovers the largest group that fits in current KV at a
- * fixed per-report budget `b`, then prunes it (freeing KV) and recurses over the
- * rest. The group size `k` flexes 1..N with available headroom — k=N (one batched
- * pass) when KV is ample, k=1 (effectively staggered) when it's tight — and grows
- * again as pruning replenishes KV. The partition IS the decision: no mode flag.
- *
- * `b` (tokens) is FIXED for the fold: `policy.reportBudget` when set (the configured
- * cap, e.g. low effort), else a fair share of current headroom computed once. It
- * bounds each report two ways — rendered into the recovery prompt as the advisory
- * word count (via the `onRecovery` budget override) AND enforced as the grammar
- * `maxLength` cap (the hard backstop). This is what fixes the pool-wide-budget bug:
- * every agent is told `b`, not the whole KV, so N concurrent reports can't
- * collectively exhaust it.
- *
- * Like `recoverInline`, this MUST run entirely on the loop fiber and finish before
- * any agent transitions to 'idle' / the orchestrator wakes — a concurrent native
- * call on the shared llama_context would SEGV.
- *
- * Returns the number of agents that reported.
- */
-function* recoverParallel(
-  cohort: Agent[],
-  policy: AgentPolicy,
-  ctx: SessionContext,
-  store: BranchStore,
-  tw: TraceWriter,
-  parentTraceId: number,
-  events: EventSender,
-  pressureOpts: PressureThresholds,
-): Operation<number> {
-  // Eligibility pass: keep idle, unreported, undisposed agents the policy opts to
-  // recover; skip-prune the rest now (frees their KV for the fold). The prompt from
-  // this probe is discarded — the fold re-renders each prompt with the fixed `b`.
-  const queue: Agent[] = [];
-  for (const agent of cohort) {
-    if (agent.status !== 'idle' || agent.result || agent.branch.disposed) continue;
-    const probe = policy.onRecovery?.(agent, new ContextPressure(ctx, pressureOpts));
-    if (!probe || probe.type === 'skip') {
-      safePrune(agent.branch);
-      continue;
-    }
-    queue.push(agent);
-  }
-  if (queue.length === 0) return 0;
-
-  // Fixed per-report budget `b` (tokens): the configured cap, else a fair share of
-  // current headroom, computed ONCE. RESERVE matches `onRecovery`'s own accounting.
-  const RESERVE = RECOVERY_PREFILL_OVERHEAD + BATCH_BUFFER;
-  const remaining0 = new ContextPressure(ctx, pressureOpts).remaining;
-  const b = policy.reportBudget
-    ?? Math.min(MAX_REPORT_BUDGET, Math.max(MIN_REPORT_BUDGET, Math.floor((remaining0 - RESERVE) / queue.length)));
-  // Grammar cap is in CHARS, `b` is in tokens: words(b) × ~6 chars × 1.2 headroom,
-  // so the model concludes within `b` on its own and the cap is a silent backstop.
-  const bChars = Math.ceil(tokenBudgetAsWords(b) * 6 * 1.2);
-  const reportGrammar = yield* recoveryReportGrammar(ctx, bChars);
-
-  // Render + tokenize every recovery prompt ONCE at the fixed budget `b` — the
-  // prompt is identical across groups since `b` is fixed, so a boundary agent is
-  // never re-rendered/re-tokenized. This pass re-runs onRecovery only to bind `b`
-  // into the prompt; its skip is budget-independent (decided before the budget
-  // calc, on agent state unchanged since the eligibility probe), so it drops no one
-  // the probe kept and `b` stays the true fair share over `queue.length`. (A custom
-  // policy that DID skip here would only under-budget — shorter reports — never
-  // over-budget/exhaust.)
-  const entries: { agent: Agent; tokens: number[] }[] = [];
-  for (const agent of queue) {
-    const recovery = policy.onRecovery!(agent, new ContextPressure(ctx, pressureOpts), b);
-    if (!recovery || recovery.type === 'skip') { safePrune(agent.branch); continue; }
-    entries.push({ agent, tokens: recoveryPromptTokens(ctx, recovery) });
-  }
-
-  // The fold: pack the largest prefix that fits at (promptTokens + b) per report
-  // into each group (always ≥ 1), recover it, prune (replenishes KV), re-read
-  // headroom, recurse over the rest. `k` flexes 1..N; the partition IS the decision.
-  let reported = 0;
-  let i = 0;
-  while (i < entries.length) {
-    const budget = new ContextPressure(ctx, pressureOpts).remaining - RESERVE;
-    const group: Agent[] = [];
-    const groupTokens: number[][] = [];
-    let used = 0;
-    while (i < entries.length) {
-      const cost = entries[i].tokens.length + b;
-      if (group.length > 0 && used + cost > budget) break; // group full — recover it, prune, re-read KV
-      group.push(entries[i].agent);
-      groupTokens.push(entries[i].tokens);
-      used += cost;
-      i++;
-    }
-    reported += yield* recoverGroup(group, groupTokens, reportGrammar, store, tw, parentTraceId, events);
-  }
-
-  // Emit tick so TUI updates pressure percentage after the final prune.
-  const postPressure = new ContextPressure(ctx);
-  yield* events.send({ type: 'agent:tick', cellsUsed: postPressure.cellsUsed, nCtx: postPressure.nCtx });
-
-  return reported;
-}
-
 
 // ── PRODUCE action handlers ─────────────────────────────────────
 // Each handler encapsulates state transitions, events, and trace for one
@@ -621,6 +502,70 @@ function* handleReturn(
   yield* events.send({ type: 'agent:return', agentId: a.id, result: a.result! });
   yield* events.send({ type: 'agent:done', agentId: a.id });
   if (pruneOnReturn && !a.branch.disposed) a.branch.pruneSync();
+}
+
+/**
+ * Is the agent already emitting the terminal (report) tool? Then it is producing
+ * its OWN report — it must never get a recovery turn bolted on, because that
+ * discards the in-flight report and re-prompts it from scratch (the "report
+ * resets and restarts" failure). Both kill paths — wind-down and pressure/time —
+ * guard on this; the agent is left to finish via the normal `isStop`→return path.
+ */
+function isEmittingTerminal(agent: Agent, terminalToolName: string | undefined): boolean {
+  return terminalToolName != null && agent.currentTool === terminalToolName;
+}
+
+/**
+ * Parallel recovery (`recoveryShape: 'parallel'`): turn a killed-without-result
+ * agent into an in-loop report instead of the blocking `recoverInline`. Mirrors
+ * `handleNudge`'s shape — build the recovery turn-delta, park the agent
+ * `awaiting_tool`, mark it `extracting`, return a `SettledTool`. SETTLE then
+ * re-activates it with the native terminal-tool grammar (the grammar-swap); the
+ * report decodes bin-packed in the tick loop, capped at budget `b` by the prompt
+ * advisory + the PRODUCE token-stop, which routes the finished/cut report to
+ * `finishRecovery`. The caller emits `pool:agentDrop` +
+ * `agent:done` first (same order as the `recoverInline` kill path).
+ *
+ * Returns the `SettledTool` to queue for SETTLE (push onto `nudges`), or `null`
+ * after pruning + idling the agent when the policy declines to recover it.
+ */
+function* handleRecover(
+  a: Agent, policy: AgentPolicy, ctx: SessionContext,
+  pressureOpts: PressureThresholds, aliveCount: number,
+): Operation<SettledTool | null> {
+  // Per-report budget `b`: the prompt advisory (onRecovery's budget arg) and the
+  // token-stop backstop share it. Size it so the WHOLE cohort's prefill+decode fits the
+  // RECOVERY RESERVE in ONE batched tick — then nothing defers and no findings are lost.
+  // Each of the `aliveCount` agents consumes ~its turn prompt (≈RECOVERY_PREFILL_OVERHEAD)
+  // + up to `b` report cells, so aliveCount·(OVERHEAD + b) ≤ (remaining − hardLimit) − BATCH_BUFFER
+  // ⟹ b ≤ (remaining − hardLimit − BATCH_BUFFER)/aliveCount − OVERHEAD. Sizing against
+  // `remaining − hardLimit` (the documented recovery reserve — what the nudge advisory,
+  // onSettleReject, and staggered recoverInline all use), NOT `remaining − softLimit`:
+  // softLimit is just the model nudge floor, so recovery is allowed to decode the soft
+  // reserve down to hardLimit (the SETTLE admission grants the same band). Dividing by the
+  // alive count (not just this tick's cohort) reserves room for siblings that could still
+  // need recovery. An explicit `policy.reportBudget` is CLAMPED to that ceiling so it can
+  // never exceed what fits. Computed here so the prompt's word advisory matches the token-stop.
+  const pressure = new ContextPressure(ctx, pressureOpts);
+  const fits = Math.floor((pressure.remaining - pressure.hardLimit - BATCH_BUFFER) / Math.max(1, aliveCount)) - RECOVERY_PREFILL_OVERHEAD;
+  const b = policy.reportBudget != null
+    // Explicit cap: honor the consumer's choice, clamped DOWN so it never exceeds
+    // what fits (when there's positive room) — the MIN floor does NOT raise it.
+    ? (fits > 0 ? Math.min(policy.reportBudget, fits) : policy.reportBudget)
+    // Adaptive: a fair share of headroom across the live agents, clamped to [MIN, MAX].
+    : Math.min(MAX_REPORT_BUDGET, Math.max(MIN_REPORT_BUDGET, fits));
+  const recovery = policy.onRecovery?.(a, pressure, b);
+  if (!recovery || recovery.type === 'skip') {
+    safePrune(a.branch);
+    a.transition('idle');
+    return null;
+  }
+  const prefillTokens = recoveryPromptTokens(ctx, recovery);
+  a.incrementTurns();
+  if (a.status === 'active') a.transition('awaiting_tool');
+  a.markExtracting(b);
+  a.resetTurn();
+  return { agentId: a.id, prefillTokens, toolName: '', callId: '', args: '' };
 }
 
 /**
@@ -814,6 +759,13 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     // in its registry — passing the full tool map makes this flag true and
     // traps reporters in an infinite rejection loop.
     const hasNonTerminalTools = terminalToolName ? [...tools.keys()].some(k => k !== terminalToolName) : tools.size > 0;
+
+    // The eager terminal-tool grammar that forces a recovered agent to emit a
+    // schema-valid terminal call (whatever the harness designated as terminal).
+    // Computed once from the terminal tool's schema; `null` when there is no
+    // terminal tool (recovery has no structured result to force, so it no-ops).
+    const terminalTool = terminalToolName ? tools.get(terminalToolName) : undefined;
+    const terminalGrammar = terminalTool ? buildTerminalGrammar(ctx, terminalTool) : null;
     const policy = opts.policy ?? new DefaultAgentPolicy();
     const pressureOpts: PressureThresholds = policy.pressureThresholds
       ?? { softLimit: ContextPressure.DEFAULT_SOFT_LIMIT, hardLimit: ContextPressure.DEFAULT_HARD_LIMIT };
@@ -1070,6 +1022,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
     function* settle(items: SettledTool[]): Operation<SettledTool[]> {
       const settlePressure = new ContextPressure(ctx, pressureOpts);
       let headroom = settlePressure.headroom;
+      // Recovery (extracting) items may spend the softLimit reserve DOWN TO hardLimit —
+      // the documented recovery reserve (agent-pool.ts ContextPressure docstring; same
+      // floor the nudge advisory + staggered recoverInline already use). So an extracting
+      // item's admission budget is `headroom + reserveBand` (= remaining − hardLimit);
+      // plain tool-result (new research) items stay gated at `headroom` (preserve softLimit).
+      const reserveBand = settlePressure.softLimit - settlePressure.hardLimit;
 
       const prefillPairs: [Branch, number[]][] = [];
       const settledAgents: Agent[] = [];
@@ -1081,7 +1039,21 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         const a = agentById.get(item.agentId);
         if (!a || a.status === 'idle') continue;
 
-        if (item.prefillTokens.length > headroom) {
+        // Admission cost. A recovery item (the agent is `extracting`) reserves the
+        // REPORT room too (prompt + b) — it will decode up to `recoveryBudget` tokens
+        // AFTER this prefill — and is budgeted against `remaining − hardLimit`
+        // (`headroom + reserveBand`), i.e. it may consume the softLimit reserve down to
+        // the hardLimit floor (the documented recovery reserve). `b` is sized in
+        // handleRecover so aliveCount·(prompt + b) ≤ remaining − hardLimit, so this gate
+        // ADMITS ALL N in the normal case: no wave, no defer (decode is O(1) in branch
+        // count, they batch in one tick). It bites ONLY when KV is genuinely too tight
+        // (`b` floored at MIN, (prompt + b)·N > remaining − hardLimit): the overflow
+        // defers → stall-break → serial `recoverInline` (uncapped, prune-between,
+        // lossless), never a report-decode overflow. Plain tool-result items reserve
+        // only their prompt and stay gated at `headroom` (preserve the softLimit reserve).
+        const cost = a.extracting ? item.prefillTokens.length + a.recoveryBudget : item.prefillTokens.length;
+        const budget = a.extracting ? headroom + reserveBand : headroom;
+        if (cost > budget) {
           // Defer — siblings may finish and free KV, letting this result
           // settle next tick (staggered-exit for parallel orchestration).
           // Policy is consulted at stall-break time, not here: invoking
@@ -1095,7 +1067,7 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
         settledAgents.push(a);
         settledOrder.push({ agentId: a.id, callId: item.callId, tokenCount: item.prefillTokens.length });
         if (item.probe) itemProbes.set(a.id, item.probe);
-        headroom -= item.prefillTokens.length;
+        headroom -= cost;
         const postSettle = new ContextPressure(ctx, pressureOpts);
         a.recordToolResult({
           name: item.toolName, args: item.args,
@@ -1135,10 +1107,19 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
           yield* call(() => store.prefill(probePairs));
         }
 
+        // Re-activate. An `extracting` agent (parallel recovery, queued by
+        // handleRecover) gets the eager terminal-tool grammar instead of the lazy
+        // tool-call grammar — the grammar-swap (#77). This forces a schema-valid
+        // terminal call that `parseChatOutput` decodes; the report then decodes
+        // bin-packed in the tick loop alongside live siblings.
         for (const a of settledAgents) {
           a.transition('active');
           a.resetTurn();
-          applyLazyGrammar(a);
+          if (a.extracting && terminalGrammar) {
+            a.branch.setGrammar(terminalGrammar);
+          } else {
+            applyLazyGrammar(a);
+          }
         }
       }
 
@@ -1515,6 +1496,12 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       // -- Phase 1: PRODUCE -- sample from active agents, collect tool calls
       policy.resetTick?.();
       const pressure = new ContextPressure(ctx, pressureOpts);
+      // Live agents = the in-flight set that could still need recovery: `active`
+      // (researching / producing a forced report) or `awaiting_tool`. Explicitly NOT
+      // `idle` (done-with-result, dropped, OR just-spawned-not-yet-activated) and NOT
+      // `disposed`. The in-loop recovery budget `b` is a fair share of headroom across
+      // them, so the whole cohort's reports fit without one agent claiming it all.
+      const aliveCount = agents.filter(x => x.status === 'active' || x.status === 'awaiting_tool').length;
 
       const entries: [Branch, number][] = [];
       const toolCalls: { agent: Agent; tc: ParsedToolCall }[] = [];
@@ -1523,40 +1510,79 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       for (const a of agents) {
         if (a.status !== 'active') continue;
 
-        // Wind-down (drain): drop active agents to idle so the termination sweep
-        // folds the whole cohort fast. An agent mid-terminal-tool (emitting its
-        // voluntary report) is left to finish — same guard as shouldExit's terminal
-        // protection. NO inline recovery (defer to the fold) and NO tool abort.
+        // Wind-down (drain): recover active agents IN-LOOP (bin-packed for a fast
+        // drain) instead of deferring to a sweep — wind-down always bin-packs,
+        // regardless of effort. An agent mid-terminal-tool (emitting its voluntary
+        // report) is left to finish — same guard as shouldExit's terminal
+        // protection; an already-extracting agent is left to finish its report.
         // SEGV-safe: the orchestrator was halted before windingDown flipped, so no
-        // concurrent spawn/prefill races this idle-transition.
-        if (windingDown && !(terminalToolName && a.currentTool === terminalToolName)) {
+        // concurrent spawn/prefill races handleRecover's prefill.
+        if (windingDown && !a.extracting && !isEmittingTerminal(a, terminalToolName)) {
           tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
             type: 'pool:agentDrop', agentId: a.id, reason: 'wind_down' });
           yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
-          a.transition('idle');
+          const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+          if (settled) nudges.push(settled);
           continue;
         }
 
+        // Kill on pressure/time. An extracting agent (producing its forced
+        // recovery report) is exempt — its token-stop cap (with `b` sized so the whole
+        // cohort fits headroom) keeps it within KV; if it overshoots, the tick-loop
+        // catch yields partials.
         const policyExit = policy.shouldExit?.(a, pressure);
-        if (policyExit ?? pressure.critical) {
+        if (!a.extracting && (policyExit ?? pressure.critical)) {
           const exitReason = pressure.critical ? 'pressure_critical' as const
             : policyExit ? 'policy_exit' as const
             : 'pressure_critical' as const;
           tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
             type: 'pool:agentDrop', agentId: a.id, reason: exitReason });
           yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
-          // Run recovery BEFORE transitioning to idle — otherwise the statusSignal
-          // fires 'idle' mid-recovery, PoolContext.waitFor returns early, the
-          // orchestrator resumes and starts spawning/prefilling the next task
-          // while this agent is still being decoded by recoverInline. Concurrent
-          // native calls on the same llama_context → SEGV.
-          yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
-          a.transition('idle');
+          if (isEmittingTerminal(a, terminalToolName)) {
+            // The agent was already producing its OWN report when the critical kill
+            // fired. DON'T prefill a fresh recovery turn — that discards the in-flight
+            // report and restarts it from scratch (the "report resets + restarts" bug),
+            // then re-decodes into the already-exhausted KV and fails. Salvage the
+            // partial terminal call it has already emitted (parseChatOutput handles the
+            // truncation); no further decode is needed.
+            yield* finishRecovery(a, a.rawOutput, a.tokenCount, poolChannel, tw, poolScope.traceId, ctx, terminalToolName);
+            a.transition('idle');
+            safePrune(a.branch);
+          } else if (policy.recoveryShape === 'parallel') {
+            // In-loop: inject the recovery turn; SETTLE re-activates it (capped
+            // report grammar) and the report decodes bin-packed with live agents.
+            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+            if (settled) nudges.push(settled);
+          } else {
+            // Staggered: blocking recoverInline, BEFORE the idle transition —
+            // otherwise the statusSignal fires 'idle' mid-recovery, waitFor
+            // returns early, the orchestrator resumes + prefills the next task
+            // while this branch is still decoding → concurrent native call → SEGV.
+            yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts, terminalGrammar, terminalToolName);
+            a.transition('idle');
+          }
+          continue;
+        }
+
+        // Token-stop backstop: an extracting agent that has produced its full report
+        // budget is force-finished here (its partial tool-call salvaged via
+        // parseChatOutput) rather than decoding further — this BOUNDS each in-loop
+        // report so a non-compliant model can't blow past the prompt's word advisory
+        // and exhaust KV. The prompt budget is the primary cap; this is the guillotine.
+        if (a.extracting && a.recoveryTokens >= a.recoveryBudget) {
+          yield* completeExtraction(a, poolChannel, tw, poolScope.traceId, ctx, pressureOpts, terminalToolName);
           continue;
         }
 
         const { token, text, isStop } = a.branch.produceSync();
         if (isStop) {
+          if (a.extracting) {
+            // The forced recovery report finished — extract + idle + child-safe
+            // prune (the KV is dead weight). `agent:done` already fired at recovery
+            // entry; completeExtraction emits `agent:recovered`.
+            yield* completeExtraction(a, poolChannel, tw, poolScope.traceId, ctx, pressureOpts, terminalToolName);
+            continue;
+          }
           const parsed = a.finalize(ctx);
 
           tw.write({
@@ -1575,7 +1601,20 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
               yield* handleFreeTextReturn(a, action.content, poolChannel);
               continue;
             case 'idle':
-              yield* handleIdleDrop(a, action.reason, poolChannel, tw, poolScope.traceId);
+              // Parallel: recover in-loop at the stop (no termination sweep for
+              // parallel). Staggered: idle now, recovered at the sweep.
+              if (policy.recoveryShape === 'parallel') {
+                if (action.reason !== 'free_text_stop') {
+                  tw.write({ traceId: tw.nextId(), parentTraceId: poolScope.traceId, ts: performance.now(),
+                    type: 'pool:agentDrop', agentId: a.id,
+                    reason: action.reason === 'max_turns' ? 'maxTurns' : 'pressure_softcut' });
+                }
+                yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
+                const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+                if (settled) nudges.push(settled);
+              } else {
+                yield* handleIdleDrop(a, action.reason, poolChannel, tw, poolScope.traceId);
+              }
               continue;
             case 'nudge':
               // authGuard rejection: emit the structured
@@ -1707,9 +1746,22 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
             type: 'pool:agentDrop', agentId: a.id, reason,
           });
           yield* poolChannel.send({ type: 'agent:done', agentId: a.id });
-          // Recover BEFORE transition — single-fiber store discipline.
-          yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
-          a.transition('idle');
+          if (policy.recoveryShape === 'parallel' && !a.extracting) {
+            // In-loop (first attempt): queue the recovery turn for next tick's
+            // SETTLE (alongside the surviving nudges). Agent is awaiting_tool → no
+            // transition.
+            const settled = yield* handleRecover(a, policy, ctx, pressureOpts, aliveCount);
+            if (settled) resolved.push(settled);
+          } else {
+            // Staggered — OR a parallel agent ALREADY extracting whose recovery
+            // turn couldn't fit headroom (reaching the stall-break with no active
+            // siblings to free KV). Fall back to blocking recoverInline, which
+            // extracts within the hardLimit reserve. BEFORE transition →
+            // single-fiber store discipline. This is what prevents the
+            // defer→stall→re-queue non-terminating loop when the turn never fits.
+            yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts, terminalGrammar, terminalToolName);
+            a.transition('idle');
+          }
         }
 
         // Replace deferred with the surviving (nudged) items for next tick.
@@ -1744,18 +1796,14 @@ export function useAgentPool(opts: AgentPoolOptions): Operation<Subscription<Age
       if (allIdle && orchestratorDone && fanoutQuiet) {
         if (!recoveryAttempted) {
           recoveryAttempted = true;
-          // Recover any idle agents that weren't handled by inline recovery
-          // (e.g., killed by max_turns, time budget, or free_text_stop).
-          // `parallel` batches the whole cohort (one prefill + batched decode —
-          // wall-clock ≈ the slowest single report); `staggered` (default)
-          // recovers them one at a time for maximum per-report headroom.
-          if (policy.recoveryShape === 'parallel' || windingDown) {
-            yield* recoverParallel(agents, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
-          } else {
-            for (const a of agents) {
-              if (a.status === 'idle' && !a.result && !a.branch.disposed) {
-                yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts);
-              }
+          // Staggered leftovers reach here idle-without-result (killed by
+          // max_turns / time / free_text_stop). `parallel` + wind-down already
+          // recovered in-loop at each agent's stop (handleRecover), so this loop
+          // is a no-op for them. One at a time → maximum per-report headroom
+          // (the lossless path).
+          for (const a of agents) {
+            if (a.status === 'idle' && !a.result && !a.branch.disposed) {
+              yield* recoverInline(a, policy, ctx, store, tw, poolScope.traceId, poolChannel, pressureOpts, terminalGrammar, terminalToolName);
             }
           }
         }

--- a/packages/agents/src/context.ts
+++ b/packages/agents/src/context.ts
@@ -181,3 +181,22 @@ export const GrantStoreCtx = createContext<GrantStore>('lloyal.grantStore');
  * @category Agents
  */
 export const WindDown = createContext<Signal<void, void>>('lloyal.windDown');
+
+/**
+ * Effection context holding an optional per-agent cancel {@link Signal}.
+ *
+ * A consumer that wants to cancel a single live agent (e.g. a per-card ×) provides a
+ * `createSignal<{ agentId: number }, void>()` in the pool's run scope and
+ * `.send({ agentId })`s it. The pool reads it at boot (`yield* CancelAgent.get()`); on
+ * emission it halts that agent's in-flight tool (aborting the fetch), emits a terminal
+ * `agent:failed` (reason `user_cancel`) — NO recovery, the user killed it deliberately —
+ * and prunes its branch to reclaim KV for its siblings. Cancel = **discard**, not drain.
+ *
+ * This is the per-agent twin of {@link WindDown} (which reaps the whole cohort to
+ * recovery). Intended for flat / independent (parallel) agents — chain agents feed the
+ * spine, so the consumer wires this only where an agent's branch is a reclaimable leaf.
+ * Absent context = no cancel capability.
+ *
+ * @category Agents
+ */
+export const CancelAgent = createContext<Signal<{ agentId: number }, void>>('lloyal.cancelAgent');

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -9,6 +9,7 @@ export {
   AppConfigStoreCtx,
   GrantStoreCtx,
   WindDown,
+  CancelAgent,
 } from './context';
 export { Tool, ToolRetryError } from './Tool';
 export { Agent } from './Agent';

--- a/packages/agents/src/trace-types.ts
+++ b/packages/agents/src/trace-types.ts
@@ -129,7 +129,8 @@ export type TraceEvent =
         | 'maxTurns'
         | 'tool_error'
         | 'stop_token'
-        | 'wind_down';
+        | 'wind_down'
+        | 'user_cancel';
     }
   | TraceEventBase & {
       type: 'pool:agentNudge';

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -480,5 +480,6 @@ export type AgentEvent =
   | { type: 'agent:tool_retry'; agentId: number; tool: string; retryAfterMs: number; attempt: number }
   | { type: 'agent:return'; agentId: number; result: string }
   | { type: 'agent:recovered'; agentId: number; result: string }
+  | { type: 'agent:failed'; agentId: number; reason: string }
   | { type: 'agent:done'; agentId: number }
   | { type: 'agent:tick'; cellsUsed: number; nCtx: number };

--- a/packages/agents/test/agent-pool.test.ts
+++ b/packages/agents/test/agent-pool.test.ts
@@ -1370,12 +1370,11 @@ describe('SPLIT-SEMANTICS GATE: voluntary vs recovery emission', () => {
 
     // Token sequence for the single agent's branch:
     //   [STOP, 100, STOP]
-    //   - first STOP: agent's PRODUCE phase hits stop, parser returns no
-    //     content/toolCalls (per parseChatOutput override below), policy
-    //     returns idle → agent killed → recoverInline fires
-    //   - 100, STOP: recovery's produce/commit loop generates token 100
-    //     (text = JSON payload), then STOP → JSON.parse succeeds →
-    //     agent.setResult fires → agent:recovered event emits
+    //   - first STOP: agent's PRODUCE phase hits stop; the main turn's parse goes
+    //     through onProduced → idle (free_text_stop) → agent killed → recoverInline
+    //   - 100, STOP: recovery's produce/commit loop generates token 100, then STOP →
+    //     finishRecovery parses the recovery output via parseChatOutput, which (below)
+    //     returns the terminal `report` call → agent.setResult → agent:recovered
     const queues = [[STOP, 100, STOP]];
     ctx._branchSample = (handle: number): number => {
       const fi = branchForkIndex.get(handle) ?? -1;
@@ -1384,8 +1383,12 @@ describe('SPLIT-SEMANTICS GATE: voluntary vs recovery emission', () => {
       branchSampleCount.set(handle, idx + 1);
       return idx < queue.length ? queue[idx] : STOP;
     };
+    // The recovery output is a native terminal-tool call (the real model emits Hermes
+    // `<tool_call><function=report>`); finishRecovery extracts `result` via the same
+    // parseChatOutput path every turn uses. onProduced ignores it on the main turn
+    // (returns idle), so the agent still drops → recovers.
     ctx.parseChatOutput = (): ParseChatOutputResult =>
-      ({ content: '', reasoningContent: '', toolCalls: [] });
+      ({ content: '', reasoningContent: '', toolCalls: [{ name: 'report', arguments: '{"result":"recovered findings"}', id: 'c1' }] });
 
     const traceWriter = new CapturingTraceWriter();
     const collectedEvents: AgentEvent[] = [];

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -125,6 +125,15 @@ export interface PoolSpec {
    * scenarios — e.g. fire on the first `agent:spawn` to reap the active cohort.
    */
   windDownAfter?: (ev: AgentEvent, count: number) => boolean;
+  /**
+   * Escape hatch to wrap/override any `ctx` method AFTER the instrumented mock is
+   * built but BEFORE the pool runs — the same affordance the harness uses
+   * internally for `_branchSample` / `parseChatOutput`. Recovery scenarios use it
+   * to make `tokenToText` spell out a parseable report (so the in-loop recovery
+   * SETS a result, as the real model would) and to capture the report grammar's
+   * `maxLength` budget out of `jsonSchemaToGrammar`.
+   */
+  instrument?: (ctx: InstrumentedMockSessionContext) => void;
 }
 
 /**
@@ -138,6 +147,7 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
     nCtx: spec.nCtx,
     cellsUsed: spec.cellsUsed,
   });
+  spec.instrument?.(ctx);
 
   // Wire scripted _branchSample: index by forkCount, advance per sample.
   let forkCount = 0;

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -33,6 +33,9 @@ export interface PoolRun {
   channelEvents: AgentEvent[];
   nativeCalls: NativeCall[];
   ctx: InstrumentedMockSessionContext;
+  /** Set if the pool run THREW (e.g. a decode OOM) instead of completing. The
+   *  captured `traceEvents`/`channelEvents` still reflect everything up to the throw. */
+  error?: unknown;
 }
 
 /**
@@ -44,6 +47,9 @@ export interface PoolRun {
 export class InstrumentedMockSessionContext extends MockSessionContext {
   readonly nativeCalls: NativeCall[] = [];
   private _seq = 0;
+  /** Simulate a decode OOM: throw from `_storeCommit` the first time this token is
+   *  in the committed batch (deterministic — tie it to a report-turn sentinel token). */
+  throwOnCommitToken: number | null = null;
 
   async _storePrefill(handles: number[], tokenArrays: number[][]): Promise<void> {
     const tStart = performance.now();
@@ -58,6 +64,9 @@ export class InstrumentedMockSessionContext extends MockSessionContext {
   }
 
   async _storeCommit(handles: number[], tokens: number[]): Promise<void> {
+    if (this.throwOnCommitToken != null && tokens.includes(this.throwOnCommitToken)) {
+      throw new Error('llama_decode failed: no KV slot (mock OOM)');
+    }
     const tStart = performance.now();
     const seq = this._seq++;
     await super._storeCommit(handles, tokens);
@@ -134,6 +143,9 @@ export interface PoolSpec {
    * `maxLength` budget out of `jsonSchemaToGrammar`.
    */
   instrument?: (ctx: InstrumentedMockSessionContext) => void;
+  /** Capture a thrown pool run into `PoolRun.error` instead of rejecting — for scenarios
+   *  that expect a throw AND need the events emitted before it. Default: re-throw (fail-loud). */
+  captureError?: boolean;
 }
 
 /**
@@ -217,7 +229,10 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
     ? JSON.stringify([...spec.tools.values()].map(t => t.schema))
     : '');
 
-  const result = await run(function* () {
+  let result: AgentPoolResult;
+  let poolError: unknown;
+  try {
+  result = await run(function* () {
     yield* Ctx.set(ctx as any);
     yield* Store.set(store);
     const events: Channel<AgentEvent, void> = createChannel();
@@ -263,9 +278,18 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
       return next.value;
     });
   });
+  } catch (e) {
+    // Default: RE-THROW (fail-loud — an unexpected pool throw must surface, e.g. the
+    // hardLimit<nBatch startup invariant). Scenarios that expect a throw AND need the
+    // events emitted before it opt in via `captureError`.
+    if (!spec.captureError) throw e;
+    poolError = e;
+    result = { agents: [] } as unknown as AgentPoolResult;
+  }
 
   return {
     result,
+    error: poolError,
     traceEvents: trace.events,
     channelEvents,
     nativeCalls: ctx.nativeCalls,

--- a/packages/agents/test/invariants/harness.ts
+++ b/packages/agents/test/invariants/harness.ts
@@ -7,7 +7,7 @@ import type { ChatFormat, ParseChatOutputOptions, ParseChatOutputResult } from '
 import { useAgentPool } from '../../src/agent-pool';
 import type { Orchestrator } from '../../src/orchestrators';
 import { parallel, chain } from '../../src/orchestrators';
-import { Ctx, Store, Events, Trace, WindDown } from '../../src/context';
+import { Ctx, Store, Events, Trace, WindDown, CancelAgent } from '../../src/context';
 import type { AgentPolicy } from '../../src/AgentPolicy';
 import type { AgentPoolResult, AgentEvent } from '../../src/types';
 import type { TraceEvent } from '../../src/trace-types';
@@ -135,6 +135,12 @@ export interface PoolSpec {
    */
   windDownAfter?: (ev: AgentEvent, count: number) => boolean;
   /**
+   * Like {@link windDownAfter}, but fires the per-agent `CancelAgent` signal with the
+   * returned agentId the FIRST time this predicate returns a non-null id (null = skip).
+   * Drives the cancel scenario — e.g. fire on the agent's `agent:spawn` to discard it.
+   */
+  cancelAfter?: (ev: AgentEvent, count: number) => number | null;
+  /**
    * Escape hatch to wrap/override any `ctx` method AFTER the instrumented mock is
    * built but BEFORE the pool runs — the same affordance the harness uses
    * internally for `_branchSample` / `parseChatOutput`. Recovery scenarios use it
@@ -240,6 +246,8 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
     yield* Trace.set(trace);
     const windDownSignal = createSignal<void, void>();
     if (spec.windDownAfter) yield* WindDown.set(windDownSignal);
+    const cancelSignal = createSignal<{ agentId: number }, void>();
+    if (spec.cancelAfter) yield* CancelAgent.set(cancelSignal);
 
     const taskCount = spec.taskCount ?? spec.scripts.length;
     const taskSpecs = Array.from({ length: taskCount }, (_, i) => ({
@@ -266,12 +274,20 @@ export async function runPool(spec: PoolSpec): Promise<PoolRun> {
       let next = yield* sub.next();
       let evCount = 0;
       let windDownFired = false;
+      let cancelFired = false;
       while (!next.done) {
         channelEvents.push(next.value);
         evCount++;
         if (!windDownFired && spec.windDownAfter?.(next.value, evCount)) {
           windDownFired = true;
           windDownSignal.send();
+        }
+        if (!cancelFired && spec.cancelAfter) {
+          const cancelId = spec.cancelAfter(next.value, evCount);
+          if (cancelId != null) {
+            cancelFired = true;
+            cancelSignal.send({ agentId: cancelId });
+          }
         }
         next = yield* sub.next();
       }

--- a/packages/agents/test/invariants/scenarios/agent-cancel-no-sweep-recovery.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/agent-cancel-no-sweep-recovery.scenario.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Invariant: a user-cancelled agent is DISCARDED — the staggered termination sweep must
+ * NOT force-recover it, even when its branch couldn't be pruned.
+ *
+ * `safePrune` only reclaims childless leaves. An agent that spawned a sub-agent (recursion
+ * is a standing capability) has `branch.children.length > 0`, so `safePrune` no-ops at
+ * cancel and the branch stays non-disposed. The termination sweep recovers any agent left
+ * `idle && !result && !branch.disposed` — so pre-fix it would `recoverInline()` the
+ * cancelled agent, emitting a SECOND terminal event (here `agent:failed(recovery_skipped)`)
+ * after the `agent:failed(user_cancel)`. The `cancelledIds` guard excludes it.
+ *
+ * (PR #26 Copilot review, agent-pool.ts:1911.)
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import type { Orchestrator } from '../../../src/orchestrators';
+import { runPool, STOP } from '../harness';
+
+// Non-leaf topology: agent A has a spawned child B forked from A's own branch.
+const nested: Orchestrator = function* (ctx) {
+  const a = yield* ctx.spawn({ content: 'A', systemPrompt: 'You are A.', seed: 0 });
+  yield* ctx.spawn({ content: 'B', systemPrompt: 'You are B.', seed: 1, parent: a.branch });
+};
+
+describe('scenario: cancelled non-leaf agent is not force-recovered by the sweep', () => {
+  it('cancel A (has child B) → exactly one terminal agent:failed (user_cancel), no sweep recovery', async () => {
+    const policy: AgentPolicy = {
+      recoveryShape: 'staggered', // staggered ⇒ the termination sweep runs at pool close
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'skip' }),
+    };
+
+    const run = await runPool({
+      nCtx: 8000,
+      cellsUsed: 0,
+      // A: long run — stays active until cancelled. B: short — idles fast, leaving A the
+      // idle-no-result-non-disposed leftover the sweep would otherwise pick up.
+      scripts: [
+        { tokens: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, STOP] }, // A (fork 0)
+        { tokens: [1, STOP], content: 'b' },               // B (fork 1, child of A)
+      ],
+      policy,
+      orchestrate: nested,
+      terminalToolName: 'report',
+      // A is the first agent to spawn; cancel it.
+      cancelAfter: (ev) => (ev.type === 'agent:spawn' ? ev.agentId : null),
+    });
+
+    // Exactly one user_cancel; capture the cancelled agent id.
+    const cancelled = run.channelEvents.filter(
+      e => e.type === 'agent:failed' && (e as { reason?: string }).reason === 'user_cancel',
+    );
+    expect(cancelled.length).toBe(1);
+    const aId = (cancelled[0] as { agentId: number }).agentId;
+
+    // The cancelled agent must have EXACTLY ONE terminal event (the user_cancel) and NO
+    // recovery. Pre-fix, the sweep's recoverInline(A) emits a second agent:failed
+    // (recovery_skipped) — this assertion is red then.
+    const aFailures = run.channelEvents.filter(
+      e => e.type === 'agent:failed' && (e as { agentId: number }).agentId === aId,
+    );
+    expect(aFailures.length).toBe(1);
+    expect((aFailures[0] as { reason: string }).reason).toBe('user_cancel');
+    expect(
+      run.channelEvents.some(e => e.type === 'agent:recovered' && (e as { agentId: number }).agentId === aId),
+    ).toBe(false);
+    // No recovery prefill ran for the cancelled agent (recoverInline never entered).
+    const aRecoveryPrefills = run.traceEvents.filter(
+      e => e.type === 'branch:prefill'
+        && (e as { role?: string }).role === 'recovery'
+        && (e as { branchHandle?: number }).branchHandle === aId,
+    );
+    expect(aRecoveryPrefills.length).toBe(0);
+  });
+});

--- a/packages/agents/test/invariants/scenarios/agent-cancel-user.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/agent-cancel-user.scenario.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Invariant: a per-agent `CancelAgent.send({agentId})` DISCARDS exactly that agent —
+ * one terminal `agent:failed` (reason `user_cancel`), its branch pruned, NO recovery,
+ * no orphan. Mirrors the Artifact per-card × (halt the agent's tool + prune, reclaiming
+ * its KV for siblings) while the pool keeps running.
+ *
+ * The drain runs on the loop fiber before PRODUCE, so an `active` agent is pulled out
+ * before it joins the batched decode (here the agent has a long token run to stay live
+ * across the tick or two the signal→watcher→queue hop takes).
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+
+describe('scenario: per-agent cancel discards one agent (user_cancel)', () => {
+  it('CancelAgent → agent:failed (user_cancel) + pool:agentDrop, no recovery, no orphan', async () => {
+    const policy: AgentPolicy = {
+      recoveryShape: 'parallel',
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      // If the cancel somehow missed, the agent would free-text → recover; the assertions
+      // below (exactly one agent:failed=user_cancel, zero recovered) would then fail loud.
+      onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+    };
+
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 0,
+      // Long run keeps the agent `active` for many ticks so the cancel lands while it's live.
+      scripts: [{ tokens: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, STOP] }],
+      policy,
+      terminalToolName: 'report',
+      // Fire the cancel on the agent's spawn, targeting its own id.
+      cancelAfter: (ev) => (ev.type === 'agent:spawn' ? ev.agentId : null),
+    });
+
+    const failed = run.channelEvents.filter(e => e.type === 'agent:failed');
+    expect(failed.length).toBe(1);
+    expect((failed[0] as { reason: string }).reason).toBe('user_cancel');
+    // Discard, not recover — no forced report.
+    expect(run.channelEvents.some(e => e.type === 'agent:recovered')).toBe(false);
+    // The drop is traced as user_cancel (exactly one).
+    const drops = run.traceEvents.filter(
+      e => e.type === 'pool:agentDrop' && (e as { reason?: string }).reason === 'user_cancel',
+    );
+    expect(drops.length).toBe(1);
+  });
+});

--- a/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/parallel-recovery.scenario.test.ts
@@ -2,184 +2,293 @@ import { describe, it, expect } from 'vitest';
 import type { AgentPolicy } from '../../../src/AgentPolicy';
 import { runPool, STOP } from '../harness';
 import type { PoolRun } from '../harness';
-import { I1_nativeStoreSingleFiber, I29_recoveryDiagnostic } from '../predicates';
+import { I1_nativeStoreSingleFiber } from '../predicates';
 
 const N = 3;
 
+// The recovery report is a TERMINAL-tool call: the mock's script-driven
+// parseChatOutput returns this for the recovery output (same as the real model
+// emitting a Hermes `<tool_call><function=report>`), so finishRecovery extracts
+// `result` and the in-loop recovery SETS the agent's result. The grammar/maxLength
+// is verified against the real model; here the mock ignores the grammar, so we
+// assert the PATH, the co-batching, and the CAP (the token-stop, observable as
+// `pool:recoveryProduce.tokenCount`).
+const REPORT_CALL = { name: 'report', arguments: '{"result":"recovered"}' };
+
 /**
- * Every agent drops to idle WITHOUT a result on its first stop
- * (`free_text_stop`, not `free_text_return`), so all N land in the
- * termination-sweep recovery cohort. `onRecovery` always extracts (no
- * min-token/min-tool gates), and `recoveryShape` selects the reap path under
- * test. The recovery prompt is a parameter so the pressure tests can make
- * Σ(prefill) dwarf the available headroom.
+ * Every agent drops to idle WITHOUT a voluntary result on its first stop
+ * (`free_text_stop`), so each is recovered: `parallel` injects the recovery turn
+ * IN-LOOP (handleRecover → SETTLE admission → bin-packed decode); `staggered`
+ * blocks via `recoverInline`. `reportBudget` is the FIXED per-report cap `b`.
  */
 function idleNoResultPolicy(
   shape: 'staggered' | 'parallel',
-  recoveryPrompt: { system: string; user: string },
+  reportBudget?: number,
 ): AgentPolicy {
   return {
     onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
     onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
-    onRecovery: () => ({ type: 'extract', prompt: recoveryPrompt }),
+    onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
     shouldExit: () => false,
     recoveryShape: shape,
-  };
-}
-
-/**
- * A `'parallel'` policy that records the per-report budget the fold hands each
- * agent — the fold's recovery pass calls `onRecovery(agent, pressure, b)` WITH a
- * budget, while the eligibility probe calls it WITHOUT one, so recording only the
- * defined-`budgetTokens` calls captures the fold's actual per-report budgets.
- * Optionally pins a fixed `reportBudget` (the low-effort path) instead of the
- * headroom-derived default.
- */
-function recordingParallelPolicy(sink: number[], reportBudget?: number): AgentPolicy {
-  return {
-    onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
-    onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
-    onRecovery: (_a, _pressure, budgetTokens) => {
-      if (budgetTokens !== undefined) sink.push(budgetTokens);
-      return { type: 'extract', prompt: { system: 's', user: 'u' } };
-    },
-    shouldExit: () => false,
-    recoveryShape: 'parallel',
     ...(reportBudget !== undefined ? { reportBudget } : {}),
   };
 }
 
-const recoveryPrefills = (r: PoolRun) =>
+// role='recovery' → the BLOCKING `recoverInline` path (staggered + the stall-break
+// fallback). role='toolResult' → the IN-LOOP recovery turn prefilled through SETTLE
+// (the parallel path). In these no-tool scenarios `toolResult` prefills are exactly
+// the in-loop recovery turns.
+const inlinePrefills = (r: PoolRun) =>
   r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
-const prefillCount = (r: PoolRun) =>
-  r.nativeCalls.filter(c => c.op === 'prefill').length;
+const inLoopPrefills = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'toolResult');
+const recoveryProduce = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'pool:recoveryProduce');
+const recoveryReturn = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'pool:recoveryReturn');
 
-// Each agent: main turn [1, STOP], then recovery decode [2, STOP]. The mock
-// emits non-JSON text from token 2 → recovery lands on `pool:recoveryFailed`
-// (we assert the batching *shape* + budget, not parse success — the mock can't
-// produce grammar-valid JSON, and ignores the maxLength grammar entirely).
+// Each agent: main turn [1, STOP], then a short recovery decode [1, STOP].
 const idleScriptsN = (n: number) =>
-  Array.from({ length: n }, () => ({ tokens: [1, STOP, 2, STOP], content: 'prose findings' }));
+  Array.from({ length: n }, () => ({ tokens: [1, STOP, 1, STOP], content: 'prose findings', toolCall: REPORT_CALL }));
 const idleScripts = () => idleScriptsN(N);
 
-// Group count of a parallel fold run, derived from the prefill delta vs a
-// staggered baseline: staggered does one recovery prefill per agent (M), the fold
-// does one per group (G), and root+spawn prefills (S) are identical between runs —
-// so prefillCount(par) − prefillCount(stag) = (S+G) − (S+M) = G − M.
-const groupCount = (par: PoolRun, stag: PoolRun, m: number) =>
-  prefillCount(par) - prefillCount(stag) + m;
-
 /**
- * Parallel recovery is a bounded FOLD: each step recovers the largest group of
- * the cohort that fits in current KV at a fixed per-report budget `b`, prunes it
- * (freeing KV), and recurses. `k` (group size) flexes 1..N with headroom — k=N
- * (one batched pass) when KV is ample, k=1 (one report at a time) when it's tight,
- * intermediate when moderate. The maxLength report cap itself is verified against
- * the real model (the grammar probe — `result ::= "\"" char{0,N} "\"" space`);
- * here the mock ignores the grammar, so we assert the fold's *packing* + *budget*.
+ * Parallel recovery is a turn (#77): a killed-without-result agent gets the
+ * recovery prompt injected IN-LOOP via the nudge/SETTLE path — prefilled as a
+ * `toolResult`, re-activated with the native terminal-tool grammar, and decoded
+ * BIN-PACKED in the tick loop alongside live siblings (one O(1) llama_decode per
+ * tick, regardless of how many recover at once). The per-report cap is the budget
+ * `b` (prompt advisory + token-stop), sized so the WHOLE cohort's prefill+decode
+ * fits headroom in one tick — so every reaped agent recovers, nothing is deferred or
+ * lost. `staggered` (high effort) is the lossless serial path — blocking
+ * `recoverInline`, uncapped — and is unchanged.
  */
-describe('scenario: parallel recovery (the fold)', () => {
-  it('packs the whole cohort into ONE batched pass when KV is ample (k=N)', async () => {
-    // Small recovery prompt + generous nCtx → all N reports fit at once, so the
-    // fold takes one group = one batched prefill. Same scripts/policy except the
-    // reap shape, so root + spawn prefills are identical between the two runs.
-    const prompt = { system: 's', user: 'u' };
-    const par = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
-    const stag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+describe('scenario: parallel recovery (in-loop via SETTLE)', () => {
+  it('recovers every parallel agent IN-LOOP via SETTLE — never the blocking recoverInline', async () => {
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0, scripts: idleScripts(),
+      policy: idleNoResultPolicy('parallel'),
+    });
 
-    // Both shapes recover every agent (one recovery prefill trace each).
-    expect(recoveryPrefills(par).length).toBe(N);
-    expect(recoveryPrefills(stag).length).toBe(N);
-
-    // THE batching proof: the only difference between the runs is the reap shape,
-    // so the fold collapsing N recovery prefills into one batched `store.prefill`
-    // shows up as exactly (N-1) fewer native prefill calls.
-    expect(prefillCount(par)).toBe(prefillCount(stag) - (N - 1));
-
-    // The batched decode holds the single-fiber invariant (the SEGV guard)…
-    expect(I1_nativeStoreSingleFiber(par).ok).toBe(true);
-    // …and every recovering agent still gets exactly one diagnostic (no loss).
-    expect(I29_recoveryDiagnostic(par).ok).toBe(true);
+    // Every agent's recovery turn was prefilled through SETTLE (role=toolResult)…
+    expect(inLoopPrefills(r).length).toBe(N);
+    // …and NONE went through the blocking private-loop recoverInline (role=recovery).
+    expect(inlinePrefills(r).length).toBe(0);
+    // Every agent extracted a result in-loop (no loss).
+    expect(recoveryProduce(r).length).toBe(N);
+    expect(recoveryReturn(r).length).toBe(N);
+    // The bin-packed decode holds the single-fiber invariant (the SEGV guard).
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
+    expect(r.result).toBeDefined();
   });
 
-  it('shrinks to k=1 under pressure — one report at a time, none lost', async () => {
-    // Huge recovery prompt → at most one (prompt + report) fits per step, so the
-    // fold groups into N singletons: same native-prefill count as staggered, but
-    // reached by the fold partitioning, not a binary gate. Prune-between frees KV
-    // for the next singleton; every report still lands.
-    const big = 'x'.repeat(4000); // ~1000 tokens each; ~3000 across the cohort
-    const prompt = { system: big, user: big };
-    const parPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('parallel', prompt) });
-    const stagPressure = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScripts(), policy: idleNoResultPolicy('staggered', prompt) });
+  it('stall-regression: a killed agent\'s recovery decodes bin-packed in a COMMIT with a LIVE sibling', async () => {
+    // Agent 0 keeps producing (the live sibling); agent 1 stops early and is
+    // recovered MID-RUN. The regression (the bug this whole change fixes): the old
+    // recoverInline ran agent 1's recovery in a private blocking loop that froze
+    // agent 0 for the duration. In-loop, agent 1's recovery tokens ride the tick's
+    // batched COMMIT *with* agent 0's live tokens — proven by a branchCount≥2 commit
+    // landing strictly inside agent 1's recovery window.
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: [
+        { tokens: [...Array(8).fill(1), STOP, 1, STOP], content: 'long live sibling', toolCall: REPORT_CALL },
+        { tokens: [1, STOP, 1, STOP], content: 'short recover me', toolCall: REPORT_CALL },
+      ],
+      policy: idleNoResultPolicy('parallel'),
+    });
 
-    // k=1 ⇒ the fold's per-step prefills match the staggered baseline (no N→1 collapse).
-    expect(prefillCount(parPressure)).toBe(prefillCount(stagPressure));
+    // The short agent recovers FIRST; derive its id from the first recovery-turn
+    // prefill (role=toolResult) rather than hardcoding a fork handle. Its recovery
+    // window runs from that prefill to its recovery extraction (pool:recoveryProduce).
+    const prefill = r.traceEvents.find(
+      e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'toolResult',
+    );
+    expect(prefill).toBeDefined();
+    const recoveringId = (prefill as { branchHandle: number }).branchHandle;
+    const produce = r.traceEvents.find(
+      e => e.type === 'pool:recoveryProduce' && (e as { agentId?: number }).agentId === recoveringId,
+    );
+    expect(produce).toBeDefined();
+    const tPrefill = (prefill as { ts: number }).ts;
+    const tProduce = (produce as { ts: number }).ts;
 
-    // Every agent still recovered — the grouping loses no reports.
-    expect(recoveryPrefills(parPressure).length).toBe(N);
-    expect(I29_recoveryDiagnostic(parPressure).ok).toBe(true);
+    // A batched commit (branchCount≥2 ⇒ recovering agent 1 + live agent 0 together)
+    // lands inside the window — recovery co-batched with the live sibling, no block.
+    const coBatched = r.nativeCalls.filter(
+      c => c.op === 'commit' && c.branchCount >= 2 && c.tStart > tPrefill && c.tStart < tProduce,
+    );
+    expect(coBatched.length).toBeGreaterThanOrEqual(1);
+
+    // And it never fell back to the blocking recoverInline path.
+    expect(inlinePrefills(r).length).toBe(0);
+    expect(recoveryReturn(r).some(e => (e as { agentId?: number }).agentId === recoveringId)).toBe(true);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
   });
 
-  it('folds into intermediate groups (1 < k < N) under moderate pressure — the partition branch', async () => {
-    // Headroom-derived budget: fitting all M at once is impossible (the prompts add
-    // overhead beyond the M×b the budget reserves), but several fit — so the fold
-    // takes a partial first group, then recovers the rest after pruning replenishes
-    // KV. This exercises the `used + cost > budget` break — the packing branch that
-    // k=N and k=1 never reach.
-    const M = 4;
-    const prompt = { system: 's', user: 'u' };
-    const par = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScriptsN(M), policy: idleNoResultPolicy('parallel', prompt) });
-    const stag = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: idleScriptsN(M), policy: idleNoResultPolicy('staggered', prompt) });
-
-    const groups = groupCount(par, stag, M);
-    expect(groups).toBeGreaterThan(1);   // not one all-at-once pass…
-    expect(groups).toBeLessThan(M);      // …and not M singletons either
-
-    // Every agent still recovered — partitioning loses nothing.
-    expect(recoveryPrefills(par).length).toBe(M);
-    expect(I29_recoveryDiagnostic(par).ok).toBe(true);
+  it('recovery budget draws from the hardLimit RESERVE, not softLimit (floor regression — a3 truncation)', async () => {
+    // The floor-fix: `b` = (remaining − hardLimit − …)/aliveCount, so a LARGE softLimit
+    // (the model NUDGE floor — no mechanical meaning for recovery) does NOT shrink the
+    // forced report. The OLD code drew from `remaining − softLimit`, so a big softLimit
+    // truncated recovery reports (the TC1 a3 "missing Moat #2"). Here softLimit=7000 sits
+    // far above hardLimit=512 with ~8k cells free: the budget reaches MAX (2048), proven by
+    // the token-stop landing at 2048 on an over-long recovery script. A softLimit-based
+    // floor would have starved it to ~500 — truncating the report.
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: [{ tokens: [1, STOP, ...Array(2100).fill(1), STOP], content: 'over-long recovery', toolCall: REPORT_CALL }],
+      policy: { ...idleNoResultPolicy('parallel'), pressureThresholds: { softLimit: 7000, hardLimit: 512 } },
+    });
+    expect(recoveryProduce(r).length).toBe(1);
+    // The cap landed at MAX (2048) — sized from the hardLimit reserve. The old softLimit
+    // floor would have produced ~500 here (remaining − softLimit, not remaining − hardLimit).
+    expect((recoveryProduce(r)[0] as { tokenCount: number }).tokenCount).toBe(2048);
+    expect(recoveryReturn(r).length).toBe(1);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
   });
 
-  it('budgets each report at a SHARE of KV, never the whole pool (the pool-wide-budget fix)', async () => {
-    // The bug the fold fixes: the old batched recovery told every concurrent agent
-    // it owned the full remaining KV → N reports collectively exhausted it. The fold
-    // passes a per-report budget `b` (a fair share of headroom) via the onRecovery
-    // override. Record what the fold hands each report and assert it's a share, not
-    // the pool. nCtx 4096 keeps the share below the MAX_REPORT_BUDGET cap so we see
-    // the division, not the clamp.
-    const foldBudgets: number[] = [];
-    const nCtx = 4096;
-    const run = await runPool({ nCtx, cellsUsed: 0, scripts: idleScripts(), policy: recordingParallelPolicy(foldBudgets) });
-
-    // Every agent was budgeted exactly once during the fold.
-    expect(foldBudgets.length).toBe(N);
-    // Each report's budget is a SHARE — comfortably under half the pool even at
-    // N=3 (it shrinks further as the cohort grows), and strictly positive. This is
-    // the structural fix: N concurrent reports can't collectively exhaust KV.
-    for (const b of foldBudgets) {
-      expect(b).toBeGreaterThan(0);
-      expect(b).toBeLessThan(nCtx / 2);
-    }
-    expect(I1_nativeStoreSingleFiber(run).ok).toBe(true);
+  it('reap UNDER negative headroom still recovers IN-LOOP from the hardLimit reserve (SETTLE-admission floor)', async () => {
+    // The production reap shape: an agent born with headroom (remaining > softLimit, so it
+    // passes the `pressure_init` spawn guard) RESEARCHES the KV down BELOW softLimit, then
+    // reaps and must recover. At reap `headroom = remaining − softLimit < 0`, so the OLD
+    // SETTLE gate (`cost > headroom`) DEFERS every recovery → stall-break → serial
+    // `recoverInline` (role=recovery). The NEW gate budgets extracting items against
+    // `headroom + reserveBand` (= remaining − hardLimit) → it ADMITS in-loop (role=toolResult).
+    // Born at remaining 3192 (> soft 3000); ~400 research commits drain it to ≈2750
+    // (headroom ≈ −250, but remaining − hardLimit ≈ 2240 — plenty for the report).
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 5000,
+      scripts: [{ tokens: [...Array(400).fill(1), STOP, 1, STOP], content: 'research then reap', toolCall: REPORT_CALL }],
+      policy: { ...idleNoResultPolicy('parallel'), pressureThresholds: { softLimit: 3000, hardLimit: 512 } },
+    });
+    // Recovered (no loss), IN-LOOP via SETTLE — NOT the serial recoverInline the old
+    // softLimit floor would have forced under this negative headroom.
+    expect(recoveryReturn(r).length).toBe(1);
+    expect(inLoopPrefills(r).length).toBeGreaterThanOrEqual(1);
+    expect(inlinePrefills(r).length).toBe(0);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
   });
 
-  it('honors an explicit reportBudget as a fixed cap, bypassing headroom division (the low-effort path)', async () => {
-    // With ample KV the headroom-derived budget would clamp to MAX_REPORT_BUDGET
-    // (2048); an explicit reportBudget must win verbatim so a `quick`-effort run gets
-    // the short reports it asked for regardless of how much KV happens to be free.
-    const foldBudgets: number[] = [];
-    await runPool({ nCtx: 8192, cellsUsed: 0, scripts: idleScripts(), policy: recordingParallelPolicy(foldBudgets, 256) });
-    expect(foldBudgets.length).toBe(N);
-    for (const b of foldBudgets) expect(b).toBe(256); // exact — not headroom-divided, not the 2048 cap
+  it('token-stop caps an over-long report at the fixed budget `b` (salvaged, not lost)', async () => {
+    // The cap that closes the deadlock: a non-compliant report that runs past its
+    // word advisory is force-finished at `b` tokens rather than decoding unbounded.
+    // reportBudget=4; the recovery script would emit 8 tokens, but the token-stop
+    // fires at 4 — and the partial report is still salvaged (no loss).
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: [{ tokens: [1, STOP, 1, 1, 1, 1, 1, 1, 1, 1, STOP], content: 'x', toolCall: REPORT_CALL }],
+      policy: idleNoResultPolicy('parallel', 4),
+    });
+    expect(inLoopPrefills(r).length).toBe(1);
+    // The report was cut at exactly the budget — not the 8 the script would produce.
+    expect((recoveryProduce(r)[0] as { tokenCount: number }).tokenCount).toBe(4);
+    // …and the (partial) call was still extracted — the cap bounds, never drops.
+    expect(recoveryReturn(r).length).toBe(1);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
   });
 
-  it('clamps the headroom-derived budget to MAX_REPORT_BUDGET (no report bloat under ample KV)', async () => {
-    // One agent + a large context → headroom/N would be many thousands of tokens;
-    // the fold caps it at MAX_REPORT_BUDGET (2048) so an early-Stop wind-down with
-    // plenty of KV still doesn't ask the model for an essay.
-    const foldBudgets: number[] = [];
-    await runPool({ nCtx: 16384, cellsUsed: 0, scripts: idleScriptsN(1), policy: recordingParallelPolicy(foldBudgets) });
-    expect(foldBudgets.length).toBe(1);
-    expect(foldBudgets[0]).toBe(2048); // MAX_REPORT_BUDGET ceiling
+  it('a simultaneous cohort reap recovers EVERY agent in-loop — adaptive `b` fits them all in one tick (loss regression)', async () => {
+    // The live failure this fix closes: a whole cohort hits the time limit on the SAME
+    // tick (the flat+medium run reaped 4 agents at 358s). The old SETTLE admission charged
+    // each recovery item (prompt + report-budget) against headroom and DEFERRED the
+    // overflow — and when the pool terminated after the admitted ones finished, the
+    // deferred agents' findings were LOST. Now `b` is sized in handleRecover so
+    // aliveCount·(prompt + b) ≤ headroom: the cohort's recovery turns all prefill + decode
+    // together in ONE batched tick (O(1) in branch count), nothing defers, nothing is lost.
+    // cellsUsed simulates a partly-filled KV so the adaptive sizing actually bites.
+    const r = await runPool({
+      nCtx: 4096, cellsUsed: 1024, scripts: idleScripts(),
+      policy: idleNoResultPolicy('parallel'), // ADAPTIVE budget — the production (low/med) path
+    });
+    expect(recoveryReturn(r).length).toBe(N);    // every agent recovered — ZERO loss (the headline)
+    expect(recoveryProduce(r).length).toBe(N);
+    expect(inLoopPrefills(r).length).toBe(N);     // …all in-loop in one tick (admitted together, not deferred)
+    expect(inlinePrefills(r).length).toBe(0);     // …never the serial recoverInline fallback
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
+    expect(r.result).toBeDefined();
+  });
+
+  it('salvages a TRUNCATED terminal call (token-stop mid-call) — clean result, no JSON wrapper', async () => {
+    // When the token-stop cuts mid-tool-call, parseChatOutput yields unclosed JSON
+    // (`{"result":"…partial`). extractTerminalResult must recover the `result` body
+    // and unescape it — NOT leak the `{"result":"` wrapper into the finding.
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: [{
+        tokens: [1, STOP, 1, STOP], content: 'x',
+        toolCall: { name: 'report', arguments: '{"result":"clean partial body' }, // truncated, no close
+      }],
+      policy: idleNoResultPolicy('parallel'),
+    });
+    const recovered = r.channelEvents.filter(e => e.type === 'agent:recovered');
+    expect(recovered.length).toBe(1);
+    expect((recovered[0] as { result: string }).result).toBe('clean partial body');
+  });
+
+  it('an extracting agent is EXEMPT from re-kill — its forced report is never lost mid-decode', async () => {
+    // The decision-boundary's lost-report failure mode: once an agent is producing
+    // its forced recovery report (extracting), a subsequent kill verdict must NOT
+    // reap it again — that would discard the very report recovery exists to save.
+    // `shouldExit: always` kills the agent on its first active tick (→ recovery),
+    // then keeps voting kill every tick; the extracting agent must ride through.
+    const alwaysExit: AgentPolicy = {
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+      shouldExit: () => true,
+      recoveryShape: 'parallel',
+    };
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: [{ tokens: [1, STOP], content: 'killed before producing', toolCall: REPORT_CALL }],
+      policy: alwaysExit,
+    });
+
+    // It entered recovery (in-loop) exactly once…
+    expect(inLoopPrefills(r).length).toBe(1);
+    // …was reaped exactly ONCE (the initial kill), never re-killed while extracting…
+    expect(r.traceEvents.filter(e => e.type === 'pool:agentDrop').length).toBe(1);
+    // …and its report survived to completion (not lost).
+    expect(recoveryReturn(r).length).toBe(1);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
+    expect(r.result).toBeDefined();
+  });
+
+  it('without an explicit reportBudget the cap ADAPTS to headroom ÷ live agents — more agents, shorter reports', async () => {
+    // The default cap is a fair share of CURRENT headroom across the live agents,
+    // not a fixed number: recovering alone licenses a longer report than recovering
+    // as one of many. A recovery that would run long is token-stopped at that
+    // adaptive `b`, so the per-report token count is strictly smaller with more
+    // co-alive agents. (No reportBudget → the adaptive path.)
+    const longRecovery = (n: number) =>
+      Array.from({ length: n }, () => ({ tokens: [1, STOP, ...Array(2200).fill(1), STOP], content: 'x', toolCall: REPORT_CALL }));
+    const solo = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: longRecovery(1), policy: idleNoResultPolicy('parallel') });
+    const crowd = await runPool({ nCtx: 4096, cellsUsed: 0, scripts: longRecovery(6), policy: idleNoResultPolicy('parallel') });
+    const soloCap = (recoveryProduce(solo)[0] as { tokenCount: number }).tokenCount;
+    const crowdCap = Math.min(...recoveryProduce(crowd).map(e => (e as { tokenCount: number }).tokenCount));
+    expect(crowdCap).toBeLessThan(soloCap); // headroom/6 < headroom/1
+    expect(recoveryReturn(crowd).length).toBe(6); // …and the whole crowd still recovered
+  });
+
+  it('staggered (high effort) recovers via the blocking recoverInline path, UNCAPPED (lossless) — unchanged', async () => {
+    // The lossless path: each report serializes through recoverInline and owns full
+    // headroom — NO token-stop, so even with a reportBudget set the report runs to
+    // its natural stop. This is what `parallel` trades away for responsiveness.
+    const r = await runPool({
+      nCtx: 8192, cellsUsed: 0,
+      scripts: Array.from({ length: N }, () => ({
+        tokens: [1, STOP, 1, 1, 1, 1, 1, 1, 1, 1, STOP], content: 'prose', toolCall: REPORT_CALL,
+      })),
+      policy: idleNoResultPolicy('staggered', 4), // budget set, but staggered ignores the token-stop
+    });
+
+    // Every agent recovered via recoverInline (role=recovery), none in-loop.
+    expect(inlinePrefills(r).length).toBe(N);
+    expect(inLoopPrefills(r).length).toBe(0);
+    // Uncapped: each report produced all 8 tokens (the full script), NOT cut at b=4.
+    for (const p of recoveryProduce(r)) expect((p as { tokenCount: number }).tokenCount).toBe(8);
+    expect(recoveryReturn(r).length).toBe(N);
+    expect(I1_nativeStoreSingleFiber(r).ok).toBe(true);
   });
 });

--- a/packages/agents/test/invariants/scenarios/recovery-agent-done-oneshot.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-agent-done-oneshot.scenario.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Invariant: `agent:done` fires EXACTLY ONCE per agent — including on the
+ * critical-kill → parallel-recovery → SETTLE-defer → stall-break path.
+ *
+ * Shape: a free-texting agent (recoveryShape 'parallel') crosses the hardLimit
+ * → `pressure.critical` kills it in PRODUCE, emitting `agent:done` (kill). The
+ * kill path calls `handleRecover`, which marks the agent `extracting` +
+ * `awaiting_tool` and queues a recovery turn. Under critical, that turn's SETTLE
+ * admission budget is `remaining − hardLimit < 0`, so it always DEFERS; with no
+ * active siblings the stall-break drop block runs.
+ *
+ * The bug: the stall-break drop emits `agent:done` a SECOND time — the
+ * `!a.extracting` guard sits AFTER the emit, so an already-extracting (already
+ * `agent:done`'d) agent is announced done twice. `agent-pool.test.ts:288`
+ * asserts `agent:done` is one-shot on the simple path; this locks it on the
+ * recovery path too.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool } from '../harness';
+
+describe('scenario: agent:done is one-shot through defer→stall-break recovery', () => {
+  it('critical kill → parallel recovery defers → stall-break does NOT re-emit agent:done', async () => {
+    // shouldExit OMITTED on purpose: `policyExit ?? pressure.critical` treats an
+    // explicit `false` as a veto (`false ?? x === false`), which would suppress the
+    // critical kill. Absent → `undefined ?? critical` → critical governs the kill.
+    // softLimit 20 (well below nCtx) so the agent is ADMITTED at spawn; hardLimit 512
+    // (== nBatch floor) is the kill floor that `critical` trips.
+    const policy: AgentPolicy = {
+      recoveryShape: 'parallel',
+      pressureThresholds: { softLimit: 20, hardLimit: 512 },
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+    };
+
+    // nCtx 700, default hardLimit 512: after root+suffix prefill (~31) + ~158
+    // committed tokens, remaining < 512 → pressure.critical fires. The agent emits
+    // no terminal call (no partialToolCall) → handleRecover, not salvage. Single
+    // agent → the deferred recovery reaches the stall-break with no active siblings.
+    const run = await runPool({
+      nCtx: 700,
+      cellsUsed: 0,
+      scripts: [{ tokens: [...Array.from({ length: 300 }, (_, i) => (i % 900) + 1), 999] }],
+      policy,
+      terminalToolName: 'report',
+    });
+
+    // Prove we exercised the critical-kill path (not a plain idle exit).
+    const drops = run.traceEvents.filter(e => e.type === 'pool:agentDrop');
+    expect(drops.some(d => (d as { reason?: string }).reason === 'pressure_critical')).toBe(true);
+
+    // INVARIANT: exactly one agent:done per agent (matches agent-pool.test.ts:288).
+    const doneByAgent = new Map<number, number>();
+    for (const e of run.channelEvents) {
+      if (e.type === 'agent:done') {
+        const id = (e as { agentId: number }).agentId;
+        doneByAgent.set(id, (doneByAgent.get(id) ?? 0) + 1);
+      }
+    }
+    expect(doneByAgent.size).toBeGreaterThanOrEqual(1); // the recovery agent went through
+    for (const [id, count] of doneByAgent) {
+      expect(count, `agent ${id} emitted agent:done ${count}×`).toBe(1);
+    }
+  });
+});

--- a/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
@@ -59,4 +59,35 @@ describe('scenario: recovery generates no terminal call', () => {
     expect(typeof f.outputExcerpt).toBe('string');
     expect(f.outputExcerpt.length).toBeGreaterThan(0);
   });
+
+  it('recovery output has only a NON-terminal call + terminalToolName set → no_terminal_call (Fix A)', async () => {
+    // shouldExit reaps the agent before any voluntary result → recovery runs. The recovery
+    // decode parses to a NON-terminal `web_search` call; with terminalToolName 'report',
+    // finishRecovery must NOT treat it as the report — require the terminal match, else fail.
+    // Pre-Fix-A: `?? toolCalls[0]` set the result from web_search's args → pool:recoveryReturn.
+    const policy: AgentPolicy = {
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+      shouldExit: () => true,
+    };
+
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 3000,
+      scripts: [{
+        tokens: [2, 3, STOP],
+        toolCall: { name: 'web_search', arguments: '{"query":"x"}' },
+      }],
+      policy,
+      terminalToolName: 'report',
+      maxTurns: 5,
+    });
+
+    const reports = run.traceEvents.filter(e => e.type === 'pool:recoveryReturn');
+    const failures = run.traceEvents.filter(e => e.type === 'pool:recoveryFailed');
+    expect(reports.length).toBe(0); // the non-terminal call must NOT be used as the report
+    expect(failures.length).toBeGreaterThanOrEqual(1);
+    expect((failures[0] as { reason: string }).reason).toMatch(/no_terminal_call/);
+  });
 });

--- a/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
@@ -1,45 +1,30 @@
 /**
- * Scenario: recoverInline produces unparseable output → pool:recoveryFailed
+ * Scenario: a recovery that yields no terminal-tool call → pool:recoveryFailed
  *
- * Shape: agent emits tool call, result oversized, policy says idle →
- * agent dropped → recoverInline runs → produces a non-JSON string →
- * JSON.parse throws → failure is visible in the trace (not silent).
+ * Shape: agent free-texts (no voluntary terminal call), policy says idle → agent
+ * dropped → recoverInline runs → the recovery decode produces output that
+ * parseChatOutput finds NO terminal call in → finishRecovery reports the failure
+ * (not silent).
  *
  * What this locks:
  *   - I29: recovery diagnostic completeness. Every recovery attempt that
- *     prefills a recovery prompt must terminate with exactly one of
+ *     prefills a recovery prompt terminates with exactly one of
  *     `pool:recoveryReturn` or `pool:recoveryFailed`.
- *   - Failure reason + output excerpt are captured so ops can diagnose
- *     why a recovery failed without re-running the job.
+ *   - Failure reason + output excerpt are captured so ops can diagnose a failed
+ *     recovery without re-running the job. The reason is `no_terminal_call` —
+ *     the native tool-call path (parseChatOutput) found no call to extract,
+ *     NOT a hand-rolled JSON.parse error.
  */
 import { describe, it, expect } from 'vitest';
-import { Tool } from '../../../src/Tool';
-import type { Operation } from 'effection';
-import type { JsonSchema } from '../../../src/types';
 import type { AgentPolicy } from '../../../src/AgentPolicy';
 import { runPool, STOP } from '../harness';
 
-class BigResultTool extends Tool<{ query: string }> {
-  readonly name = 'web_search';
-  readonly description = 'returns a fixed big payload';
-  readonly parameters: JsonSchema = { type: 'object', properties: { query: { type: 'string' } } };
-  *execute(): Operation<unknown> {
-    return { results: ['x'.repeat(8000)] };
-  }
-}
-
-describe('scenario: recovery generates unparseable output', () => {
-  it('drop → recoverInline produces non-JSON → pool:recoveryFailed with excerpt', async () => {
-    const tools = new Map<string, Tool>([['web_search', new BigResultTool()]]);
-
+describe('scenario: recovery generates no terminal call', () => {
+  it('drop → recoverInline output has no terminal call → pool:recoveryFailed with excerpt', async () => {
     const policy: AgentPolicy = {
-      onProduced: (_a, parsed) => {
-        if (parsed.toolCalls.length > 0) return { type: 'tool_call', tc: parsed.toolCalls[0] };
-        return { type: 'idle', reason: 'free_text_stop' };
-      },
-      // Policy chooses idle drop over nudge, forcing recoverInline to run.
+      // Free-text every turn → idle drop → recoverInline runs (default staggered).
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
       onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
-      // Recovery is enabled (not skip) so the produce/commit loop runs.
       onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
       shouldExit: () => false,
     };
@@ -47,20 +32,16 @@ describe('scenario: recovery generates unparseable output', () => {
     const run = await runPool({
       nCtx: 4096,
       cellsUsed: 3000,
-      // Script: [1, STOP] for the initial turn, then [2, 3, STOP] for
-      // the recovery produce loop. MockSessionContext.tokenToText emits
-      // "t2", "t3" — concatenates to "t2t3", which is not JSON.
-      scripts: [{
-        tokens: [1, STOP, 2, 3, STOP],
-        toolCall: { name: 'web_search', arguments: '{"query":"q"}' },
-      }],
+      // [1, STOP] initial turn → idle → recoverInline; [2, 3, STOP] recovery decode.
+      // The script declares NO toolCall, so the mock's parseChatOutput returns no
+      // terminal call for the recovery output → finishRecovery fails (not silent).
+      scripts: [{ tokens: [1, STOP, 2, 3, STOP], content: 'unparseable prose' }],
       policy,
-      tools,
       terminalToolName: 'report',
       maxTurns: 5,
     });
 
-    // Recovery prefill happened.
+    // Recovery prefill happened (the blocking recoverInline path, role=recovery).
     const recoveryPrefills = run.traceEvents.filter(
       e => e.type === 'branch:prefill' && (e as any).role === 'recovery',
     );
@@ -71,10 +52,10 @@ describe('scenario: recovery generates unparseable output', () => {
     const failures = run.traceEvents.filter(e => e.type === 'pool:recoveryFailed');
     expect(reports.length + failures.length).toBe(recoveryPrefills.length);
 
-    // This specific run must have produced a failure (non-JSON output).
+    // This run must have produced a failure (no terminal call in the output).
     expect(failures.length).toBeGreaterThanOrEqual(1);
     const f = failures[0] as any;
-    expect(f.reason).toMatch(/parse_error/);
+    expect(f.reason).toMatch(/no_terminal_call/);
     expect(typeof f.outputExcerpt).toBe('string');
     expect(f.outputExcerpt.length).toBeGreaterThan(0);
   });

--- a/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-fails.scenario.test.ts
@@ -58,6 +58,13 @@ describe('scenario: recovery generates no terminal call', () => {
     expect(f.reason).toMatch(/no_terminal_call/);
     expect(typeof f.outputExcerpt).toBe('string');
     expect(f.outputExcerpt.length).toBeGreaterThan(0);
+
+    // The failure is announced on the CHANNEL too (`agent:failed`), not just the
+    // trace — the UI consumes `agent:failed` to leave the "writing report" state.
+    // (Deleting the emit would keep the trace assertions above green but hang the UI.)
+    const channelFailed = run.channelEvents.filter(e => e.type === 'agent:failed');
+    expect(channelFailed.length).toBe(failures.length);
+    expect((channelFailed[0] as { reason: string }).reason).toMatch(/no_terminal_call/);
   });
 
   it('recovery output has only a NON-terminal call + terminalToolName set → no_terminal_call (Fix A)', async () => {

--- a/packages/agents/test/invariants/scenarios/recovery-oom-no-orphan.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-oom-no-orphan.scenario.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Invariant: a decode OOM during in-loop (parallel) recovery does NOT orphan the
+ * in-flight extractor.
+ *
+ * The COMMIT batch where admitted reports decode can throw (KV exhausted by
+ * concurrent reports). The pool then tears down — but each in-flight extractor
+ * must FIRST receive a terminal `agent:failed`, else the UI spins forever on
+ * "writing report". The blocking `recoverInline` path has its own `scope_error`
+ * catch; this locks the same guarantee for the in-loop COMMIT path.
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+
+describe('scenario: in-loop recovery decode OOM emits agent:failed (no orphan)', () => {
+  it('COMMIT throw while an extractor is mid-report → agent:failed for it, then propagate', async () => {
+    const policy: AgentPolicy = {
+      recoveryShape: 'parallel',
+      pressureThresholds: { softLimit: 20, hardLimit: 512 },
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'extract', prompt: { system: 's', user: 'u' } }),
+    };
+
+    // Loose KV (nCtx 8000): free-text turn 1 (`1, 2, STOP`) → idle → `handleRecover`
+    // (parallel) → the recovery is ADMITTED at SETTLE (fits, not deferred) → agent
+    // re-activates as an in-loop extractor → its report (`3, 4, 777`) decodes in the
+    // tick loop's COMMIT. The 777 sentinel makes that commit throw (mock decode OOM)
+    // while the agent is `extracting` + `active`.
+    const run = await runPool({
+      nCtx: 8000,
+      cellsUsed: 0,
+      scripts: [{ tokens: [1, 2, STOP, 3, 4, 777, STOP] }],
+      policy,
+      terminalToolName: 'report',
+      instrument: (ctx) => { ctx.throwOnCommitToken = 777; },
+      captureError: true, // the decode OOM is swallowed by the pool scope; keep the run inspectable
+    });
+
+    // The in-flight extractor got a terminal `agent:failed` (reason `scope_error`) at the
+    // failing COMMIT — the pool scope then swallows the decode error and closes gracefully,
+    // but the extractor is NOT orphaned mid-report (which the UI renders as a stuck spinner).
+    // Without the COMMIT guard, the decode error unwinds with no terminal event for it.
+    const failed = run.channelEvents.filter(e => e.type === 'agent:failed');
+    expect(failed.length).toBeGreaterThanOrEqual(1);
+    expect(String((failed[0] as { reason: string }).reason)).toMatch(/scope_error/);
+    // No `agent:recovered` for it — the report never completed (the decode threw first).
+    expect(run.channelEvents.some(e => e.type === 'agent:recovered')).toBe(false);
+  });
+});

--- a/packages/agents/test/invariants/scenarios/recovery-skip-terminal.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/recovery-skip-terminal.scenario.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Invariant: a SKIPPED recovery still emits a terminal event, so the agent isn't orphaned.
+ *
+ * `onRecovery` returns `{type:'skip'}` when the policy judges the agent too thin to force a
+ * report (DefaultAgentPolicy skips below its minTokens/minToolCalls floor — the real-world
+ * trigger: a runaway agent nudged off before it made ≥2 tool calls). `agent:done` ALREADY
+ * fired at the drop, so without a follow-up terminal event the consumer orphans the agent —
+ * an eternal "recovering" state whose card sits on its last "Thought" row (no report ever
+ * streams) with a timer that never freezes.
+ *
+ * Locks: every agent that got `agent:done` gets a resolving terminal event, even on skip
+ * (both `handleRecover`, parallel, and `recoverInline`, staggered).
+ */
+import { describe, it, expect } from 'vitest';
+import type { AgentPolicy } from '../../../src/AgentPolicy';
+import { runPool, STOP } from '../harness';
+
+describe('scenario: skipped recovery emits agent:failed (no orphan)', () => {
+  it('drop → onRecovery skip → agent:failed (recovery_skipped), not silence', async () => {
+    const policy: AgentPolicy = {
+      recoveryShape: 'parallel',
+      onProduced: () => ({ type: 'idle', reason: 'free_text_stop' }),
+      onSettleReject: () => ({ type: 'idle', reason: 'pressure_settle_reject' }),
+      onRecovery: () => ({ type: 'skip' }), // force the skip the research policy hit in the wild
+    };
+
+    // Free-text turn 1 (`1, 2, STOP`) → onProduced idle → the parallel idle path emits
+    // agent:done then calls handleRecover → onRecovery skip.
+    const run = await runPool({
+      nCtx: 4096,
+      cellsUsed: 0,
+      scripts: [{ tokens: [1, 2, STOP], content: 'thin output' }],
+      policy,
+      terminalToolName: 'report',
+    });
+
+    const done = run.channelEvents.filter(e => e.type === 'agent:done');
+    const failed = run.channelEvents.filter(e => e.type === 'agent:failed');
+    // agent:done fired once at the drop; the skip must be followed by a terminal agent:failed
+    // (pre-fix: handleRecover returned null silently → failed.length === 0 → orphan).
+    expect(done.length).toBe(1);
+    expect(failed.length).toBe(1);
+    expect((failed[0] as { reason: string }).reason).toBe('recovery_skipped');
+    // No agent:recovered — there is no report (correct; the agent was too thin to extract).
+    expect(run.channelEvents.some(e => e.type === 'agent:recovered')).toBe(false);
+  });
+});

--- a/packages/agents/test/invariants/scenarios/wind-down.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/wind-down.scenario.test.ts
@@ -32,13 +32,16 @@ const windDownDrops = (r: PoolRun) =>
   r.traceEvents.filter(e => e.type === 'pool:agentDrop' && (e as { reason?: string }).reason === 'wind_down');
 const recoveryPrefills = (r: PoolRun) =>
   r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'recovery');
+// role='toolResult' prefills are the IN-LOOP recovery turns (handleRecover → SETTLE);
+// in these no-tool scenarios they are exactly the in-loop reaps.
+const inLoopPrefills = (r: PoolRun) =>
+  r.traceEvents.filter(e => e.type === 'branch:prefill' && (e as { role?: string }).role === 'toolResult');
 const spawnEvents = (r: PoolRun) =>
   r.channelEvents.filter(e => e.type === 'agent:spawn');
-const prefillCount = (r: PoolRun) => r.nativeCalls.filter(c => c.op === 'prefill').length;
 const onFirstSpawn = (ev: { type: string }) => ev.type === 'agent:spawn';
 
 describe('scenario: graceful wind-down (drain)', () => {
-  it('reaps the whole active cohort on WindDown and recovers via the fold', async () => {
+  it('reaps the whole active cohort on WindDown and recovers them in-loop', async () => {
     const run = await runPool({
       nCtx: 8192, cellsUsed: 0,
       scripts: activeScriptsN(N),
@@ -48,31 +51,33 @@ describe('scenario: graceful wind-down (drain)', () => {
     // Every active agent was reaped SPECIFICALLY by wind-down (a distinct reason
     // from pressure/time/maxTurns), and reaped in one tick (no stagger).
     expect(windDownDrops(run).length).toBe(N);
-    // Every reaped agent was recovered (idle-no-result → onRecovery extract).
-    expect(recoveryPrefills(run).length).toBe(N);
-    // The batched recovery decode holds the single-fiber SEGV invariant.
+    // Every reaped agent had its recovery turn injected IN-LOOP (handleRecover →
+    // SETTLE, role=toolResult) — wind-down always bin-packs the drain.
+    expect(inLoopPrefills(run).length).toBe(N);
+    // The bin-packed recovery decode holds the single-fiber SEGV invariant.
     expect(I1_nativeStoreSingleFiber(run).ok).toBe(true);
     // The run terminated cleanly with a result.
     expect(run.result).toBeDefined();
   });
 
-  it('FORCES the fold even when recoveryShape is staggered (wind-down overrides the shape)', async () => {
+  it('FORCES in-loop recovery even when recoveryShape is staggered (wind-down overrides the shape)', async () => {
     const windStag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('staggered'), windDownAfter: onFirstSpawn });
     const windPar  = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('parallel'),  windDownAfter: onFirstSpawn });
     // Baseline: the SAME staggered policy WITHOUT wind-down — agents run to STOP,
-    // land idle-no-result, and the sweep recovers them one-at-a-time (staggered).
+    // land idle-no-result, and the termination sweep recovers them one-at-a-time
+    // through the BLOCKING recoverInline (role=recovery, zero in-loop prefills).
     const baseStag = await runPool({ nCtx: 8192, cellsUsed: 0, scripts: activeScriptsN(N), policy: activePolicy('staggered') });
 
-    // All three recover every agent…
-    expect(recoveryPrefills(windStag).length).toBe(N);
-    expect(recoveryPrefills(windPar).length).toBe(N);
-    expect(recoveryPrefills(baseStag).length).toBe(N);
+    // Wind-down — staggered shape AND parallel shape alike — injects every reap's
+    // recovery turn IN-LOOP (role=toolResult): the staggered shape was overridden.
+    expect(inLoopPrefills(windStag).length).toBe(N);
+    expect(inLoopPrefills(windPar).length).toBe(N);
 
-    // …but wind-down with the STAGGERED shape takes the SAME native-prefill path
-    // as the PARALLEL shape (it folded), and strictly FEWER prefills than the
-    // staggered baseline that actually staggered. ⇒ wind-down forced the fold.
-    expect(prefillCount(windStag)).toBe(prefillCount(windPar));
-    expect(prefillCount(windStag)).toBeLessThan(prefillCount(baseStag));
+    // The staggered baseline (no wind-down) takes the blocking path instead — NO
+    // in-loop recovery turns, every recovery via recoverInline. That contrast is
+    // the proof wind-down forced the in-loop shape regardless of the policy.
+    expect(inLoopPrefills(baseStag).length).toBe(0);
+    expect(recoveryPrefills(baseStag).length).toBe(N);
   });
 
   it('leaves an agent mid-terminal-tool to finish its voluntary report; reaps its free-text sibling', async () => {

--- a/packages/sdk/src/deltas.ts
+++ b/packages/sdk/src/deltas.ts
@@ -40,7 +40,8 @@ export interface DeltaOpts {
  *
  * @param ctx - Active session context
  * @param content - User message content
- * @param opts - Optional tools JSON for tool-aware formatting + thinking flag
+ * @param opts - Optional tools JSON for tool-aware formatting, an optional
+ *   `system` message to lead the turn (default empty), + the thinking flag
  * @returns Token array ready for `branch.prefill()`
  *
  * @category Agents
@@ -48,14 +49,14 @@ export interface DeltaOpts {
 export function buildUserDelta(
   ctx: SessionContext,
   content: string,
-  opts: { tools?: string } & DeltaOpts = {}
+  opts: { tools?: string; system?: string } & DeltaOpts = {}
 ): number[] {
   const sep = ctx.getTurnSeparator();
   const fmtOpts: Record<string, unknown> = {};
   if (opts.tools) fmtOpts.tools = opts.tools;
   if (opts.enableThinking !== undefined) fmtOpts.enableThinking = opts.enableThinking;
   const { prompt } = ctx.formatChatSync(
-    JSON.stringify([{ role: 'system', content: '' }, { role: 'user', content }]),
+    JSON.stringify([{ role: 'system', content: opts.system ?? '' }, { role: 'user', content }]),
     fmtOpts
   );
   const delta = ctx.tokenizeSync(prompt, false);


### PR DESCRIPTION
…dge/SETTLE path

Replace the post-loop recoverParallel/recoverGroup fold with recovery as a turn: a reaped agent's forced report is injected as a turn (buildUserDelta), routed through the nudge/SETTLE path and decoded bin-packed in the tick loop alongside live siblings. Native tool-call grammar (buildTerminalGrammar = formatChat auto, eager); finishRecovery extracts via parseChatOutput and salvages a truncated call. recoveryShape selects parallel (flat low/med) vs staggered (high/deep) recoverInline.

Hardening:
- Budget from the hardLimit reserve, not headroom. Size the per-report budget b and the SETTLE admission against remaining − hardLimit (the reserve the wrap-up nudge and recoverInline already use). softLimit is advisory, so recovery decodes the soft band down to hardLimit; the old headroom floor starved it (b → MIN, spurious deferral, truncated/lost reports). Cap = markExtracting(b) + a PRODUCE token-stop.
- agent:failed — the terminal twin of agent:recovered, emitted on both failure paths so the UI clears the spinner instead of hanging.
- Salvage on critical kill — an agent force-killed while already emitting the terminal tool salvages its in-flight report (finishRecovery on rawOutput, parse-only) instead of getting a fresh recovery turn that restarts and re-decodes into the dead KV. The kill still fires; only the recovery routing differs.