### PR TITLE
chore(release): agents 3.2.0 + rig 3.1.2 (lloyal.node ^3.0.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "packages/apps/*"
       ],
       "devDependencies": {
-        "@lloyal-labs/lloyal.node": "^3.0.0",
+        "@lloyal-labs/lloyal.node": "^3.0.1",
         "@types/node": "^25.3.0",
         "@types/react": "^18.3.28",
         "@types/semver": "^7.7.1",
@@ -83,9 +83,9 @@
       "link": true
     },
     "node_modules/@lloyal-labs/lloyal.node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node/-/lloyal.node-3.0.0.tgz",
-      "integrity": "sha512-nJxhI1qwQ+T8tkz0kjgcy9fw+iOS3yrtwxb0Pt6pJAPSNuTRzLGhJ4Fg/W3nvHfkEGdgG2ABoO31JbFakrUVdg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node/-/lloyal.node-3.0.1.tgz",
+      "integrity": "sha512-/pbKM33l3afhz4CgfWeBAwVIUmDBtuvAU5agUFCwBWMnjeTj1GuGZOXWr7JNOYmseYblUVM/L6bybFgz+r2MEw==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/tsampler": "^0.2.0",
@@ -95,19 +95,19 @@
         "node": ">=22.0.0"
       },
       "optionalDependencies": {
-        "@lloyal-labs/lloyal.node-darwin-arm64": "3.0.0",
-        "@lloyal-labs/lloyal.node-darwin-x64": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-arm64": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-arm64-cuda": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-arm64-vulkan": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-x64": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-x64-cuda": "3.0.0",
-        "@lloyal-labs/lloyal.node-linux-x64-vulkan": "3.0.0",
-        "@lloyal-labs/lloyal.node-win32-arm64": "3.0.0",
-        "@lloyal-labs/lloyal.node-win32-arm64-vulkan": "3.0.0",
-        "@lloyal-labs/lloyal.node-win32-x64": "3.0.0",
-        "@lloyal-labs/lloyal.node-win32-x64-cuda": "3.0.0",
-        "@lloyal-labs/lloyal.node-win32-x64-vulkan": "3.0.0"
+        "@lloyal-labs/lloyal.node-darwin-arm64": "3.0.1",
+        "@lloyal-labs/lloyal.node-darwin-x64": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-arm64": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-arm64-cuda": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-arm64-vulkan": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-x64": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-x64-cuda": "3.0.1",
+        "@lloyal-labs/lloyal.node-linux-x64-vulkan": "3.0.1",
+        "@lloyal-labs/lloyal.node-win32-arm64": "3.0.1",
+        "@lloyal-labs/lloyal.node-win32-arm64-vulkan": "3.0.1",
+        "@lloyal-labs/lloyal.node-win32-x64": "3.0.1",
+        "@lloyal-labs/lloyal.node-win32-x64-cuda": "3.0.1",
+        "@lloyal-labs/lloyal.node-win32-x64-vulkan": "3.0.1"
       },
       "peerDependencies": {
         "@lloyal-labs/lloyal-agents": ">=3.0.0",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@lloyal-labs/lloyal.node-darwin-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-arm64/-/lloyal.node-darwin-arm64-3.0.0.tgz",
-      "integrity": "sha512-1JTMt/EtQej45S8cZm0UPwDupAXhxx0UNhNSSV994Q4FGd04qeUXyQKFHzvL+isZZ6XzOg+exHYAP28lqyiEtg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-arm64/-/lloyal.node-darwin-arm64-3.0.1.tgz",
+      "integrity": "sha512-yPCvk8/hhjcEPCoeJFbWjGVpqemXulzQpMz/RkaeJ4P2+o6MtxqneDuPdWA5OnSm7QVqVO21XtNqbmoLbiolUQ==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +128,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-darwin-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-x64/-/lloyal.node-darwin-x64-3.0.0.tgz",
-      "integrity": "sha512-iq3tc+WN2qg7Z0FzNaRowKpkgspL05QNyMAd33CAwHGVkhhtL27ON7Xf8fEUnVJGo2MMdwHWcwivCIT7yKOJdQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-x64/-/lloyal.node-darwin-x64-3.0.1.tgz",
+      "integrity": "sha512-ul9Z4oFFUBY3DNjoSTaTKfTzivnH0m4DmaDf8aUGm8Broj4VuOWUSLiYgzekNhrRL25vHXOun9f+OFneLPRszA==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64/-/lloyal.node-linux-arm64-3.0.0.tgz",
-      "integrity": "sha512-XzATPYjgo4km40pRhKfow9lYmOYSkdIaMSlJvJhE7zbei0o2x8irUctW88LF4RlGRbQqOXj6t8XY+lKopyH9cQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64/-/lloyal.node-linux-arm64-3.0.1.tgz",
+      "integrity": "sha512-569V7Em1TkwcWzcbSWb7owBE+dwASuXC4+TwFb5VQii6QJJYLDqu3PrVPEHLVdCqzJKVXOGGcobi0/Hb7/+fkA==",
       "cpu": [
         "arm64"
       ],
@@ -154,9 +154,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64-cuda": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-cuda/-/lloyal.node-linux-arm64-cuda-3.0.0.tgz",
-      "integrity": "sha512-RQmtileNAVPlYQbCiX+HhpA8rc1axYMOUmCBPimv50NbuHlTXMrbOhWZUg3aO97uX4pRtP/QJcczfMxMAi83og==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-cuda/-/lloyal.node-linux-arm64-cuda-3.0.1.tgz",
+      "integrity": "sha512-mk2tZpH6k/Nz9i6A5Tc0SxnPcybQ9Mc0ux8c8KhfZuKhEBNAh7UuWPJSqy8TBBqBS+f7G7gr5AxuvFyZ0QyI5A==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +167,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64-vulkan": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-vulkan/-/lloyal.node-linux-arm64-vulkan-3.0.0.tgz",
-      "integrity": "sha512-YUI2onJ9ZfvysfkYG7IKtjVo25DqAJFQW30ltTH9Kl2RGWya7Bl/xwZiLTF+IWgesQWY1vPTOCH7pVqfjGfvjw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-vulkan/-/lloyal.node-linux-arm64-vulkan-3.0.1.tgz",
+      "integrity": "sha512-4uXaiXQBglLU+yv0cH3HSNu4pnFoMcVRwwh0t2PnNE6QsobRPFktDmlVLkK8AJLCpybdsLcHx8pDStXKi89zJQ==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +180,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64/-/lloyal.node-linux-x64-3.0.0.tgz",
-      "integrity": "sha512-vYo3uAsTzp8z4swhfF5kZGuVCEqKU6jeSx3YP24GPCgZYkdQUmOgcPe6jI7Ul1ddBhVfrIv/vM295EkUS9ebSA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64/-/lloyal.node-linux-x64-3.0.1.tgz",
+      "integrity": "sha512-A0PNRALoMQG/dA98TgLMTqR5U1UE9+CAoY8TglEaZ9+foYn8Mxa4Y8FS/1PWlmG3cREB3E0Dbsz//vbu9uIq4A==",
       "cpu": [
         "x64"
       ],
@@ -193,9 +193,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64-cuda": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-cuda/-/lloyal.node-linux-x64-cuda-3.0.0.tgz",
-      "integrity": "sha512-tS5ye5Gzlf5nEFiyUIDirpGz8Ibgiimvld9bOVKEf41AVd4t/bSZH+GKpL2jdZ7ilQx9iBAxmWPWEUQc5cfVOg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-cuda/-/lloyal.node-linux-x64-cuda-3.0.1.tgz",
+      "integrity": "sha512-LuvIjxgaGbAVV3i0fK/AV4qFBBfutx9/OpDQXkWgA2fubnrcmry2wpK5w6vcn/fggCCZumWjpBp6A5FVKWOCCQ==",
       "cpu": [
         "x64"
       ],
@@ -206,9 +206,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64-vulkan": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-vulkan/-/lloyal.node-linux-x64-vulkan-3.0.0.tgz",
-      "integrity": "sha512-GhlKOop5rR38tTy/QWL4yOv5V8FaPCQtXQquLkkT4TTAcbS+HTlxZFKZiNeqPLcJyVA0g7kLT7pnJAErI91Eyw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-vulkan/-/lloyal.node-linux-x64-vulkan-3.0.1.tgz",
+      "integrity": "sha512-9vL4SFx91X/7a+/ddt1/RlDarMN7TU+77ksZszbOi/cvUL//dAyN24pfHhyqgOexZ0nUMtM6n9UZll8Tuexy/Q==",
       "cpu": [
         "x64"
       ],
@@ -219,9 +219,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-arm64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64/-/lloyal.node-win32-arm64-3.0.0.tgz",
-      "integrity": "sha512-R+0C38/z6zS4z4cNNGtZb3pSbk9nYtRCW4VD3XdHq3ILf3xb/fFcCtzOmrd1Pqzyl3lqHJVuA7kRSRX3vpL0Qg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64/-/lloyal.node-win32-arm64-3.0.1.tgz",
+      "integrity": "sha512-S4CWVsorqSPiHtJ7LV6NyIUi50defdnHsDZRkwwgndBU994EXwRIVSExUNm9TEiZXmiW5gfiffAKH/M1InzCwQ==",
       "cpu": [
         "arm64"
       ],
@@ -232,9 +232,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-arm64-vulkan": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64-vulkan/-/lloyal.node-win32-arm64-vulkan-3.0.0.tgz",
-      "integrity": "sha512-y14uSBz4YBO8NsAKjvmCIKRHSsEEHRBCeDzKzdCKOEBhlZDrhipbpEWZ2jyfyUTuyFHUoUOfw0WpMBsMaxmDMQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64-vulkan/-/lloyal.node-win32-arm64-vulkan-3.0.1.tgz",
+      "integrity": "sha512-5VI6TRddb8ixwd4MThARhqkZr+oy2B/zZxWO4uSlhiBY9fJG90Hoa7xUcVAd7tfQRns2YvuyMNGV2/jtBg8Lcw==",
       "cpu": [
         "arm64"
       ],
@@ -245,9 +245,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64/-/lloyal.node-win32-x64-3.0.0.tgz",
-      "integrity": "sha512-hLlzoXvPgw5lNPPld4lYjMiZ0A8gF2TLVH6Z0QN2nicqPdX4lV3TmXe2qB+ZLdYHOMO81swnyMOO6nrSeaLxbg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64/-/lloyal.node-win32-x64-3.0.1.tgz",
+      "integrity": "sha512-oVpuIHD7VPua/iqdjSFkbFPyGGKU68Pujz9SOFvTWgIjRNXE+hvDzMu7dtVat0m9jhTnkrQm8K4ReXhLT5yEXg==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +258,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64-cuda": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-cuda/-/lloyal.node-win32-x64-cuda-3.0.0.tgz",
-      "integrity": "sha512-XI0gbjKWmxk0UduSe9Mn3lET7fxO7jHsQkUlOlUYsv2IpuCt8A2xdzBCAwprNCN7R1Ol1dTdMDT90mkI88Mx+A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-cuda/-/lloyal.node-win32-x64-cuda-3.0.1.tgz",
+      "integrity": "sha512-wpe9FMnM8B5CeZ1PCwVx/TBHH/ipFK4zwBwC0B6cpUBReePx2KMsIWeynDovrw6vPcZALbAiyNwtCY8vPbyhHw==",
       "cpu": [
         "x64"
       ],
@@ -271,9 +271,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64-vulkan": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-vulkan/-/lloyal.node-win32-x64-vulkan-3.0.0.tgz",
-      "integrity": "sha512-2xW9RHcwwrT527//FxX4e7YoNziIvJxkFQ+Qf49IsRu9hPUjBdMGW9GNryqOI1uu1SS4NxUfAQkNb5JKtehPEw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-vulkan/-/lloyal.node-win32-x64-vulkan-3.0.1.tgz",
+      "integrity": "sha512-YfENkq5+SuNGtxKgsbXhRCCTYsqfbMUFLfmy0i/V7iivNWGKm+4qXWcnIlMYlEcGIF/7FMY5GeRMYde5lLE7Xw==",
       "cpu": [
         "x64"
       ],
@@ -2500,7 +2500,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -2556,7 +2556,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",
@@ -2568,7 +2568,7 @@
         "semver": "^7.8.1"
       },
       "peerDependencies": {
-        "@lloyal-labs/lloyal.node": "^3.0.0"
+        "@lloyal-labs/lloyal.node": "^3.0.1"
       }
     },
     "packages/sdk": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "examples:reflect": "npx tsx examples/reflection/main.ts"
   },
   "devDependencies": {
-    "@lloyal-labs/lloyal.node": "^3.0.0",
+    "@lloyal-labs/lloyal.node": "^3.0.1",
     "@types/node": "^25.3.0",
     "@types/react": "^18.3.28",
     "@types/semver": "^7.7.1",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/lloyal-agents",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Multi-agent inference inside the decode loop — structured concurrency over shared KV state",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,7 +49,7 @@
     "semver": "^7.8.1"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal.node": "^3.0.0"
+    "@lloyal-labs/lloyal.node": "^3.0.1"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Release bump for the merged cancellation + recovery-as-turn work (#26) and to require the lloyal.node 3.0.1 native fixes.

## Versions
- **`@lloyal-labs/lloyal-agents` 3.1.1 → 3.2.0** — minor: new `CancelAgent` public API (per-agent cancel) + recovery-as-turn + skip-orphan + cancel-discard hardening (#26).
- **`@lloyal-labs/rig` 3.1.1 → 3.1.2** — raises the lloyal.node **peer** floor `^3.0.0 → ^3.0.1` (native fixes; rig is the only HDK package that runtime-imports lloyal.node — `createContext`/`loadBinary`).
- **root devDep + lockfile → lloyal.node 3.0.1** — main package + all 13 platform packages re-pinned off 3.0.0.

`@lloyal-labs/sdk` (3.0.3) and `harness.dev` (0.5.0) are unchanged — `release.yml` skips already-published versions.

## Release
Tag the merge commit `vX.Y.Z` (`v*`) → `release.yml` publishes agents@3.2.0 + rig@3.1.2, skips sdk/harness.dev.

## Notes
- No direct lloyal.node dependency anywhere in the published HDK; the only coupling is rig's peer. Consumers (e.g. Artifact) pick the concrete lloyal.node version via their own direct dep + lockfile.
- Build green, 400 agents+rig tests pass.