### PR TITLE
fix(rig): lazy parseMarkdown binding load (3.1.3)

### DIFF
--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/resources/files.ts
+++ b/packages/rig/src/resources/files.ts
@@ -10,9 +10,17 @@ interface Section {
   startLine: number;
   endLine: number;
 }
-const { parseMarkdown } = loadBinary() as unknown as {
-  parseMarkdown(text: string): Section[];
-};
+// Lazy: loading the native binding at module scope would bind the GPU
+// variant from whatever raw LLOYAL_GPU exists at import time — before the
+// consumer has resolved/sanitized its config — and eagerly loads a binary
+// even for processes that never chunk a corpus. Defer to first use.
+let _parseMarkdown: ((text: string) => Section[]) | null = null;
+function parseMarkdown(text: string): Section[] {
+  _parseMarkdown ??= (
+    loadBinary() as unknown as { parseMarkdown(text: string): Section[] }
+  ).parseMarkdown;
+  return _parseMarkdown(text);
+}
 
 /** Pattern accepted in glob inputs — tail must be `.md`, `.mdx`, or
  *  `.{md,mdx}` (with optional ordering / overlap variants). Anything else


### PR DESCRIPTION
Importing rig loaded the native lloyal.node binding at module scope (`resources/files.ts` destructured `parseMarkdown` from `loadBinary()` at top level). That binds the GPU variant from whatever raw `LLOYAL_GPU` exists at import time — before any consumer config resolution — producing a spurious loader fallback warning when the env value is invalid/overridden, a wasted second binding load when the consumer's contexts select a different variant, and an eager dylib load even in processes that never chunk a corpus.

Now lazy with a memo: the binding loads on the first `parseMarkdown` call, after consumer config has settled. Found while tracing env-sanitization order in [reasoning-run#4](https://github.com/lloyal-ai/reasoning-run/pull/4)'s review.

`npm run test:unit`: 472 passed (rig's chunking tests exercise the lazy path). Version → 3.1.3; tag `v3.2.1`-style release flow after merge as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)