### PR TITLE
chore: lloyal.node devDependency ^3.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "packages/apps/*"
       ],
       "devDependencies": {
-        "@lloyal-labs/lloyal.node": "^3.0.1",
+        "@lloyal-labs/lloyal.node": "^3.1.1",
         "@types/node": "^25.3.0",
         "@types/react": "^18.3.28",
         "@types/semver": "^7.7.1",
@@ -83,31 +83,31 @@
       "link": true
     },
     "node_modules/@lloyal-labs/lloyal.node": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node/-/lloyal.node-3.0.1.tgz",
-      "integrity": "sha512-/pbKM33l3afhz4CgfWeBAwVIUmDBtuvAU5agUFCwBWMnjeTj1GuGZOXWr7JNOYmseYblUVM/L6bybFgz+r2MEw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node/-/lloyal.node-3.1.1.tgz",
+      "integrity": "sha512-+eAtY0G2uWESW1d7GZPlQATl2gLatwdlv6mgXwi0WAD0M5esQz2KdIHz8Vjc3JaFp7md6qclWfrA0txtMUhuhg==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/tsampler": "^0.2.0",
         "node-addon-api": "^8.5.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       },
       "optionalDependencies": {
-        "@lloyal-labs/lloyal.node-darwin-arm64": "3.0.1",
-        "@lloyal-labs/lloyal.node-darwin-x64": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-arm64": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-arm64-cuda": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-arm64-vulkan": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-x64": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-x64-cuda": "3.0.1",
-        "@lloyal-labs/lloyal.node-linux-x64-vulkan": "3.0.1",
-        "@lloyal-labs/lloyal.node-win32-arm64": "3.0.1",
-        "@lloyal-labs/lloyal.node-win32-arm64-vulkan": "3.0.1",
-        "@lloyal-labs/lloyal.node-win32-x64": "3.0.1",
-        "@lloyal-labs/lloyal.node-win32-x64-cuda": "3.0.1",
-        "@lloyal-labs/lloyal.node-win32-x64-vulkan": "3.0.1"
+        "@lloyal-labs/lloyal.node-darwin-arm64": "3.1.1",
+        "@lloyal-labs/lloyal.node-darwin-x64": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-arm64": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-arm64-cuda": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-arm64-vulkan": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-x64": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-x64-cuda": "3.1.1",
+        "@lloyal-labs/lloyal.node-linux-x64-vulkan": "3.1.1",
+        "@lloyal-labs/lloyal.node-win32-arm64": "3.1.1",
+        "@lloyal-labs/lloyal.node-win32-arm64-vulkan": "3.1.1",
+        "@lloyal-labs/lloyal.node-win32-x64": "3.1.1",
+        "@lloyal-labs/lloyal.node-win32-x64-cuda": "3.1.1",
+        "@lloyal-labs/lloyal.node-win32-x64-vulkan": "3.1.1"
       },
       "peerDependencies": {
         "@lloyal-labs/lloyal-agents": ">=3.0.0",
@@ -115,9 +115,9 @@
       }
     },
     "node_modules/@lloyal-labs/lloyal.node-darwin-arm64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-arm64/-/lloyal.node-darwin-arm64-3.0.1.tgz",
-      "integrity": "sha512-yPCvk8/hhjcEPCoeJFbWjGVpqemXulzQpMz/RkaeJ4P2+o6MtxqneDuPdWA5OnSm7QVqVO21XtNqbmoLbiolUQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-arm64/-/lloyal.node-darwin-arm64-3.1.1.tgz",
+      "integrity": "sha512-RQnGfmDMSLsGZY1SSHxp+Qm5T895XBbRJD3CXMcwEjTRIIsucsJVYjJO/FihW4sLM7zcPepeyAVMYMmiLp5c6w==",
       "cpu": [
         "arm64"
       ],
@@ -128,9 +128,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-darwin-x64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-x64/-/lloyal.node-darwin-x64-3.0.1.tgz",
-      "integrity": "sha512-ul9Z4oFFUBY3DNjoSTaTKfTzivnH0m4DmaDf8aUGm8Broj4VuOWUSLiYgzekNhrRL25vHXOun9f+OFneLPRszA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-darwin-x64/-/lloyal.node-darwin-x64-3.1.1.tgz",
+      "integrity": "sha512-tDV0ju2Uz5ThmheI8YWdPL24rLVE52ZslnjjXADf9nt8zfx3rOrpm+VKI4zezEo7/oMWotIffOzlYz4X7WG38w==",
       "cpu": [
         "x64"
       ],
