### PR TITLE
chore(release): publish binding + relay; raise lloyal.node peer floor (rig 3.1.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,14 +36,20 @@ jobs:
           test -f packages/agents/dist/index.d.ts
           test -f packages/rig/dist/index.js
           test -f packages/rig/dist/index.d.ts
+          test -f packages/binding/dist/index.js
+          test -f packages/binding/dist/index.d.ts
+          test -f packages/binding/dist/node.js
+          test -f packages/binding/dist/web.js
+          test -f packages/relay/dist/index.js
+          test -f packages/relay/dist/index.d.ts
 
       - name: Typecheck
-        run: npx tsc -b packages/sdk packages/agents packages/rig
+        run: npx tsc -b packages/sdk packages/agents packages/rig packages/binding packages/relay
 
       - name: Publish packages
         if: success() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.skip_publish))
         run: |
-          for pkg in packages/sdk packages/agents packages/rig packages/harness-cli; do
+          for pkg in packages/sdk packages/agents packages/rig packages/harness-cli packages/binding packages/relay; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then

--- a/package-lock.json
+++ b/package-lock.json
@@ -2524,7 +2524,7 @@
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",
-        "@lloyal-labs/lloyal.node": "^3.0.0",
+        "@lloyal-labs/lloyal.node": "^3.1.1",
         "@lloyal-labs/rig": "^3.0.0",
         "effection": "^4.0.2"
       }
@@ -2579,7 +2579,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",
@@ -2591,7 +2591,7 @@
         "semver": "^7.8.1"
       },
       "peerDependencies": {
-        "@lloyal-labs/lloyal.node": "^3.0.1"
+        "@lloyal-labs/lloyal.node": "^3.1.1"
       }
     },
     "packages/sdk": {

--- a/packages/apps/corpus/package.json
+++ b/packages/apps/corpus/package.json
@@ -26,7 +26,7 @@
   },
   "peerDependencies": {
     "@lloyal-labs/lloyal-agents": "^3.0.0",
-    "@lloyal-labs/lloyal.node": "^3.0.0",
+    "@lloyal-labs/lloyal.node": "^3.1.1",
     "@lloyal-labs/rig": "^3.0.0",
     "effection": "^4.0.2"
   }

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -49,7 +49,7 @@
     "semver": "^7.8.1"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal.node": "^3.0.1"
+    "@lloyal-labs/lloyal.node": "^3.1.1"
   },
   "files": [
     "dist/",


### PR DESCRIPTION
Release prep to publish the reshaped binding + relay and unblock downstream harnesses.

## What
- **release.yml**: add \`packages/binding\` + \`packages/relay\` to the publish loop + verify-dist + typecheck. First npm publish of \`@lloyal-labs/binding@0.1.0\` and \`@lloyal-labs/relay@0.1.0\`.
- **rig**: raise \`@lloyal-labs/lloyal.node\` peer floor \`^3.0.1 → ^3.1.1\` (require the 3.1 native ABI, not merely admit it) → bump **rig 3.1.3 → 3.1.4** to ship it.
- **corpus** (private): same peer floor \`^3.0.0 → ^3.1.1\`.
- lockfile reconciled (3-line delta).

## Why
`@lloyal-labs/binding` on the file: link keeps downstream CI (reasoning-run) red; publishing it (merged + 38 tests green) unblocks the chain. relay depends on binding so they publish together.

## On tag
`release.yml` publishes each package at its own version, idempotently: `binding@0.1.0`, `relay@0.1.0`, `rig@3.1.4` ship; `sdk`/`agents`/`harness.dev` are already current and skip.

## Verify (local)
`npm run build` · verify-dist (binding node/web + relay dist present) · `tsc -b` (incl. binding/relay) · 38/38 binding+relay vitest.