### PR TITLE
chore(apps): web + corpus 1.2.0 — first channel release carrying Tool.fanout

### DIFF
--- a/packages/apps/corpus/package.json
+++ b/packages/apps/corpus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/corpus-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "HDK reference app \u2014 local-corpus research (Source + tools + contract). Distributed via the signed-bundle channel, never public npm.",
   "license": "SEE LICENSE IN LICENSE",

--- a/packages/apps/web/package.json
+++ b/packages/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/web-app",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "description": "HDK reference app \u2014 web research (Source + tools + contract). Distributed via the signed-bundle channel, never public npm.",
   "license": "SEE LICENSE IN LICENSE",


### PR DESCRIPTION
The published `lloyal__{web,corpus}-1.1.0.tgz` on the channel predate target-dispatch — zero `fanout` refs — so **channel consumers get inline-serial tool execution even on agents 3.2.0**. Verified end-to-end in reasoning.run (installs faithfully from the channel): trace shows 0 overlapping dispatches and 0 decode-side events while any tool call is open. Artifact only exhibits concurrent tools via a locally-built `node_modules` that diverges from its own lockfile.

This PR is just the version bump 1.1.0 → 1.2.0 (the fanout source has been in-tree since 3.2; no publishable artifact existed because the version never moved). Publish + review-approve happen via `harness.dev publish` / `review` after merge — TTY-gated, not CI.

Never republish a version in place: sha512 immutability means both consumers' lockfiles would EINTEGRITY on changed 1.1.0 bytes.

Closes the app-side half of the pending "re-publish first-party apps" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)