### PR TITLE
chore(release): harness.dev 0.5.1 — ship the scaffold template fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2545,7 +2545,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "license": "Apache-2.0",
       "bin": {
         "harness.dev": "dist/cli.js"

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "dist/cli.js"


### PR DESCRIPTION
The published `harness.dev@0.5.0` scaffold is broken: its generated `package.json` pins `@lloyal-labs/lloyal.node ^2.1.0`, which conflicts with rig 3.x's peer floor `^3.0.1` — a fresh `npx harness.dev <name> && npm install` fails with **ERESOLVE** (verified against the live npm artifact; with the #30 template fix swapped in, the same install resolves cleanly — 72 packages, zero conflicts).

#30 fixed the template but didn't bump the CLI version, so tagging now would hit release.yml's idempotent skip (`harness.dev@0.5.0 already published`). This PR:

- `packages/harness-cli/package.json` — 0.5.0 → **0.5.1**
- `package-lock.json` — reconcile the workspace entry to 0.5.1

Verified: `npm run build` green; `npm pack --dry-run` includes `templates/**` with the `^3.0.1` pin.

**After merge:** tag the merge commit (`v0.5.1-cli`) → release.yml publishes `harness.dev@0.5.1` (sdk/agents/rig unchanged, skipped idempotently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)