### PR TITLE
docs(agents,cli): fix stale docstrings + scaffold pin to match current API

### DIFF
--- a/packages/agents/src/agent-pool.ts
+++ b/packages/agents/src/agent-pool.ts
@@ -697,18 +697,26 @@ function* setupAgent(
 /**
  * Concurrent agent generation loop as an Effection resource
  *
- * Runs N agents in parallel using a four-phase tick loop over shared
+ * Runs N agents in parallel using a phased tick loop over shared
  * {@link BranchStore} infrastructure. Each agent forks from a parent
  * branch, generates tokens, invokes tools, and reports findings.
  *
- * **Four-phase tick loop:**
- * 1. **PRODUCE** — sample all active agents via `produceSync()` (no async gap)
- * 2. **COMMIT** — single GPU call via `store.commit()` for all produced tokens
- * 3. **SETTLE** — drain settled tool results, batch prefill, reset grammars
- * 4. **DISPATCH** — execute collected tool calls sequentially via `scoped()` + `call()`
+ * **Tick loop (per tick):** SPAWN+EXTEND (drain queued spawns/extends +
+ * pending cancels) → PRODUCE (sample all active agents via `produceSync()`,
+ * no async gap) → COMMIT (single `store.commit()` for all produced tokens) →
+ * DRAIN (post-process completed fan-out tool results) → SETTLE (drain settled
+ * tool results, batch prefill, reset grammars) → DISPATCH (execute collected
+ * tool calls).
  *
- * Tool dispatch uses `scoped()` + `call()` — each tool executes to completion
- * before the next tick, ensuring exclusive `llama_context` access (no concurrent decode).
+ * **Dispatch is per-agent serial, inter-agent concurrent.** Each agent has at
+ * most one tool in flight — PRODUCE emits one call, then parks the agent
+ * `awaiting_tool` until its result settles (the barrier that yields the
+ * decision boundary). Inline tools run on this loop fiber, so `llama_context`
+ * access is exclusive by single-fiber discipline. A `Tool.fanout` tool runs
+ * OFF the loop fiber (bounded by a permit gate), issues no main-context op,
+ * and has its result tokenized/prefilled later in DRAIN + SETTLE on the loop
+ * fiber — so the store is only ever touched from the tick loop, never
+ * concurrently.
  *
  * **Resource semantics:** `provide()` suspends after all agents complete,
  * keeping branches alive so the caller can fork from them (e.g. for

--- a/packages/agents/src/app-types.ts
+++ b/packages/agents/src/app-types.ts
@@ -243,8 +243,9 @@ export interface App {
 
 /**
  * A zero-arg Operation that constructs an {@link App}. This — not a
- * constructed `App` — is what the registry consumes (`createAppRegistry({
- * apps })` at boot, or `registry.enable(factory)` dynamically): the
+ * constructed `App` — is what the registry consumes via
+ * `registry.enable(factory)` (the one enable path, whether at boot or
+ * dynamically): the
  * registry runs the factory inside a per-app **detached** Effection scope
  * that it seeds with `AppConfigStoreCtx` / `AppRegistryCtx` / `RerankerCtx`,
  * so the factory reads its config and reranker, does any setup, and returns
@@ -262,8 +263,8 @@ export interface App {
  * Apps installed via `harness.dev install` (signed npm tarballs from
  * the canonical channel) export a factory of this exact shape from
  * their package entry point — the harness imports it with a plain
- * `import { createXxxApp } from '@lloyal-labs/<name>-app'` and passes
- * it to `createAppRegistry({ apps: [...] })`.
+ * `import { createXxxApp } from '@lloyal-labs/<name>-app'` and enables
+ * it with `registry.enable(createXxxApp)`.
  */
 export type AppFactory = () => Operation<App>;
 
@@ -287,11 +288,12 @@ export type AppState = 'enabled' | 'disabled';
  * enable/disable are methods on this interface.
  *
  * Registry state is the single source of truth for which apps are
- * enabled within a harness scope. The harness declares its boot set
- * via `createAppRegistry({ apps })`; each app runs in its own detached
- * Effection scope. `disable` (or registry scope-exit) tears that scope
- * down, firing the app factory's `ensure(...)` teardown. There are no
- * install/uninstall hooks.
+ * enabled within a harness scope. `createAppRegistry({ configStore })`
+ * returns an empty registry; the harness enables its boot set with a
+ * `registry.enable(factory)` call per app, each running in its own
+ * detached Effection scope. `disable` (or registry scope-exit) tears that
+ * scope down, firing the app factory's `ensure(...)` teardown. There are
+ * no install/uninstall hooks.
  */
 export interface AppRegistry {
   /**
@@ -318,7 +320,7 @@ export interface AppRegistry {
    * validates the manifest, and adds it. Returns the constructed App.
    * Throws — and tears down the partial scope — if the factory
    * throws, validation fails, or the name is already enabled. The boot
-   * set is enabled the same way via `createAppRegistry({ apps })`.
+   * set is enabled the same way — a `registry.enable(factory)` call per app.
    */
   enable(factory: AppFactory): Operation<App>;
   /**

--- a/packages/harness-cli/templates/harness/package.json
+++ b/packages/harness-cli/templates/harness/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@lloyal-labs/lloyal-agents": "^3.0.0",
-    "@lloyal-labs/lloyal.node": "^2.1.0",
+    "@lloyal-labs/lloyal.node": "^3.0.1",
     "@lloyal-labs/rig": "^3.0.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.0.0.tgz",


### PR DESCRIPTION
Doc-comment + scaffold-template drift surfaced while reconciling hdk-docs against current source. **Comment/template only — no runtime change.**

- **`agent-pool.ts` header docstring** — described a "four-phase tick loop" ending in "DISPATCH … execute collected tool calls sequentially … ensuring exclusive `llama_context` access (no concurrent decode)." That's the pre-#19 model. Rewritten to **target-dispatch fan-out**: per-agent serial / inter-agent concurrent (`Tool.fanout` off the loop fiber, bounded by a permit gate), plus the DRAIN + cancel-drain sub-steps. The per-agent barrier (what actually yields the decision boundary) is now stated explicitly.
- **`app-types.ts`** — four docstrings claimed `createAppRegistry({ apps })` / `{ apps: [...] }`. The real `CreateAppRegistryOpts` is `{ configStore, grantStore? }` (no `apps`); the registry is created empty and each app enabled via `registry.enable(factory)`. Corrected.
- **`harness-cli` scaffold template** — `@lloyal-labs/lloyal.node` pinned `^2.1.0`; bumped to `^3.0.1` to match the rig peer floor (agents/rig/sdk in the template are already `^3.0.0`).

Verified: `npm run build` green across all workspaces.