@@ -141,9 +141,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64/-/lloyal.node-linux-arm64-3.0.1.tgz",
-      "integrity": "sha512-569V7Em1TkwcWzcbSWb7owBE+dwASuXC4+TwFb5VQii6QJJYLDqu3PrVPEHLVdCqzJKVXOGGcobi0/Hb7/+fkA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64/-/lloyal.node-linux-arm64-3.1.1.tgz",
+      "integrity": "sha512-ou1LzcF2qrd1i4nIIMggWmKaeVCkjeyhrY/jmtkwe6OW0Hk3ojC8AxOS2d/WtOYr1/Pwkb320YAhTksiwhvqbg==",
       "cpu": [
         "arm64"
       ],
@@ -154,9 +154,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64-cuda": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-cuda/-/lloyal.node-linux-arm64-cuda-3.0.1.tgz",
-      "integrity": "sha512-mk2tZpH6k/Nz9i6A5Tc0SxnPcybQ9Mc0ux8c8KhfZuKhEBNAh7UuWPJSqy8TBBqBS+f7G7gr5AxuvFyZ0QyI5A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-cuda/-/lloyal.node-linux-arm64-cuda-3.1.1.tgz",
+      "integrity": "sha512-QdysfkocSDZQgIcv//gTKFMUdn/58zq98mH4mfTvm1tvRO5SGYPns4g4w3XLeL33DyRsqM+ze/0QrEaEGz5NAQ==",
       "cpu": [
         "arm64"
       ],
@@ -167,9 +167,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-arm64-vulkan": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-vulkan/-/lloyal.node-linux-arm64-vulkan-3.0.1.tgz",
-      "integrity": "sha512-4uXaiXQBglLU+yv0cH3HSNu4pnFoMcVRwwh0t2PnNE6QsobRPFktDmlVLkK8AJLCpybdsLcHx8pDStXKi89zJQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-arm64-vulkan/-/lloyal.node-linux-arm64-vulkan-3.1.1.tgz",
+      "integrity": "sha512-NG202IhvDlYwK0f/qGguMLiy9bIyzm7igiakXEchf1p6fEAOUuQnqPqYztMX2t1aC4wXqmYst9RKu8R0lolhMw==",
       "cpu": [
         "arm64"
       ],
@@ -180,9 +180,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64/-/lloyal.node-linux-x64-3.0.1.tgz",
-      "integrity": "sha512-A0PNRALoMQG/dA98TgLMTqR5U1UE9+CAoY8TglEaZ9+foYn8Mxa4Y8FS/1PWlmG3cREB3E0Dbsz//vbu9uIq4A==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64/-/lloyal.node-linux-x64-3.1.1.tgz",
+      "integrity": "sha512-dwlXj7LvoRrHAsMH2938Uh2iJFuVuiKtYjVFflrLXjkMmPGG7ekwlOc8OZLyCJQe1R1n1cjQGHpxfjvLPzlKcw==",
       "cpu": [
         "x64"
       ],
@@ -193,9 +193,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64-cuda": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-cuda/-/lloyal.node-linux-x64-cuda-3.0.1.tgz",
-      "integrity": "sha512-LuvIjxgaGbAVV3i0fK/AV4qFBBfutx9/OpDQXkWgA2fubnrcmry2wpK5w6vcn/fggCCZumWjpBp6A5FVKWOCCQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-cuda/-/lloyal.node-linux-x64-cuda-3.1.1.tgz",
+      "integrity": "sha512-jTnGn8bQfK51IQ7TftoFh59mO/HQ078b3uZ+ZHfjaLrt1Cg+/D+rUBHNXCqlAWMwLG5L/F3m33KTBCGpH2dW5g==",
       "cpu": [
         "x64"
       ],
@@ -206,9 +206,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-linux-x64-vulkan": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-vulkan/-/lloyal.node-linux-x64-vulkan-3.0.1.tgz",
-      "integrity": "sha512-9vL4SFx91X/7a+/ddt1/RlDarMN7TU+77ksZszbOi/cvUL//dAyN24pfHhyqgOexZ0nUMtM6n9UZll8Tuexy/Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-linux-x64-vulkan/-/lloyal.node-linux-x64-vulkan-3.1.1.tgz",
+      "integrity": "sha512-RZjFAgChDBuzrLqHvXrOwsWZLtODUHNxOXKQ+JYXzo2zw9BMzcKCLJzkIViCty75xRrCEBMg/IHFXrbs0MKrGQ==",
       "cpu": [
         "x64"
       ],
