### PR TITLE
feat(binding): @lloyal-labs/binding — the harness's headless interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "packages/agents",
         "packages/sdk",
         "packages/rig",
+        "packages/binding",
         "packages/harness-cli",
         "packages/apps/*"
       ],
@@ -73,6 +74,10 @@
       "version": "1.5.5",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@lloyal-labs/binding": {
+      "resolved": "packages/binding",
+      "link": true
     },
     "node_modules/@lloyal-labs/corpus-app": {
       "resolved": "packages/apps/corpus",
@@ -2542,6 +2547,11 @@
         "@lloyal-labs/rig": "^3.0.0",
         "effection": "^4.0.2"
       }
+    },
+    "packages/binding": {
+      "name": "@lloyal-labs/binding",
+      "version": "0.1.0",
+      "license": "SEE LICENSE IN LICENSE"
     },
     "packages/harness-cli": {
       "name": "harness.dev",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "packages/agents",
     "packages/sdk",
     "packages/rig",
+    "packages/binding",
     "packages/harness-cli",
     "packages/apps/*"
   ],

--- a/packages/binding/LICENSE
+++ b/packages/binding/LICENSE
@@ -1,0 +1,107 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 Lloyal Labs
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publish, and distribute the
+Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A "Permitted Purpose" is any purpose other than a Competing Use. A
+"Competing Use" means making the Software available to others in a
+commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a Licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives
+of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND,
+INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO
+THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software
+under the Apache License, Version 2.0 that is effective on the second
+anniversary of the date we make the Software available. On or after that
+date, you may use the Software under the Apache License, Version 2.0, in
+which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/binding/LICENSE-FAQ.md
+++ b/packages/binding/LICENSE-FAQ.md
@@ -1,0 +1,256 @@
+# Licensing FAQ
+
+> Canonical version at https://docs.lloyal.ai/licensing/faq.
+> This file is a synced copy. Edit the canonical source and re-run
+> `scripts/sync-license-faq.sh` in lloyal-sdk to update all copies.
+
+
+**You can build and sell commercial products using HDK.**
+
+> HDK is free to build products with; it is not free to become the
+> replacement HDK platform.
+
+That single sentence is the entire restriction reduced to one line. The rest
+of this page is illustration.
+
+## The short version
+
+HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
+packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
+
+Each version converts to Apache 2.0 two years after its release. The
+restriction during those two years is narrow: **you cannot offer a competing
+HDK runtime, a managed HDK service, or an alternative HDK App distribution
+channel.** Everything else — commercial use, redistribution, modification,
+sale, embedding in shipped products — is freely permitted.
+
+The reason the channel restriction exists is consumer-protective: every App
+listed on `apps.lloyal.ai` is reviewed by Lloyal Labs for tool-safety,
+manifest conformance, and signature provenance before publication. Pinning
+the App ecosystem to one verified channel keeps the AI-safety review meaningful
+(consumers can rely on a single trust boundary) and prevents protocol
+fragmentation (an App that works on one harness works on every harness).
+
+The `harness.dev` CLI and `hdk-create-app` scaffolder are licensed under
+**Apache 2.0** (unrestricted). They're not part of the runtime stack.
+
+## Can I ship a commercial product built on HDK?
+
+**Yes.** This is the question everyone has and the answer is straightforward.
+Concretely:
+
+- **Shipping a paid intelligent inbox app to consumers** — permitted ✅
+- **Selling an Excel-with-AI desktop app to enterprises** — permitted ✅
+- **Embedding HDK in a medical device sold commercially** — permitted ✅
+- **A consulting firm building a custom intelligent harness for a Fortune
+  500 client, charging $500K for the engagement, deploying on client
+  infrastructure** — permitted ✅
+- **An indie dev shipping a paid productivity app on the Mac App Store** —
+  permitted ✅
+- **An OEM shipping HDK inside an infotainment system or industrial device**
+  — permitted ✅
+- **A startup building an end-user product on top of HDK** — including
+  vertical research apps, workflow tools, and agent applications — permitted
+  ✅, *as long as the product is not offering HDK itself as a substitute
+  runtime, managed HDK service, or competing App distribution channel*.
+- **A research lab using HDK in published academic work** — permitted ✅
+- **Forking HDK on GitHub to learn, modify, demo, or contribute** — permitted ✅
+- **Running HDK internally inside your company for any business use** —
+  permitted ✅
+
+If you are building something *with* HDK, you are almost certainly fine.
+
+## What is actually restricted?
+
+The restriction is narrow and specific: **don't become the replacement
+platform vendor**. Concretely:
+
+- **AWS / Google / Microsoft launching "Bedrock Managed HDK" or "Vertex HDK"
+  as a hosted runtime service** — restricted ❌
+- **A competitor publishing "OpenHDK" as a forked harness runtime under a
+  different name** — restricted ❌
+- **A clean-room reimplementation of the HDK runtime in Python / Rust / Go
+  intended as a drop-in replacement** — restricted ❌ (Competing Use doesn't
+  require forking source code — a reimplementation that competes is the
+  same problem)
+- **Launching `apps.competitor.com` as an alternative HDK App distribution
+  channel** — restricted ❌
+- **Offering "managed HDK hosting" or "HDK-as-a-Service" as a competing
+  SaaS** — restricted ❌
+- **A hosted orchestration service exposing HDK-compatible APIs as a
+  substitute for the HDK runtime** — restricted ❌
+
+Notice the pattern: every restricted scenario is "become the platform
+vendor," not "build products with HDK." If your project doesn't compete
+directly with the HDK runtime or its distribution channel, FSL doesn't
+affect you.
+
+## Why does the LICENSE list four narrow Permitted Purposes then?
+
+You may read the FSL LICENSE and see this section:
+
+> Permitted Purposes specifically include using the Software:
+> 1. for your internal use and access;
+> 2. for non-commercial education;
+> 3. for non-commercial research; and
+> 4. in connection with professional services that you provide to a
+>    Licensee using the Software in accordance with these Terms and
+>    Conditions.
+
+A careful first reading can mistake this list for the *exclusive* set of
+permitted uses — leading to the (incorrect) conclusion that commercial
+product distribution is prohibited.
+
+It isn't. **The operative definition is broader.** Earlier in the same
+section, the license states:
+
+> A "Permitted Purpose" is any purpose other than a Competing Use.
+
+The four enumerated items are **illustrative examples** added because those
+specific cases are ones a careful reader might otherwise hesitate about
+("is research permitted? is consulting permitted?"). The four items are
+additive clarifications, not a closing of the open-ended definition.
+
+Sentry, who authored FSL and uses it on their own software, [confirms this
+explicitly in their FAQ](https://fsl.software):
+
+> "You can do anything with FSL software except undermine its producer. You
+> can run it for almost all purposes, study it, modify it, and distribute
+> your changes…"
+
+If the license felt restrictive on first read, that's a documented
+[FSL adoption hazard](https://fair.io) — many developers hit the same wall.
+The answer is to read the "any purpose other than a Competing Use" line as
+the operative definition and treat the four enumerated items as examples,
+not as a closed list.
+
+## Will it become Apache 2.0?
+
+**Yes — automatically, on a per-version schedule.** Each released version of
+the runtime stack converts to Apache 2.0 exactly two years after its release
+date. The conversion is irrevocable and written into the license text — it's
+not a promise from Lloyal Labs, it's a contractual clause.
+
+For example: if `lloyal-sdk @lloyal-labs/lloyal-agents` v3.0.0 is released
+on 2026-06-01, that exact version becomes available under Apache 2.0 on
+2028-06-01. Any consumer can elect to use that version under Apache 2.0
+from that date forward — Lloyal Labs takes no action; the grant is
+automatic.
+
+New versions released after v3.0.0 start their own two-year clock from
+their own release dates. There is no single global Change Date.
+
+## Is this OSI-approved open source?
+
+**No, and we want to be honest about that.** FSL is not OSI-approved
+because the OSI definition of open source (clause 6, "No Discrimination
+Against Fields of Endeavor") does not permit restrictions on specific
+use cases. FSL restricts Competing Use. That restriction takes it out of
+strict OSI compliance.
+
+FSL falls under the [Fair Source](https://fair.io) classification —
+source-available licenses that are explicitly developer-friendly:
+commercial use permitted, free redistribution, eventual open-source
+conversion. Fair Source is a more developer-friendly framing than the
+generic "source-available" label, which has been tainted by the
+SSPL / Elastic / MongoDB relicensing trauma cycles.
+
+What this means practically:
+
+- **You can read the source.** ✅
+- **You can modify it.** ✅
+- **You can sell products built with it.** ✅
+- **You can redistribute it (with the same FSL terms).** ✅
+- **It will be Apache 2.0 in two years.** ✅
+- Some enterprise procurement policies that strictly require OSI-approved
+  licenses will require an exception for this. We're working on making
+  that exception easy to grant.
+
+## Why FSL specifically — why not stay Apache?
+
+HDK 3.0 introduces installable HDK Apps. Every App declares against a
+specific App protocol — the bytes-locked intro, catalog format,
+tool-selection rule, and boundary marker that the runtime renders into
+the spine. Your App's reliability depends on every HDK runtime your users
+install agreeing on the same protocol.
+
+Under a permissive license alone, the protocol is forkable. A
+well-resourced redistributor could fork the runtime, modify the protocol
+surface, and distribute a variant under a different name with captive
+distribution. App developers then face a fragmented ecosystem: target one
+protocol, target both, or pick the bigger distribution and abandon the
+others. The cost of that split is paid by App developers in testing
+burden, divergent behavior, and reliability degradation across runtimes.
+
+FSL's two-year Competing Use restriction is shaped to block that
+fragmentation specifically. After the conversion, anyone can build
+whatever they want — by which time the protocol has had enough time to
+stabilize through ecosystem use and the protection is no longer the load-
+bearing thing keeping it coherent.
+
+For the longer treatment of this argument, see
+[Why FSL](./why-fsl).
+
+We could have used Apache 2.0 and tried to protect only the channel via
+terms-of-service. We could have written a custom license. We chose
+standard FSL because it's:
+
+- **Off-the-shelf** — no bespoke license review at every adopter
+- **Recognizable** — Sentry, PowerSync, and others use it
+- **Documented** — the FAQ, definitions, and edge cases have been
+  litigated publicly
+- **Time-bounded** — the protocolual Apache 2.0 conversion is the answer
+  to the "is this just source-available forever?" critique
+- **Pre-launch** — relicensing at HDK 3.0 launch is structurally
+  different from MongoDB / Elastic / HashiCorp relicensing under an
+  existing installed base, which is what causes the backlash cycle
+
+## What about the lloyal stack — what's under FSL and what's not?
+
+| Component | License | Why |
+|---|---|---|
+| `liblloyal` (C++ engine) | FSL-1.1-Apache-2.0 | Native primitives the runtime is built on |
+| `lloyal-node` (N-API binding) | FSL-1.1-Apache-2.0 | The binding that lets Effection drive llama.cpp |
+| `@lloyal-labs/lloyal-agents` | FSL-1.1-Apache-2.0 | Runtime framework |
+| `@lloyal-labs/lloyal-sdk` | FSL-1.1-Apache-2.0 | Runtime framework |
+| `@lloyal-labs/rig` | FSL-1.1-Apache-2.0 | Runtime framework — holds the App protocol |
+| `@lloyal-labs/corpus`, `@lloyal-labs/web` | FSL-1.1-Apache-2.0 | Reference Apps shipped in-tree |
+| **`@lloyal-labs/harness-cli` (the `harness.dev` CLI)** | **Apache 2.0** | Scaffolder — unrestricted for scaffolding new harnesses and Apps |
+| **`hdk-create-app`** (when shipped) | **Apache 2.0** | Scaffolder — same as above |
+| `llama.cpp` (vendored dependency) | MIT (unchanged) | External upstream library; we don't relicense their code |
+
+## Can I contribute to HDK?
+
+**Yes.** Contributions are welcome under the same FSL license terms. If you
+submit a PR, you're granting Lloyal Labs the right to distribute your
+contribution under FSL-1.1-Apache-2.0 (and automatically under Apache 2.0
+two years after each release that includes it). The CONTRIBUTING file in
+each repo has the details.
+
+## I have a use case that's borderline — who do I ask?
+
+Email [legal@lloyal.ai](mailto:legal@lloyal.ai) (or open a discussion in the repo). The runtime
+team will help you confirm whether your use case falls under Permitted
+Purpose or Competing Use. We'd rather give you a quick yes than have you
+worry about it.
+
+## Further reading
+
+- [FSL official site](https://fsl.software) — Sentry's canonical FSL
+  resources and FAQ
+- [Fair Source](https://fair.io) — the category FSL belongs to
+- [The FSL template, instantiated for each repo](./fsl-template)
+- [Why we chose FSL over BSL, Apache, or a custom license](./why-fsl)
+
+## Is there a safe harbor for building products with the HDK?
+
+Yes. The [Lloyal Harness Builder Grant](https://github.com/lloyal-ai/hdk/blob/main/GRANT.md)
+irrevocably guarantees that building, selling, and hosting Harnesses and Apps
+is a Permitted Purpose and never a Competing Use — even products that compete
+head-on with Lloyal's own (including reasoning.run). Only three uses remain
+restricted: offering the HDK itself as a developer framework, hosting the HDK
+as-a-service for third-party developers, and operating a general-purpose App
+distribution channel. Private/internal App distribution and your Harness's
+own plugin system are explicitly permitted.

--- a/packages/binding/README.md
+++ b/packages/binding/README.md
@@ -1,0 +1,16 @@
+# @lloyal-labs/binding
+
+The harness's **headless interface** — the event/command binding and its transports.
+
+A harness exposes its work through an `EventBus<WorkflowEvent>` (events *down*) and a
+command dispatch (commands *up*). That pair is its headless interface; a **binding** is
+a *transport* of it. This package owns the generic binding — the bus, the wire frame,
+the mode selector, and the Node transports — so "one harness, many placements" is real
+rather than copy-pasted.
+
+- **`@lloyal-labs/binding`** — `createBus`, `EventBus<T>`, `BindingFrame<E, C>` (isomorphic).
+- **`@lloyal-labs/binding/node`** — `selectMode`, `bindHeadless` (the `jsonl` and
+  `parentPort`-else-`fork` transports).
+
+Ink (in-process) stays app-side; this package owns the headless transports. The `wss`
+transport (`./web`) is reserved.

--- a/packages/binding/package.json
+++ b/packages/binding/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lloyal-labs/binding",
+  "version": "0.1.0",
+  "description": "The harness's headless interface — the event/command binding and its transports",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./node": {
+      "types": "./dist/node.d.ts",
+      "default": "./dist/node.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lloyal-ai/hdk.git",
+    "directory": "packages/binding"
+  },
+  "homepage": "https://github.com/lloyal-ai/hdk/tree/main/packages/binding#readme",
+  "bugs": {
+    "url": "https://github.com/lloyal-ai/hdk/issues"
+  },
+  "keywords": [
+    "binding",
+    "transport",
+    "headless",
+    "harness",
+    "event-bus"
+  ],
+  "license": "SEE LICENSE IN LICENSE",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "LICENSE-FAQ.md"
+  ]
+}

--- a/packages/binding/src/index.ts
+++ b/packages/binding/src/index.ts
@@ -1,0 +1,62 @@
+/**
+ * @lloyal-labs/binding — the harness's headless interface.
+ *
+ * A harness exposes its work through two primitives: an `EventBus<WorkflowEvent>`
+ * going *down* (events) and a command dispatch going *up*. That pair IS the
+ * harness's headless interface; a *binding* is a transport of it — in-process
+ * (Ink), one-way JSONL, the `parentPort`-else-`fork` bridge, or (later) wss.
+ *
+ * This module is the isomorphic core: the event bus and the wire frame. The Node
+ * transports live in `@lloyal-labs/binding/node`.
+ */
+
+export interface EventBus<T> {
+  send(event: T): void;
+  subscribe(handler: (event: T) => void): () => void;
+}
+
+/**
+ * Minimal replay-to-first-subscriber event bus. Buffers while no subscriber
+ * exists; the FIRST subscriber synchronously drains the buffer, then live events
+ * stream as they arrive. Later subscribers get only live events. Plain JS — no
+ * framework — so callers bridge it to any UI/transport, and `send` is safe from
+ * non-generator callbacks.
+ */
+export function createBus<T>(): EventBus<T> {
+  let buffer: T[] | null = [];
+  const subscribers = new Set<(event: T) => void>();
+
+  return {
+    send(event: T): void {
+      if (buffer !== null) {
+        // No subscriber yet — buffer and wait.
+        buffer.push(event);
+        return;
+      }
+      for (const handler of subscribers) handler(event);
+    },
+    subscribe(handler: (event: T) => void): () => void {
+      subscribers.add(handler);
+      if (buffer !== null) {
+        // First subscriber ever — drain the buffer synchronously, then flip to
+        // live mode forever (no second-race window).
+        const drained = buffer;
+        buffer = null;
+        for (const event of drained) handler(event);
+      }
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+  };
+}
+
+/**
+ * The wire frame every binding transport carries — a closed, JSON-serializable
+ * union. `E`/`C` are the harness's own event/command unions; the binding treats
+ * them as opaque payload and never inspects their semantics.
+ */
+export type BindingFrame<E = unknown, C = unknown> =
+  | { t: "event"; payload: E }
+  | { t: "command"; payload: C }
+  | { t: "ready" };

--- a/packages/binding/src/index.ts
+++ b/packages/binding/src/index.ts
@@ -52,9 +52,11 @@ export function createBus<T>(): EventBus<T> {
 }
 
 /**
- * The wire frame every binding transport carries — a closed, JSON-serializable
- * union. `E`/`C` are the harness's own event/command unions; the binding treats
- * them as opaque payload and never inspects their semantics.
+ * The wire frame the BIDIRECTIONAL binding transports carry — `bridge` (and,
+ * later, `wss`) — a closed, JSON-serializable union. `E`/`C` are the harness's
+ * own event/command unions; the binding treats them as opaque payload and never
+ * inspects their semantics. Exception: the one-way `jsonl` transport emits raw
+ * events as NDJSON (no envelope, no `ready`) — it has no inbound command channel.
  */
 export type BindingFrame<E = unknown, C = unknown> =
   | { t: "event"; payload: E }

--- a/packages/binding/src/node.ts
+++ b/packages/binding/src/node.ts
@@ -1,0 +1,98 @@
+/**
+ * @lloyal-labs/binding/node — the Node transports of the binding.
+ *
+ * `selectMode` — the `RR_BRIDGE` / TTY / jsonl mode selector.
+ * `bindHeadless` — wires a *headless* transport (one-way `jsonl`, or the
+ *   `parentPort`-else-`fork` `bridge`) to a harness's `EventBus` + a command
+ *   dispatch callback. The `bridge` transport auto-detects Electron `parentPort`
+ *   (a local cut) vs a Node forked child's IPC channel (`process.send`). Ink
+ *   (in-process) is NOT handled here — the app mounts it directly.
+ */
+
+import type { EventBus, BindingFrame } from "./index";
+
+export type BindMode = "ink" | "jsonl" | "bridge";
+
+/**
+ * Pick the binding mode. `RR_BRIDGE` forces the bridge transport (some IPC host
+ * is present); a TTY without jsonl mounts Ink (app-side); otherwise one-way JSONL.
+ */
+export function selectMode(opts: {
+  env?: NodeJS.ProcessEnv;
+  isTTY: boolean;
+  jsonl?: boolean;
+}): BindMode {
+  const bridge = !!(opts.env ?? process.env).RR_BRIDGE;
+  if (bridge) return "bridge";
+  if (opts.isTTY && !opts.jsonl) return "ink";
+  return "jsonl";
+}
+
+export interface BindHeadlessOpts<E, C> {
+  /** the harness's event bus (events flow out of it) */
+  uiChannel: EventBus<E>;
+  /** called with each inbound command (the app wraps `commands.send`) */
+  dispatch: (command: C) => void;
+  /** events seeded before `ready` (e.g. config loaded, download plan) */
+  bootstrap: E[];
+  /** which headless transport ('ink' is app-side, not accepted here) */
+  mode: "jsonl" | "bridge";
+  /** jsonl line sink; defaults to stdout NDJSON */
+  out?: (line: string) => void;
+}
+
+/**
+ * Wire a headless transport of the binding. Synchronous setup — the harness's own
+ * loop keeps running afterward. The `bridge` transport speaks the `BindingFrame`
+ * over Electron `parentPort` if present, else the Node fork IPC channel.
+ */
+export function bindHeadless<E, C>(opts: BindHeadlessOpts<E, C>): void {
+  const { uiChannel, dispatch, bootstrap, mode } = opts;
+
+  if (mode === "jsonl") {
+    const out =
+      opts.out ?? ((line: string) => process.stdout.write(line + "\n"));
+    uiChannel.subscribe((ev) => out(JSON.stringify(ev)));
+    for (const ev of bootstrap) uiChannel.send(ev);
+    return;
+  }
+
+  // mode === "bridge": parentPort (Electron utilityProcess) else fork() IPC.
+  const pp = (
+    process as unknown as {
+      parentPort?: {
+        postMessage(m: unknown): void;
+        on(e: "message", cb: (ev: { data: unknown }) => void): void;
+        start?(): void;
+      };
+    }
+  ).parentPort;
+
+  const post: (m: BindingFrame<E, C>) => void = pp
+    ? (m) => pp.postMessage(m)
+    : (m) => process.send!(m);
+
+  const onMsg = (m: { t?: string; payload?: unknown }): void => {
+    if (m?.t === "command") dispatch(m.payload as C);
+  };
+
+  if (pp) {
+    // Electron MessagePortMain: the envelope arrives wrapped as `e.data`.
+    pp.on("message", (e) => onMsg(e.data as { t?: string; payload?: unknown }));
+    pp.start?.();
+  } else {
+    // Node child_process.fork IPC: the envelope arrives directly.
+    process.on("message", (m) => onMsg(m as { t?: string; payload?: unknown }));
+  }
+
+  uiChannel.subscribe((ev) => post({ t: "event", payload: ev }));
+
+  // No Ink/stdin handle holds the libuv loop open in bridge mode; keep it alive
+  // while the suspended command loop waits. Cleared on exit.
+  const keepAlive = setInterval(() => {}, 1 << 30);
+  process.on("exit", () => clearInterval(keepAlive));
+
+  // Seed bootstrap through the (already-subscribed) bus, then signal ready.
+  for (const ev of bootstrap) uiChannel.send(ev);
+  post({ t: "ready" });
+}

--- a/packages/binding/src/node.ts
+++ b/packages/binding/src/node.ts
@@ -68,6 +68,19 @@ export function bindHeadless<E, C>(opts: BindHeadlessOpts<E, C>): void {
     }
   ).parentPort;
 
+  // `bridge` needs a real IPC channel: Electron `parentPort`, else a
+  // `child_process.fork()` child's `process.send`. In a plain Node process
+  // (e.g. RR_BRIDGE set outside a fork/Electron parent) neither exists — fail
+  // fast with a clear message rather than a cryptic "process.send is not a
+  // function" when the first frame posts.
+  if (!pp && typeof process.send !== "function") {
+    throw new Error(
+      "bindHeadless: 'bridge' mode requires an IPC channel — an Electron " +
+        "parentPort or a child_process.fork() child (neither process.parentPort " +
+        "nor process.send is available).",
+    );
+  }
+
   const post: (m: BindingFrame<E, C>) => void = pp
     ? (m) => pp.postMessage(m)
     : (m) => process.send!(m);

--- a/packages/binding/test/__fork-smoke.mjs
+++ b/packages/binding/test/__fork-smoke.mjs
@@ -1,0 +1,50 @@
+// Fork-IPC round-trip smoke for the `bridge` transport (Node fork branch).
+// GPU-free: a stub "harness" over the fork IPC channel, no model.
+// Run AFTER `tsc -b`:  node packages/binding/test/__fork-smoke.mjs
+import { fork } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import core from "../dist/index.js";
+import node from "../dist/node.js";
+
+const { createBus } = core;
+const { bindHeadless } = node;
+const __filename = fileURLToPath(import.meta.url);
+
+if (process.env.__BIND_CHILD) {
+  // CHILD: a headless "harness" bound over the fork transport. `parentPort` is
+  // undefined here, so bindHeadless uses process.send / process.on('message').
+  const bus = createBus();
+  bindHeadless({
+    uiChannel: bus,
+    dispatch: (c) => process.send?.({ t: "cmd-echo", payload: c }),
+    bootstrap: [{ type: "boot" }],
+    mode: "bridge",
+  });
+  bus.send({ type: "hello" });
+} else {
+  // PARENT: fork the child and assert the frame round-trips both ways.
+  const child = fork(__filename, [], {
+    env: { ...process.env, __BIND_CHILD: "1" },
+  });
+  const seen = { ready: false, event: false, cmdEcho: false };
+  const finish = (ok) => {
+    child.kill();
+    if (ok) {
+      console.log("OK — fork round-trip: ready + event(down) + command(up) echo");
+      process.exit(0);
+    }
+    console.error("FAIL — fork round-trip incomplete:", seen);
+    process.exit(1);
+  };
+  child.on("message", (m) => {
+    if (m?.t === "ready") {
+      seen.ready = true;
+      child.send({ t: "command", payload: { type: "ping" } });
+    }
+    if (m?.t === "event") seen.event = true;
+    if (m?.t === "cmd-echo") seen.cmdEcho = true;
+    if (seen.ready && seen.event && seen.cmdEcho) finish(true);
+  });
+  child.on("error", () => finish(false));
+  setTimeout(() => finish(false), 5000);
+}

--- a/packages/binding/test/bindHeadless.test.ts
+++ b/packages/binding/test/bindHeadless.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { createBus } from "../src/index";
+import { bindHeadless } from "../src/node";
+
+describe("bindHeadless — jsonl transport (one-way NDJSON)", () => {
+  it("drains bootstrap then streams live events as raw NDJSON, in order", () => {
+    const bus = createBus<{ type: string }>();
+    const lines: string[] = [];
+    bindHeadless({
+      uiChannel: bus,
+      dispatch: () => {},
+      bootstrap: [{ type: "a" }, { type: "b" }],
+      mode: "jsonl",
+      out: (l) => lines.push(l),
+    });
+    expect(lines).toEqual(['{"type":"a"}', '{"type":"b"}']); // bootstrap, in order
+    bus.send({ type: "c" });
+    expect(lines).toEqual(['{"type":"a"}', '{"type":"b"}', '{"type":"c"}']); // live after
+  });
+
+  it("emits raw events — no BindingFrame envelope, no ready, no inbound dispatch", () => {
+    const bus = createBus<{ type: string }>();
+    const lines: string[] = [];
+    let dispatched = 0;
+    bindHeadless({
+      uiChannel: bus,
+      dispatch: () => {
+        dispatched++;
+      },
+      bootstrap: [{ type: "boot" }],
+      mode: "jsonl",
+      out: (l) => lines.push(l),
+    });
+    expect(lines).toEqual(['{"type":"boot"}']);
+    // no `{"t":...}` frame envelope and no `ready` — jsonl is raw + one-way
+    expect(lines.some((l) => l.includes('"t":') || l.includes('"payload"'))).toBe(false);
+    expect(dispatched).toBe(0); // jsonl has no command channel
+  });
+});
+
+describe("bindHeadless — bridge transport", () => {
+  afterEach(() => {
+    delete (process as unknown as { parentPort?: unknown }).parentPort;
+    vi.useRealTimers();
+  });
+
+  it("posts framed events + a trailing ready, and dispatches inbound commands", () => {
+    vi.useFakeTimers(); // contain bindHeadless's keep-alive interval
+    const posted: unknown[] = [];
+    let onMessage: ((e: { data: unknown }) => void) | undefined;
+    (process as unknown as { parentPort: unknown }).parentPort = {
+      postMessage: (m: unknown) => posted.push(m),
+      on: (_e: "message", cb: (e: { data: unknown }) => void) => {
+        onMessage = cb;
+      },
+      start: () => {},
+    };
+    const bus = createBus<{ type: string }>();
+    const commands: unknown[] = [];
+    bindHeadless({
+      uiChannel: bus,
+      dispatch: (c) => commands.push(c),
+      bootstrap: [{ type: "boot" }],
+      mode: "bridge",
+    });
+    // bootstrap framed as an event, then a trailing ready
+    expect(posted).toEqual([
+      { t: "event", payload: { type: "boot" } },
+      { t: "ready" },
+    ]);
+    // live events keep framing
+    bus.send({ type: "live" });
+    expect(posted).toContainEqual({ t: "event", payload: { type: "live" } });
+    // inbound `command` frames dispatch; other frames are ignored (up-channel only for commands)
+    onMessage?.({ data: { t: "command", payload: { cmd: "ping" } } });
+    onMessage?.({ data: { t: "event", payload: {} } });
+    expect(commands).toEqual([{ cmd: "ping" }]);
+  });
+
+  it("throws a clear error when 'bridge' has no IPC channel", () => {
+    const orig = process.send;
+    delete (process as unknown as { parentPort?: unknown }).parentPort;
+    (process as unknown as { send?: unknown }).send = undefined; // simulate no fork IPC
+    try {
+      expect(() =>
+        bindHeadless({
+          uiChannel: createBus(),
+          dispatch: () => {},
+          bootstrap: [],
+          mode: "bridge",
+        }),
+      ).toThrow(/requires an IPC channel/);
+    } finally {
+      (process as unknown as { send?: unknown }).send = orig;
+    }
+  });
+});

--- a/packages/binding/test/bus.test.ts
+++ b/packages/binding/test/bus.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { createBus } from "../src/index";
+
+describe("createBus — replay-to-first-subscriber", () => {
+  it("buffers before any subscriber and drains to the first synchronously", () => {
+    const bus = createBus<number>();
+    bus.send(1);
+    bus.send(2);
+    const got: number[] = [];
+    bus.subscribe((n) => got.push(n));
+    expect(got).toEqual([1, 2]); // drained synchronously on first subscribe
+    bus.send(3);
+    expect(got).toEqual([1, 2, 3]); // live after drain
+  });
+
+  it("later subscribers get only live events (no re-drain)", () => {
+    const bus = createBus<string>();
+    bus.send("a");
+    const first: string[] = [];
+    bus.subscribe((s) => first.push(s)); // drains ['a']
+    const second: string[] = [];
+    bus.subscribe((s) => second.push(s));
+    bus.send("b");
+    expect(first).toEqual(["a", "b"]);
+    expect(second).toEqual(["b"]); // never sees 'a'
+  });
+
+  it("unsubscribe stops delivery", () => {
+    const bus = createBus<number>();
+    const got: number[] = [];
+    const off = bus.subscribe((n) => got.push(n));
+    bus.send(1);
+    off();
+    bus.send(2);
+    expect(got).toEqual([1]);
+  });
+});

--- a/packages/binding/test/selectMode.test.ts
+++ b/packages/binding/test/selectMode.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from "vitest";
+import { selectMode } from "../src/node";
+
+describe("selectMode", () => {
+  it("RR_BRIDGE forces the bridge transport regardless of TTY/jsonl", () => {
+    expect(selectMode({ env: { RR_BRIDGE: "1" }, isTTY: true })).toBe("bridge");
+    expect(
+      selectMode({ env: { RR_BRIDGE: "1" }, isTTY: false, jsonl: true }),
+    ).toBe("bridge");
+  });
+
+  it("a TTY without jsonl mounts Ink", () => {
+    expect(selectMode({ env: {}, isTTY: true })).toBe("ink");
+  });
+
+  it("non-TTY, or jsonl, falls to JSONL", () => {
+    expect(selectMode({ env: {}, isTTY: false })).toBe("jsonl");
+    expect(selectMode({ env: {}, isTTY: true, jsonl: true })).toBe("jsonl");
+  });
+});

--- a/packages/binding/tsconfig.json
+++ b/packages/binding/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}


### PR DESCRIPTION
## What

Adds **`@lloyal-labs/binding`** — the harness's *headless interface*: the generic event/command binding and its transports, extracted into a runtime package so the binding layer stops being copied across reasoning.run and Artifact.

- **`@lloyal-labs/binding`** (`.`) — `createBus` / `EventBus<T>` (moved from the copied `tui-ink/event-bus.ts`) + the `BindingFrame` envelope (`{ t: 'event' | 'command' | 'ready', payload }`, previously typed nowhere).
- **`@lloyal-labs/binding/node`** — `selectMode` (`RR_BRIDGE` / TTY / jsonl) + `bindHeadless` (the `jsonl` and `parentPort`-else-`fork` transports). The `wss` transport (`./web`) is reserved.

Payload-opaque; **zero runtime deps** (no `ink`/`react`/`electron`/`effection`); Ink (in-process) stays app-side.

## Why

`harness.ts` is byte-identical and *copied* across reasoning.run and Artifact, and the transports are inlined + copied in each `main()`, because this headless interface didn't exist. This package is that interface — the generalization every placement is a transport of. The `parentPort`-else-`fork` transport is the old fork-IPC bridge, now a transport *of* the package rather than a `main()` edit.

## Verification

- `tsc -b` green; `npm pack --dry-run` ships `.` + `./node`.
- vitest: **6/6** — bus replay-to-first-subscriber; `selectMode` branches.
- fork-IPC round-trip smoke (`test/__fork-smoke.mjs`): a stub harness over the fork transport round-trips `ready` + event (down) + command (up), GPU-free.

## Notes

- **Unpublished** — `0.1.0` stays unpublished until an app consumes it. The apps migrate onto it next via a local link; it publishes via the CI tag then.
- The fork smoke is a manual dev script (needs `dist/`), not wired into CI vitest.
