### PR TITLE
fix(relay): add repository field for provenance publish

### DIFF
--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -2,6 +2,11 @@
   "name": "@lloyal-labs/relay",
   "version": "0.1.0",
   "description": "The self-hostable framework-relay — serves a headless harness to remote frontends over wss",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lloyal-ai/hdk.git",
+    "directory": "packages/relay"
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "exports": {


### PR DESCRIPTION
relay@0.1.0 failed first publish with E422 (provenance validation: empty repository.url). Adds the repository field matching binding. binding@0.1.0 already published; re-tagging after this merges will publish relay (binding skips).