@@ -219,9 +219,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-arm64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64/-/lloyal.node-win32-arm64-3.0.1.tgz",
-      "integrity": "sha512-S4CWVsorqSPiHtJ7LV6NyIUi50defdnHsDZRkwwgndBU994EXwRIVSExUNm9TEiZXmiW5gfiffAKH/M1InzCwQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64/-/lloyal.node-win32-arm64-3.1.1.tgz",
+      "integrity": "sha512-iHGfbAUVtxqyKpJFAZGwqo20wu6vAVRLY/V40dBIxmKWMbZtGxEezhqFSTBdDbD59wQrpUDZ490RZ7Whn8e2wg==",
       "cpu": [
         "arm64"
       ],
@@ -232,9 +232,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-arm64-vulkan": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64-vulkan/-/lloyal.node-win32-arm64-vulkan-3.0.1.tgz",
-      "integrity": "sha512-5VI6TRddb8ixwd4MThARhqkZr+oy2B/zZxWO4uSlhiBY9fJG90Hoa7xUcVAd7tfQRns2YvuyMNGV2/jtBg8Lcw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-arm64-vulkan/-/lloyal.node-win32-arm64-vulkan-3.1.1.tgz",
+      "integrity": "sha512-ESRHX6czTovG7ILqXA7B5DRuhFmOOxripEOIfiwAbw3fAKYIlfrzdukKhDzTnW0oP8vcaLNQz9LuMwVLFjS1uw==",
       "cpu": [
         "arm64"
       ],
@@ -245,9 +245,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64/-/lloyal.node-win32-x64-3.0.1.tgz",
-      "integrity": "sha512-oVpuIHD7VPua/iqdjSFkbFPyGGKU68Pujz9SOFvTWgIjRNXE+hvDzMu7dtVat0m9jhTnkrQm8K4ReXhLT5yEXg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64/-/lloyal.node-win32-x64-3.1.1.tgz",
+      "integrity": "sha512-55MaHQpyMe5lUOCvRD/xBl5/Vg9Qp8mkHsKnL6w+8QJqlvErfnv3aX6ktcj1GNfu5Pj0IzsQn8N3/GF3wVj+Kw==",
       "cpu": [
         "x64"
       ],
@@ -258,9 +258,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64-cuda": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-cuda/-/lloyal.node-win32-x64-cuda-3.0.1.tgz",
-      "integrity": "sha512-wpe9FMnM8B5CeZ1PCwVx/TBHH/ipFK4zwBwC0B6cpUBReePx2KMsIWeynDovrw6vPcZALbAiyNwtCY8vPbyhHw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-cuda/-/lloyal.node-win32-x64-cuda-3.1.1.tgz",
+      "integrity": "sha512-DHcykhe3XqicgbWDwnHE2kkU+QdJd5d9amRrYOrLSwJtZttOqBi02WSHMPcRmEgORnmrLKNkhScKAxw57nSw0Q==",
       "cpu": [
         "x64"
       ],
@@ -271,9 +271,9 @@
       ]
     },
     "node_modules/@lloyal-labs/lloyal.node-win32-x64-vulkan": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-vulkan/-/lloyal.node-win32-x64-vulkan-3.0.1.tgz",
-      "integrity": "sha512-YfENkq5+SuNGtxKgsbXhRCCTYsqfbMUFLfmy0i/V7iivNWGKm+4qXWcnIlMYlEcGIF/7FMY5GeRMYde5lLE7Xw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@lloyal-labs/lloyal.node-win32-x64-vulkan/-/lloyal.node-win32-x64-vulkan-3.1.1.tgz",
+      "integrity": "sha512-CjVQs/OkIWC7f7PfBVoCtskuTs0orgpTcGIJajnU2+GZRg17gsOHJ6A3kmPEvDV2AjAIShGPAZTZAtCEY3pnKg==",
       "cpu": [
         "x64"
       ],

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "examples:reflect": "npx tsx examples/reflection/main.ts"
   },
   "devDependencies": {
-    "@lloyal-labs/lloyal.node": "^3.0.1",
+    "@lloyal-labs/lloyal.node": "^3.1.1",
     "@types/node": "^25.3.0",
     "@types/react": "^18.3.28",
     "@types/semver": "^7.7.1",


### PR DESCRIPTION
PR-5 (part 1) of the BACKEND_DL arc: dev-environment bump to the first lloyal.node with the DL channel (`probeBackendPack`/`ensureBackendPack` exports, `engines >=24`, signed pack live on apps.lloyal.ai).

No code changes — packages/* remain backend-blind by design (verified by the original arc sweep). rig's peerDependency range `^3.0.1` already admits 3.1.1, so consumers are unaffected.

Gates: `npm install` + `npm run build` + `npm run test:unit` green against installed 3.1.1.
