### PR TITLE
feat(host): @lloyal-labs/host — the box model-runtime host

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "packages/rig",
     "packages/binding",
     "packages/relay",
+    "packages/host",
     "packages/harness-cli",
     "packages/apps/*"
   ],

--- a/packages/host/LICENSE
+++ b/packages/host/LICENSE
@@ -1,0 +1,107 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 Lloyal Labs
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publish, and distribute the
+Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A "Permitted Purpose" is any purpose other than a Competing Use. A
+"Competing Use" means making the Software available to others in a
+commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a Licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives
+of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND,
+INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO
+THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software
+under the Apache License, Version 2.0 that is effective on the second
+anniversary of the date we make the Software available. On or after that
+date, you may use the Software under the Apache License, Version 2.0, in
+which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/host/LICENSE-FAQ.md
+++ b/packages/host/LICENSE-FAQ.md
@@ -1,0 +1,256 @@
+# Licensing FAQ
+
+> Canonical version at https://docs.lloyal.ai/licensing/faq.
+> This file is a synced copy. Edit the canonical source and re-run
+> `scripts/sync-license-faq.sh` in lloyal-sdk to update all copies.
+
+
+**You can build and sell commercial products using HDK.**
+
+> HDK is free to build products with; it is not free to become the
+> replacement HDK platform.
+
+That single sentence is the entire restriction reduced to one line. The rest
+of this page is illustration.
+
+## The short version
+
+HDK 3.0 runtime packages — `liblloyal`, `lloyal-node`, and the lloyal-sdk
+packages (`agents`, `sdk`, `rig`, `apps/corpus`, `apps/web`) — are
+**[Fair Source](https://fair.io)** under **FSL-1.1-Apache-2.0** (the Functional
+Source License, Apache 2.0 future grant).
+
+Each version converts to Apache 2.0 two years after its release. The
+restriction during those two years is narrow: **you cannot offer a competing
+HDK runtime, a managed HDK service, or an alternative HDK App distribution
+channel.** Everything else — commercial use, redistribution, modification,
+sale, embedding in shipped products — is freely permitted.
+
+The reason the channel restriction exists is consumer-protective: every App
+listed on `apps.lloyal.ai` is reviewed by Lloyal Labs for tool-safety,
+manifest conformance, and signature provenance before publication. Pinning
+the App ecosystem to one verified channel keeps the AI-safety review meaningful
+(consumers can rely on a single trust boundary) and prevents protocol
+fragmentation (an App that works on one harness works on every harness).
+
+The `harness.dev` CLI and `hdk-create-app` scaffolder are licensed under
+**Apache 2.0** (unrestricted). They're not part of the runtime stack.
+
+## Can I ship a commercial product built on HDK?
+
+**Yes.** This is the question everyone has and the answer is straightforward.
+Concretely:
+
+- **Shipping a paid intelligent inbox app to consumers** — permitted ✅
+- **Selling an Excel-with-AI desktop app to enterprises** — permitted ✅
+- **Embedding HDK in a medical device sold commercially** — permitted ✅
+- **A consulting firm building a custom intelligent harness for a Fortune
+  500 client, charging $500K for the engagement, deploying on client
+  infrastructure** — permitted ✅
+- **An indie dev shipping a paid productivity app on the Mac App Store** —
+  permitted ✅
+- **An OEM shipping HDK inside an infotainment system or industrial device**
+  — permitted ✅
+- **A startup building an end-user product on top of HDK** — including
+  vertical research apps, workflow tools, and agent applications — permitted
+  ✅, *as long as the product is not offering HDK itself as a substitute
+  runtime, managed HDK service, or competing App distribution channel*.
+- **A research lab using HDK in published academic work** — permitted ✅
+- **Forking HDK on GitHub to learn, modify, demo, or contribute** — permitted ✅
+- **Running HDK internally inside your company for any business use** —
+  permitted ✅
+
+If you are building something *with* HDK, you are almost certainly fine.
+
+## What is actually restricted?
+
+The restriction is narrow and specific: **don't become the replacement
+platform vendor**. Concretely:
+
+- **AWS / Google / Microsoft launching "Bedrock Managed HDK" or "Vertex HDK"
+  as a hosted runtime service** — restricted ❌
+- **A competitor publishing "OpenHDK" as a forked harness runtime under a
+  different name** — restricted ❌
+- **A clean-room reimplementation of the HDK runtime in Python / Rust / Go
+  intended as a drop-in replacement** — restricted ❌ (Competing Use doesn't
+  require forking source code — a reimplementation that competes is the
+  same problem)
+- **Launching `apps.competitor.com` as an alternative HDK App distribution
+  channel** — restricted ❌
+- **Offering "managed HDK hosting" or "HDK-as-a-Service" as a competing
+  SaaS** — restricted ❌
+- **A hosted orchestration service exposing HDK-compatible APIs as a
+  substitute for the HDK runtime** — restricted ❌
+
+Notice the pattern: every restricted scenario is "become the platform
+vendor," not "build products with HDK." If your project doesn't compete
+directly with the HDK runtime or its distribution channel, FSL doesn't
+affect you.
+
+## Why does the LICENSE list four narrow Permitted Purposes then?
+
+You may read the FSL LICENSE and see this section:
+
+> Permitted Purposes specifically include using the Software:
+> 1. for your internal use and access;
+> 2. for non-commercial education;
+> 3. for non-commercial research; and
+> 4. in connection with professional services that you provide to a
+>    Licensee using the Software in accordance with these Terms and
+>    Conditions.
+
+A careful first reading can mistake this list for the *exclusive* set of
+permitted uses — leading to the (incorrect) conclusion that commercial
+product distribution is prohibited.
+
+It isn't. **The operative definition is broader.** Earlier in the same
+section, the license states:
+
+> A "Permitted Purpose" is any purpose other than a Competing Use.
+
+The four enumerated items are **illustrative examples** added because those
+specific cases are ones a careful reader might otherwise hesitate about
+("is research permitted? is consulting permitted?"). The four items are
+additive clarifications, not a closing of the open-ended definition.
+
+Sentry, who authored FSL and uses it on their own software, [confirms this
+explicitly in their FAQ](https://fsl.software):
+
+> "You can do anything with FSL software except undermine its producer. You
+> can run it for almost all purposes, study it, modify it, and distribute
+> your changes…"
+
+If the license felt restrictive on first read, that's a documented
+[FSL adoption hazard](https://fair.io) — many developers hit the same wall.
+The answer is to read the "any purpose other than a Competing Use" line as
+the operative definition and treat the four enumerated items as examples,
+not as a closed list.
+
+## Will it become Apache 2.0?
+
+**Yes — automatically, on a per-version schedule.** Each released version of
+the runtime stack converts to Apache 2.0 exactly two years after its release
+date. The conversion is irrevocable and written into the license text — it's
+not a promise from Lloyal Labs, it's a contractual clause.
+
+For example: if `lloyal-sdk @lloyal-labs/lloyal-agents` v3.0.0 is released
+on 2026-06-01, that exact version becomes available under Apache 2.0 on
+2028-06-01. Any consumer can elect to use that version under Apache 2.0
+from that date forward — Lloyal Labs takes no action; the grant is
+automatic.
+
+New versions released after v3.0.0 start their own two-year clock from
+their own release dates. There is no single global Change Date.
+
+## Is this OSI-approved open source?
+
+**No, and we want to be honest about that.** FSL is not OSI-approved
+because the OSI definition of open source (clause 6, "No Discrimination
+Against Fields of Endeavor") does not permit restrictions on specific
+use cases. FSL restricts Competing Use. That restriction takes it out of
+strict OSI compliance.
+
+FSL falls under the [Fair Source](https://fair.io) classification —
+source-available licenses that are explicitly developer-friendly:
+commercial use permitted, free redistribution, eventual open-source
+conversion. Fair Source is a more developer-friendly framing than the
+generic "source-available" label, which has been tainted by the
+SSPL / Elastic / MongoDB relicensing trauma cycles.
+
+What this means practically:
+
+- **You can read the source.** ✅
+- **You can modify it.** ✅
+- **You can sell products built with it.** ✅
+- **You can redistribute it (with the same FSL terms).** ✅
+- **It will be Apache 2.0 in two years.** ✅
+- Some enterprise procurement policies that strictly require OSI-approved
+  licenses will require an exception for this. We're working on making
+  that exception easy to grant.
+
+## Why FSL specifically — why not stay Apache?
+
+HDK 3.0 introduces installable HDK Apps. Every App declares against a
+specific App protocol — the bytes-locked intro, catalog format,
+tool-selection rule, and boundary marker that the runtime renders into
+the spine. Your App's reliability depends on every HDK runtime your users
+install agreeing on the same protocol.
+
+Under a permissive license alone, the protocol is forkable. A
+well-resourced redistributor could fork the runtime, modify the protocol
+surface, and distribute a variant under a different name with captive
+distribution. App developers then face a fragmented ecosystem: target one
+protocol, target both, or pick the bigger distribution and abandon the
+others. The cost of that split is paid by App developers in testing
+burden, divergent behavior, and reliability degradation across runtimes.
+
+FSL's two-year Competing Use restriction is shaped to block that
+fragmentation specifically. After the conversion, anyone can build
+whatever they want — by which time the protocol has had enough time to
+stabilize through ecosystem use and the protection is no longer the load-
+bearing thing keeping it coherent.
+
+For the longer treatment of this argument, see
+[Why FSL](./why-fsl).
+
+We could have used Apache 2.0 and tried to protect only the channel via
+terms-of-service. We could have written a custom license. We chose
+standard FSL because it's:
+
+- **Off-the-shelf** — no bespoke license review at every adopter
+- **Recognizable** — Sentry, PowerSync, and others use it
+- **Documented** — the FAQ, definitions, and edge cases have been
+  litigated publicly
+- **Time-bounded** — the protocolual Apache 2.0 conversion is the answer
+  to the "is this just source-available forever?" critique
+- **Pre-launch** — relicensing at HDK 3.0 launch is structurally
+  different from MongoDB / Elastic / HashiCorp relicensing under an
+  existing installed base, which is what causes the backlash cycle
+
+## What about the lloyal stack — what's under FSL and what's not?
+
+| Component | License | Why |
+|---|---|---|
+| `liblloyal` (C++ engine) | FSL-1.1-Apache-2.0 | Native primitives the runtime is built on |
+| `lloyal-node` (N-API binding) | FSL-1.1-Apache-2.0 | The binding that lets Effection drive llama.cpp |
+| `@lloyal-labs/lloyal-agents` | FSL-1.1-Apache-2.0 | Runtime framework |
+| `@lloyal-labs/lloyal-sdk` | FSL-1.1-Apache-2.0 | Runtime framework |
+| `@lloyal-labs/rig` | FSL-1.1-Apache-2.0 | Runtime framework — holds the App protocol |
+| `@lloyal-labs/corpus`, `@lloyal-labs/web` | FSL-1.1-Apache-2.0 | Reference Apps shipped in-tree |
+| **`@lloyal-labs/harness-cli` (the `harness.dev` CLI)** | **Apache 2.0** | Scaffolder — unrestricted for scaffolding new harnesses and Apps |
+| **`hdk-create-app`** (when shipped) | **Apache 2.0** | Scaffolder — same as above |
+| `llama.cpp` (vendored dependency) | MIT (unchanged) | External upstream library; we don't relicense their code |
+
+## Can I contribute to HDK?
+
+**Yes.** Contributions are welcome under the same FSL license terms. If you
+submit a PR, you're granting Lloyal Labs the right to distribute your
+contribution under FSL-1.1-Apache-2.0 (and automatically under Apache 2.0
+two years after each release that includes it). The CONTRIBUTING file in
+each repo has the details.
+
+## I have a use case that's borderline — who do I ask?
+
+Email [legal@lloyal.ai](mailto:legal@lloyal.ai) (or open a discussion in the repo). The runtime
+team will help you confirm whether your use case falls under Permitted
+Purpose or Competing Use. We'd rather give you a quick yes than have you
+worry about it.
+
+## Further reading
+
+- [FSL official site](https://fsl.software) — Sentry's canonical FSL
+  resources and FAQ
+- [Fair Source](https://fair.io) — the category FSL belongs to
+- [The FSL template, instantiated for each repo](./fsl-template)
+- [Why we chose FSL over BSL, Apache, or a custom license](./why-fsl)
+
+## Is there a safe harbor for building products with the HDK?
+
+Yes. The [Lloyal Harness Builder Grant](https://github.com/lloyal-ai/hdk/blob/main/GRANT.md)
+irrevocably guarantees that building, selling, and hosting Harnesses and Apps
+is a Permitted Purpose and never a Competing Use — even products that compete
+head-on with Lloyal's own (including reasoning.run). Only three uses remain
+restricted: offering the HDK itself as a developer framework, hosting the HDK
+as-a-service for third-party developers, and operating a general-purpose App
+distribution channel. Private/internal App distribution and your Harness's
+own plugin system are explicitly permitted.

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@lloyal-labs/host",
+  "version": "0.1.0",
+  "description": "The box model-runtime host — one resident model, N native harness sessions, FIFO admission",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/lloyal-ai/hdk.git",
+    "directory": "packages/host"
+  },
+  "homepage": "https://github.com/lloyal-ai/hdk/tree/main/packages/host#readme",
+  "bugs": {
+    "url": "https://github.com/lloyal-ai/hdk/issues"
+  },
+  "keywords": [
+    "host",
+    "serving",
+    "harness",
+    "model-runtime",
+    "resident"
+  ],
+  "license": "SEE LICENSE IN LICENSE",
+  "type": "commonjs",
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "@lloyal-labs/binding": "^0.1.0",
+    "effection": "^4.0.2"
+  },
+  "files": [
+    "dist/",
+    "LICENSE",
+    "LICENSE-FAQ.md"
+  ]
+}

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -31,8 +31,9 @@ import type {
 export interface ModelRuntimeHost<Ctx = unknown> {
   /** Enqueue a Session for admission (FIFO). Emits `queued`, then the pump takes
    *  it to `warming`→`live` when a slot is free (or `died` if materialise fails).
-   *  A `sessionId` that is already queued or live is refused (emits `died`) — the
-   *  one-Session↔one-context invariant, so a duplicate never orphans a context. */
+   *  A `sessionId` that is already queued, warming, or live is refused (emits
+   *  `died`) — the one-Session↔one-context invariant, so a duplicate never orphans
+   *  a context (including one mid-`warming`, whose materialise is still in flight). */
   admit(req: AdmissionRequest): void;
   /** Release a live Session: halt its harness scope (the context frees on unwind),
    *  which re-pumps the queue for the next waiting Session. No-op if unknown.
@@ -59,6 +60,13 @@ export function createModelRuntimeHost<Ctx = unknown>(
   return resource(function* (provide) {
     const queue: AdmissionRequest[] = [];
     const sessions = new Map<string, NativeSessionRecord<Ctx>>();
+    // Every id from `admit` until final teardown — the dedup gate spanning
+    // queued ∪ warming ∪ live. It is the ONLY correct dedup source: mid-`warming`
+    // a request sits in neither `queue` (already shifted) nor `sessions` (not set
+    // until materialise resolves), so a `queue`/`sessions` check would let a
+    // duplicate `admit` slip through that window and orphan the live context.
+    // (Keying off a Set also makes the check O(1).)
+    const admitted = new Set<string>();
 
     // A caller-provided `onState` must never take down the pump or corrupt a
     // teardown — the "one bad callback can't sink all N sessions" boundary. Every
@@ -98,6 +106,7 @@ export function createModelRuntimeHost<Ctx = unknown>(
       // memory and the pump can't over-admit while a context is still freeing.
       yield* ensure(() => {
         sessions.delete(req.sessionId);
+        admitted.delete(req.sessionId); // id free to be re-admitted
         emit(req, { phase: outcome });
         kick();
       });
@@ -128,11 +137,12 @@ export function createModelRuntimeHost<Ctx = unknown>(
     }
 
     // The admission pump — the sole ADMITTER: the only fiber that dequeues and
-    // writes NEW `sessions` entries. (`admit` only enqueues at the tail + does a
-    // read-only dedup check; a session's own teardown ensure deletes its entry.)
+    // writes NEW `sessions` entries. (`admit` only enqueues at the tail after an
+    // O(1) `admitted` dedup check; a session's own teardown ensure removes its id.)
     // Non-reentrant by being one fiber, so `materialise`'s `await` is the only
-    // window and no two admissions can race the last free slot. The harnesses it
-    // spawns run fully concurrently.
+    // suspension window — and that window is exactly why dedup keys off `admitted`
+    // (which still holds the id mid-`warming`) rather than `queue`/`sessions`. The
+    // harnesses it spawns run fully concurrently.
     yield* spawn(function* (): Operation<void> {
       for (;;) {
         dirty = false;
@@ -143,8 +153,9 @@ export function createModelRuntimeHost<Ctx = unknown>(
           try {
             m = yield* call(() => served.materialise(req.sessionId));
           } catch {
-            // Typed rejection for THIS request, not a dead pump. Nothing was
-            // inserted, so there is nothing to roll back.
+            // Typed rejection for THIS request, not a dead pump. Release the id
+            // (nothing else was inserted) so a later admit can retry it.
+            admitted.delete(req.sessionId);
             emit(req, { phase: "died" });
             continue;
           }
@@ -175,15 +186,15 @@ export function createModelRuntimeHost<Ctx = unknown>(
 
     const host: ModelRuntimeHost<Ctx> = {
       admit(req) {
-        // Refuse a duplicate: a `sessionId` already resident or waiting would,
-        // once the pump ran, overwrite the live record and orphan its context.
-        if (
-          sessions.has(req.sessionId) ||
-          queue.some((q) => q.sessionId === req.sessionId)
-        ) {
+        // Refuse a duplicate: an id already queued, warming, or live would, once
+        // the pump ran, overwrite the live record and orphan its context. Gate on
+        // `admitted` (NOT `queue`/`sessions`) — it still holds the id during the
+        // `warming` window, where the request is in neither structure.
+        if (admitted.has(req.sessionId)) {
           emit(req, { phase: "died" });
           return;
         }
+        admitted.add(req.sessionId);
         emit(req, { phase: "queued", position: queue.length });
         queue.push(req);
         kick();

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -87,29 +87,52 @@ export function createModelRuntimeHost<Ctx = unknown>(
       m: Materialised<Ctx>,
       req: AdmissionRequest,
     ): Operation<void> {
+      // Terminal state: `reaped` on a clean stop (a `release`/halt, or a harness
+      // that ends on its own); `died` if the harness itself THROWS. It flips only
+      // in the catch below — and in Effection a halt unwinds via ensure/finally
+      // and never enters catch, so a normal release stays `reaped`.
+      let outcome: "reaped" | "died" = "reaped";
       // Teardown runs LIFO — register the slot-drop FIRST (runs last) and the
       // dispose SECOND (runs first): on unwind we dispose the context BEFORE
       // dropping the slot + re-pumping, so occupancy never understates resident
       // memory and the pump can't over-admit while a context is still freeing.
       yield* ensure(() => {
         sessions.delete(req.sessionId);
-        emit(req, { phase: "reaped" });
+        emit(req, { phase: outcome });
         kick();
       });
       yield* ensure(() => {
-        m.dispose();
+        // A throwing dispose must not abort teardown (the slot-drop above still
+        // has to run) nor reject the halt promise — swallow it. Freeing the
+        // context is the supplier's contract; a failure there is not the host's
+        // to propagate.
+        try {
+          m.dispose();
+        } catch {
+          /* supplier's dispose failed — not the host's error to surface */
+        }
       });
       try {
         yield* served.run(m, req.sessionId); // the UNCHANGED harness, concurrent
+      } catch {
+        // A harness ERROR (not a halt — halts bypass catch) is isolated to THIS
+        // session: mark it `died` and SWALLOW, so an uncaught throw can't
+        // propagate up the spawn into the pump and take down the host + every
+        // sibling session.
+        outcome = "died";
       } finally {
-        emit(req, { phase: "draining" });
+        // Clean stop → `draining` then `reaped`; a died session skips straight to
+        // its terminal `died` (emitted by the slot-drop ensure above).
+        if (outcome !== "died") emit(req, { phase: "draining" });
       }
     }
 
-    // The admission pump. Sole mutator of `queue` + `sessions`; non-reentrant by
-    // being one fiber. `materialise` is awaited here ⇒ context construction is
-    // serialised (over its `await` is the only window an admission could race the
-    // last free slot). The harnesses it spawns run fully concurrently.
+    // The admission pump — the sole ADMITTER: the only fiber that dequeues and
+    // writes NEW `sessions` entries. (`admit` only enqueues at the tail + does a
+    // read-only dedup check; a session's own teardown ensure deletes its entry.)
+    // Non-reentrant by being one fiber, so `materialise`'s `await` is the only
+    // window and no two admissions can race the last free slot. The harnesses it
+    // spawns run fully concurrently.
     yield* spawn(function* (): Operation<void> {
       for (;;) {
         dirty = false;
@@ -131,7 +154,10 @@ export function createModelRuntimeHost<Ctx = unknown>(
             sessionId: req.sessionId,
             task,
             cancel: () => {
-              void task.halt();
+              // Fire-and-forget halt: swallow a teardown rejection so it can't
+              // surface as an unhandled promise rejection. (`release()` returns
+              // the promise for callers that want to await the teardown.)
+              void task.halt().catch(() => {});
             },
           });
           emit(req, { phase: "live" });

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -23,13 +23,16 @@ import type {
   Materialised,
   ModelRuntimeHostOpts,
   NativeSessionRecord,
+  SessionState,
 } from "./types";
 
 /** The handle a transport (or a driver) drives. Sync methods — callable from a
  *  plain `ws.on("connection")` callback; they feed the pump, never block it. */
 export interface ModelRuntimeHost<Ctx = unknown> {
   /** Enqueue a Session for admission (FIFO). Emits `queued`, then the pump takes
-   *  it to `warming`→`live` when a slot is free (or `died` if materialise fails). */
+   *  it to `warming`→`live` when a slot is free (or `died` if materialise fails).
+   *  A `sessionId` that is already queued or live is refused (emits `died`) — the
+   *  one-Session↔one-context invariant, so a duplicate never orphans a context. */
   admit(req: AdmissionRequest): void;
   /** Release a live Session: halt its harness scope (the context frees on unwind),
    *  which re-pumps the queue for the next waiting Session. No-op if unknown.
@@ -57,6 +60,17 @@ export function createModelRuntimeHost<Ctx = unknown>(
     const queue: AdmissionRequest[] = [];
     const sessions = new Map<string, NativeSessionRecord<Ctx>>();
 
+    // A caller-provided `onState` must never take down the pump or corrupt a
+    // teardown — the "one bad callback can't sink all N sessions" boundary. Every
+    // transition goes through here.
+    const emit = (req: AdmissionRequest, state: SessionState): void => {
+      try {
+        req.onState?.(state);
+      } catch {
+        /* a broken observer is the observer's problem, not the host's */
+      }
+    };
+
     // Race-free wake latch. `admit` and `release` call `kick()` synchronously
     // (from any callback); the pump drains the queue, then suspends until the
     // next kick. `dirty` closes the window between "queue looks drained" and
@@ -79,7 +93,7 @@ export function createModelRuntimeHost<Ctx = unknown>(
       // memory and the pump can't over-admit while a context is still freeing.
       yield* ensure(() => {
         sessions.delete(req.sessionId);
-        req.onState?.({ phase: "reaped" });
+        emit(req, { phase: "reaped" });
         kick();
       });
       yield* ensure(() => {
@@ -88,7 +102,7 @@ export function createModelRuntimeHost<Ctx = unknown>(
       try {
         yield* served.run(m, req.sessionId); // the UNCHANGED harness, concurrent
       } finally {
-        req.onState?.({ phase: "draining" });
+        emit(req, { phase: "draining" });
       }
     }
 
@@ -101,14 +115,14 @@ export function createModelRuntimeHost<Ctx = unknown>(
         dirty = false;
         while (queue.length > 0 && sessions.size < maxNativeSessions) {
           const req = queue.shift()!;
-          req.onState?.({ phase: "warming" });
+          emit(req, { phase: "warming" });
           let m: Materialised<Ctx>;
           try {
             m = yield* call(() => served.materialise(req.sessionId));
           } catch {
             // Typed rejection for THIS request, not a dead pump. Nothing was
             // inserted, so there is nothing to roll back.
-            req.onState?.({ phase: "died" });
+            emit(req, { phase: "died" });
             continue;
           }
           const task = yield* spawn(() => sessionOp(m, req));
@@ -120,7 +134,7 @@ export function createModelRuntimeHost<Ctx = unknown>(
               void task.halt();
             },
           });
-          req.onState?.({ phase: "live" });
+          emit(req, { phase: "live" });
         }
         if (dirty) continue; // a kick landed during the drain — re-drain
         yield* action<void>((resolve) => {
@@ -135,7 +149,16 @@ export function createModelRuntimeHost<Ctx = unknown>(
 
     const host: ModelRuntimeHost<Ctx> = {
       admit(req) {
-        req.onState?.({ phase: "queued", position: queue.length });
+        // Refuse a duplicate: a `sessionId` already resident or waiting would,
+        // once the pump ran, overwrite the live record and orphan its context.
+        if (
+          sessions.has(req.sessionId) ||
+          queue.some((q) => q.sessionId === req.sessionId)
+        ) {
+          emit(req, { phase: "died" });
+          return;
+        }
+        emit(req, { phase: "queued", position: queue.length });
         queue.push(req);
         kick();
       },

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -1,0 +1,159 @@
+/**
+ * `ModelRuntimeHost` — the box-side host that turns ONE resident model into N
+ * users: it admits Sessions (FIFO, capped),
+ * materialises one `SessionContext` per admission over the shared model, and runs
+ * N UNCHANGED harness scopes concurrently.
+ *
+ * Two planes, never conflated:
+ *   · Admission — serialised by the pump (below). The doorman, not the dispatcher.
+ *   · Execution — the N harness scopes, spawned as independent concurrent children;
+ *     the pump never touches a running harness again. (A *third* plane — whether N
+ *     same-model contexts may decode truly-concurrently on the GPU — is what the
+ *     spike measures, backend-uniform; a native width ceiling hardens it later.
+ *     Not this file's concern.)
+ *
+ * Built as an Effection `resource` that `spawn`s each harness as a structured
+ * child, so halting the host unwinds every session — no captured scope, no manual
+ * task management on top of the runtime.
+ */
+import { resource, spawn, action, call, ensure } from "effection";
+import type { Operation } from "effection";
+import type {
+  AdmissionRequest,
+  Materialised,
+  ModelRuntimeHostOpts,
+  NativeSessionRecord,
+} from "./types";
+
+/** The handle a transport (or a driver) drives. Sync methods — callable from a
+ *  plain `ws.on("connection")` callback; they feed the pump, never block it. */
+export interface ModelRuntimeHost<Ctx = unknown> {
+  /** Enqueue a Session for admission (FIFO). Emits `queued`, then the pump takes
+   *  it to `warming`→`live` when a slot is free (or `died` if materialise fails). */
+  admit(req: AdmissionRequest): void;
+  /** Release a live Session: halt its harness scope (the context frees on unwind),
+   *  which re-pumps the queue for the next waiting Session. No-op if unknown.
+   *  Returns the halt promise — the transport may ignore it; a caller that wants
+   *  to await the context actually freeing (e.g. a graceful drain) can. */
+  release(sessionId: string): Promise<void>;
+  /** Live Sessions. `sessions.size` IS the authoritative occupancy (no counter). */
+  readonly sessions: ReadonlyMap<string, NativeSessionRecord<Ctx>>;
+  readonly occupancy: number;
+  readonly queueDepth: number;
+  readonly maxNativeSessions: number;
+}
+
+/**
+ * Create the host. It runs a single admission pump for its lifetime; when the
+ * caller's scope unwinds, the resource tears down — halting the pump and every
+ * session child with it.
+ */
+export function createModelRuntimeHost<Ctx = unknown>(
+  opts: ModelRuntimeHostOpts<Ctx>,
+): Operation<ModelRuntimeHost<Ctx>> {
+  const { served, maxNativeSessions } = opts;
+
+  return resource(function* (provide) {
+    const queue: AdmissionRequest[] = [];
+    const sessions = new Map<string, NativeSessionRecord<Ctx>>();
+
+    // Race-free wake latch. `admit` and `release` call `kick()` synchronously
+    // (from any callback); the pump drains the queue, then suspends until the
+    // next kick. `dirty` closes the window between "queue looks drained" and
+    // "start waiting" — a plain `createSignal` pulse would be lost if it fired
+    // before the pump subscribed, which is exactly what admission does.
+    let dirty = false;
+    let wakeWaiter: (() => void) | null = null;
+    const kick = (): void => {
+      dirty = true;
+      wakeWaiter?.();
+    };
+
+    function* sessionOp(
+      m: Materialised<Ctx>,
+      req: AdmissionRequest,
+    ): Operation<void> {
+      // Teardown runs LIFO — register the slot-drop FIRST (runs last) and the
+      // dispose SECOND (runs first): on unwind we dispose the context BEFORE
+      // dropping the slot + re-pumping, so occupancy never understates resident
+      // memory and the pump can't over-admit while a context is still freeing.
+      yield* ensure(() => {
+        sessions.delete(req.sessionId);
+        req.onState?.({ phase: "reaped" });
+        kick();
+      });
+      yield* ensure(() => {
+        m.dispose();
+      });
+      try {
+        yield* served.run(m, req.sessionId); // the UNCHANGED harness, concurrent
+      } finally {
+        req.onState?.({ phase: "draining" });
+      }
+    }
+
+    // The admission pump. Sole mutator of `queue` + `sessions`; non-reentrant by
+    // being one fiber. `materialise` is awaited here ⇒ context construction is
+    // serialised (over its `await` is the only window an admission could race the
+    // last free slot). The harnesses it spawns run fully concurrently.
+    yield* spawn(function* (): Operation<void> {
+      for (;;) {
+        dirty = false;
+        while (queue.length > 0 && sessions.size < maxNativeSessions) {
+          const req = queue.shift()!;
+          req.onState?.({ phase: "warming" });
+          let m: Materialised<Ctx>;
+          try {
+            m = yield* call(() => served.materialise(req.sessionId));
+          } catch {
+            // Typed rejection for THIS request, not a dead pump. Nothing was
+            // inserted, so there is nothing to roll back.
+            req.onState?.({ phase: "died" });
+            continue;
+          }
+          const task = yield* spawn(() => sessionOp(m, req));
+          sessions.set(req.sessionId, {
+            ...m,
+            sessionId: req.sessionId,
+            task,
+            cancel: () => {
+              void task.halt();
+            },
+          });
+          req.onState?.({ phase: "live" });
+        }
+        if (dirty) continue; // a kick landed during the drain — re-drain
+        yield* action<void>((resolve) => {
+          wakeWaiter = resolve;
+          if (dirty) resolve(); // kicked between the check above and here
+          return () => {
+            wakeWaiter = null;
+          };
+        });
+      }
+    });
+
+    const host: ModelRuntimeHost<Ctx> = {
+      admit(req) {
+        req.onState?.({ phase: "queued", position: queue.length });
+        queue.push(req);
+        kick();
+      },
+      release(sessionId) {
+        const rec = sessions.get(sessionId);
+        return rec ? rec.task.halt() : Promise.resolve();
+      },
+      get sessions() {
+        return sessions;
+      },
+      get occupancy() {
+        return sessions.size;
+      },
+      get queueDepth() {
+        return queue.length;
+      },
+      maxNativeSessions,
+    };
+    yield* provide(host);
+  });
+}

--- a/packages/host/src/host.ts
+++ b/packages/host/src/host.ts
@@ -35,10 +35,13 @@ export interface ModelRuntimeHost<Ctx = unknown> {
    *  `died`) — the one-Session↔one-context invariant, so a duplicate never orphans
    *  a context (including one mid-`warming`, whose materialise is still in flight). */
   admit(req: AdmissionRequest): void;
-  /** Release a live Session: halt its harness scope (the context frees on unwind),
-   *  which re-pumps the queue for the next waiting Session. No-op if unknown.
-   *  Returns the halt promise — the transport may ignore it; a caller that wants
-   *  to await the context actually freeing (e.g. a graceful drain) can. */
+  /** Release a Session at ANY phase — the transport calls this on disconnect:
+   *  `live` halts its harness scope (context frees on unwind, then re-pump);
+   *  `queued` is dropped from the queue (never materialises); `warming` is flagged
+   *  so the pump discards the just-built context rather than spawn a consumer-less
+   *  harness. No-op if unknown. Returns the halt promise for a `live` release (an
+   *  awaitable teardown a graceful drain can wait on); resolves immediately for
+   *  `queued`/`warming` (whose disposal, if any, the pump completes). */
   release(sessionId: string): Promise<void>;
   /** Live Sessions. `sessions.size` IS the authoritative occupancy (no counter). */
   readonly sessions: ReadonlyMap<string, NativeSessionRecord<Ctx>>;
@@ -90,6 +93,14 @@ export function createModelRuntimeHost<Ctx = unknown>(
       dirty = true;
       wakeWaiter?.();
     };
+
+    // The one session whose `materialise` is in flight (the single pump means at
+    // most one at a time) plus a flag `release()` sets to cancel it mid-`warming`.
+    // Kept as a single slot, NOT a per-id set, precisely so a re-`admit` of the
+    // same id can't confuse "this specific request was released" with "this id is
+    // known" — `admitted` stays populated through warming, blocking re-admit.
+    let warmingReq: AdmissionRequest | null = null;
+    let warmingCancelled = false;
 
     function* sessionOp(
       m: Materialised<Ctx>,
@@ -148,6 +159,8 @@ export function createModelRuntimeHost<Ctx = unknown>(
         dirty = false;
         while (queue.length > 0 && sessions.size < maxNativeSessions) {
           const req = queue.shift()!;
+          warmingReq = req;
+          warmingCancelled = false;
           emit(req, { phase: "warming" });
           let m: Materialised<Ctx>;
           try {
@@ -155,8 +168,24 @@ export function createModelRuntimeHost<Ctx = unknown>(
           } catch {
             // Typed rejection for THIS request, not a dead pump. Release the id
             // (nothing else was inserted) so a later admit can retry it.
+            warmingReq = null;
             admitted.delete(req.sessionId);
             emit(req, { phase: "died" });
+            continue;
+          }
+          warmingReq = null;
+          if (warmingCancelled) {
+            // `release()` cancelled this session while its context was being built
+            // (transport gone). Discard the just-built context and never spawn a
+            // consumer-less harness. The id frees HERE — the pump owns the delete
+            // on the cancel path, so a re-admit stayed blocked until now.
+            admitted.delete(req.sessionId);
+            try {
+              m.dispose();
+            } catch {
+              /* freeing a just-built context — not the host's error to surface */
+            }
+            emit(req, { phase: "reaped" });
             continue;
           }
           const task = yield* spawn(() => sessionOp(m, req));
@@ -200,8 +229,26 @@ export function createModelRuntimeHost<Ctx = unknown>(
         kick();
       },
       release(sessionId) {
+        // Live: halt the harness scope (context frees on unwind, pump re-pumps).
         const rec = sessions.get(sessionId);
-        return rec ? rec.task.halt() : Promise.resolve();
+        if (rec) return rec.task.halt();
+        // Warming (materialise in flight for this id): flag it so the pump discards
+        // the just-built context instead of spawning. Leave `admitted` to the
+        // pump's cancel path (keeps a re-admit blocked until the discard completes).
+        if (warmingReq?.sessionId === sessionId) {
+          warmingCancelled = true;
+          return Promise.resolve();
+        }
+        // Queued (behind the cap): pull it out, free its id, re-pump — it never
+        // materialises, so no consumer-less harness is ever spawned.
+        const idx = queue.findIndex((q) => q.sessionId === sessionId);
+        if (idx >= 0) {
+          const [req] = queue.splice(idx, 1);
+          admitted.delete(sessionId);
+          emit(req, { phase: "reaped" });
+          kick();
+        }
+        return Promise.resolve();
       },
       get sessions() {
         return sessions;

--- a/packages/host/src/index.ts
+++ b/packages/host/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @lloyal-labs/host — the box model-runtime host.
+ *
+ * One resident model, N native harness sessions, FIFO admission. Harness-agnostic:
+ * a caller injects a `ServedHarness` (materialise + run) and drives admission; the
+ * host owns queue / cap / lifecycle / `SessionState` and imports no harness.
+ */
+export { createModelRuntimeHost } from "./host";
+export type { ModelRuntimeHost } from "./host";
+export type {
+  SessionState,
+  Materialised,
+  ServedHarness,
+  ModelRuntimeHostOpts,
+  AdmissionRequest,
+  NativeSessionRecord,
+} from "./types";

--- a/packages/host/src/types.ts
+++ b/packages/host/src/types.ts
@@ -1,0 +1,70 @@
+/**
+ * The two host types + the injected-harness seam. Deliberately
+ * generic over the context type `Ctx` so this package imports NO harness and NO
+ * `@lloyal-labs/sdk` — under B, a caller instantiates it with `SessionContext`.
+ */
+import type { Operation, Task, Signal } from "effection";
+import type { EventBus, SessionState } from "@lloyal-labs/binding";
+
+export type { SessionState };
+
+/**
+ * The per-session substrate a harness supplier builds. The host holds these and
+ * routes `uiChannel`/`commands` to the transport; `dispose()` frees the context.
+ * The event/command payloads are opaque to the host (the binding is
+ * payload-opaque), so they are typed `unknown` here.
+ */
+export interface Materialised<Ctx = unknown> {
+  /** The compute context (a `SessionContext` under B). */
+  context: Ctx;
+  /** This session's event bus — the harness sends `WorkflowEvent`s here. */
+  uiChannel: EventBus<unknown>;
+  /** This session's command signal — the transport `send`s into it. */
+  commands: Signal<unknown, void>;
+  /** Free the context. Called by the host on teardown, BEFORE the slot is dropped. */
+  dispose(): void;
+}
+
+/**
+ * The harness-specific half, injected by the harness package (e.g. reasoning.run
+ * via its `./runner` served export). The host calls exactly these two functions
+ * and never imports a harness — this is a DI seam, not a placement abstraction
+ * (the reserved-extension guardrail: keep it to two functions).
+ */
+export interface ServedHarness<Ctx = unknown> {
+  /** Build the per-session substrate over the resident model. Called ON the
+   *  admission pump, so context construction is serialised. All model/context
+   *  params live in the supplier — never in the host. */
+  materialise(sessionId: string): Promise<Materialised<Ctx>>;
+  /** Set the harness's runner context + run its unchanged `harness(ctx,…)` scope.
+   *  Long-running; the host spawns it as a per-session structured child. */
+  run(m: Materialised<Ctx>, sessionId: string): Operation<void>;
+}
+
+/** What `createModelRuntimeHost` needs. */
+export interface ModelRuntimeHostOpts<Ctx = unknown> {
+  /** The injected harness supplier (materialise + run). */
+  served: ServedHarness<Ctx>;
+  /** Resident-session cap; FIFO admission behind it (the MVP admission proxy). */
+  maxNativeSessions: number;
+}
+
+/** What a caller enqueues to admit a Session. */
+export interface AdmissionRequest {
+  sessionId: string;
+  /** The host calls this on every `SessionState` transition
+   *  (queued→warming→live→draining→reaped, or →died). The transport turns these
+   *  into `session`-plane wss frames; a caller learns its Session's fate here. */
+  onState?(state: SessionState): void;
+}
+
+/**
+ * A materialised, running-harness embodiment of one
+ * Session. `sessions.size` (Map of these) IS the occupancy ledger — no counter.
+ */
+export interface NativeSessionRecord<Ctx = unknown> extends Materialised<Ctx> {
+  sessionId: string;
+  /** The spawned harness scope. `cancel()` halts it → the context frees on unwind. */
+  task: Task<void>;
+  cancel(): void;
+}

--- a/packages/host/test/host.test.ts
+++ b/packages/host/test/host.test.ts
@@ -164,16 +164,68 @@ describe("ModelRuntimeHost", () => {
       host.admit({ sessionId: "X", onState: onState("X") });
       yield* waitFor(() => host.sessions.has("X"), "X live");
 
-      // A second admit of the SAME id must be refused — never a second
-      // materialise, never an overwrite of the live record.
+      // A second admit of the SAME id is refused SYNCHRONOUSLY inside admit —
+      // never enqueued, so the pump can't re-materialise or overwrite the live
+      // record. No wait needed: `queueDepth === 0` is the deterministic gate (a
+      // broken guard would have `push`ed).
       const dupPhases: string[] = [];
       host.admit({ sessionId: "X", onState: (s) => dupPhases.push(s.phase) });
-      yield* sleep(20); // give the pump every chance to (wrongly) re-materialise
 
       expect(dupPhases).toEqual(["died"]); // the duplicate was refused
+      expect(host.queueDepth).toBe(0); // never enqueued
       expect(host.occupancy).toBe(1); // still exactly one X
       expect(started.filter((id) => id === "X")).toHaveLength(1); // materialised once
       expect(disposed).toEqual([]); // the live X was NOT disposed/orphaned
+    });
+  });
+
+  it("a throwing served.run dies that session but leaves the host + siblings alive", async () => {
+    const { onState, phases } = stateCollector();
+    const disposed: string[] = [];
+    const served: ServedHarness = {
+      async materialise(id: string): Promise<Materialised> {
+        return {
+          context: { id },
+          uiChannel: createBus<unknown>(),
+          commands: createSignal<unknown, void>(),
+          dispose() {
+            disposed.push(id);
+          },
+        };
+      },
+      *run(_m: Materialised, id: string): Operation<void> {
+        if (id === "boom") throw new Error("harness crashed");
+        yield* suspend(); // a healthy sibling — stays live
+      },
+    };
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 4 });
+      host.admit({ sessionId: "boom", onState: onState("boom") });
+      host.admit({ sessionId: "ok", onState: onState("ok") });
+      yield* waitFor(
+        () =>
+          (phases.get("boom")?.includes("died") ?? false) &&
+          host.sessions.has("ok"),
+        "boom died, ok live",
+      );
+
+      // The crashing harness reached the terminal `died` (never draining/reaped),
+      // yet its context was still disposed + the slot freed — and the throw did
+      // NOT propagate up the spawn to take down the pump.
+      expect(phases.get("boom")).toEqual(["queued", "warming", "live", "died"]);
+      expect(disposed).toEqual(["boom"]); // context freed despite the crash
+      expect(host.sessions.has("boom")).toBe(false);
+
+      // The host survived: the healthy sibling is still live, and the pump still
+      // admits after a session crash.
+      expect(host.sessions.has("ok")).toBe(true);
+      host.admit({ sessionId: "later", onState: onState("later") });
+      yield* waitFor(
+        () => host.sessions.has("later"),
+        "host still admits after a crash",
+      );
+      expect(host.occupancy).toBe(2);
     });
   });
 

--- a/packages/host/test/host.test.ts
+++ b/packages/host/test/host.test.ts
@@ -229,6 +229,70 @@ describe("ModelRuntimeHost", () => {
     });
   });
 
+  it("refuses a duplicate sessionId that races the warming window (materialise in flight)", async () => {
+    const started: string[] = [];
+    const disposed: string[] = [];
+    // A gate that keeps the FIRST materialise pending until we release it —
+    // parking the session in `warming` (shifted from `queue`, not yet in
+    // `sessions`), the exact window the old queue/sessions dedup missed.
+    let releaseMaterialise!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseMaterialise = resolve;
+    });
+    let firstBlocked = false;
+    const served: ServedHarness = {
+      async materialise(id: string): Promise<Materialised> {
+        started.push(id);
+        if (!firstBlocked) {
+          firstBlocked = true;
+          await gate; // hold the first admission in `warming`
+        }
+        return {
+          context: { id },
+          uiChannel: createBus<unknown>(),
+          commands: createSignal<unknown, void>(),
+          dispose() {
+            disposed.push(id);
+          },
+        };
+      },
+      *run(): Operation<void> {
+        yield* suspend();
+      },
+    };
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 4 });
+
+      host.admit({ sessionId: "R", onState: () => {} });
+      // Wait until the pump has SHIFTED R out of the queue and is parked on
+      // materialise: R is now in neither `queue` nor `sessions` — pure `warming`.
+      yield* waitFor(
+        () =>
+          started.includes("R") &&
+          host.queueDepth === 0 &&
+          !host.sessions.has("R"),
+        "R is warming (materialise in flight)",
+      );
+
+      // Duplicate admit DURING the warming window — the race. Must be refused
+      // synchronously and never enqueued (a broken guard would queue it and, once
+      // the pump re-ran, materialise a second context that overwrites the live R).
+      const dupPhases: string[] = [];
+      host.admit({ sessionId: "R", onState: (s) => dupPhases.push(s.phase) });
+      expect(dupPhases).toEqual(["died"]);
+      expect(host.queueDepth).toBe(0);
+
+      // Let the first materialise finish → R goes live, materialised exactly once,
+      // and the live R was never disposed/orphaned.
+      releaseMaterialise();
+      yield* waitFor(() => host.sessions.has("R"), "R live");
+      expect(started.filter((id) => id === "R")).toHaveLength(1);
+      expect(disposed).toEqual([]);
+      expect(host.occupancy).toBe(1);
+    });
+  });
+
   it("survives an onState callback that throws (one bad observer can't sink the host)", async () => {
     const { served } = fakeHarness();
 

--- a/packages/host/test/host.test.ts
+++ b/packages/host/test/host.test.ts
@@ -51,6 +51,22 @@ function stateCollector() {
   return { phases, onState };
 }
 
+/** Poll until `predicate` holds (or throw) — a condition wait, so assertions are
+ *  not hostage to a fixed sleep on a loaded CI box. */
+function* waitFor(
+  predicate: () => boolean,
+  label = "condition",
+  timeoutMs = 2000,
+): Operation<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error(`waitFor: "${label}" not met within ${timeoutMs}ms`);
+    }
+    yield* sleep(2);
+  }
+}
+
 describe("ModelRuntimeHost", () => {
   it("admits up to the cap, queues the rest FIFO, and frees a slot on release", async () => {
     const { served, started, disposed } = fakeHarness();
@@ -62,11 +78,12 @@ describe("ModelRuntimeHost", () => {
       host.admit({ sessionId: "A", onState: onState("A") });
       host.admit({ sessionId: "B", onState: onState("B") });
       host.admit({ sessionId: "C", onState: onState("C") });
-      yield* sleep(20); // let the pump materialise A + B (materialise is async)
+      yield* waitFor(
+        () => host.occupancy === 2 && host.queueDepth === 1,
+        "A + B live, C queued",
+      );
 
       // Cap holds: 2 live, 1 queued. `sessions.size` is the ledger.
-      expect(host.occupancy).toBe(2);
-      expect(host.queueDepth).toBe(1);
       expect([...host.sessions.keys()].sort()).toEqual(["A", "B"]);
       // Construction is serialised through the pump, in admission order.
       expect(started).toEqual(["A", "B"]);
@@ -75,14 +92,15 @@ describe("ModelRuntimeHost", () => {
       expect(phases.get("A")).toEqual(["queued", "warming", "live"]);
 
       // Release A → its context disposes, the slot frees, and the FIFO head (C)
-      // is admitted into it. Await the halt (deterministic teardown), then a beat
+      // is admitted into it. Await the halt (deterministic teardown), then wait
       // for the re-pump to materialise C.
       yield* call(() => host.release("A"));
-      yield* sleep(20);
+      yield* waitFor(
+        () => host.sessions.has("C") && !host.sessions.has("A"),
+        "C admitted into A's freed slot",
+      );
 
       expect(host.occupancy).toBe(2);
-      expect(host.sessions.has("A")).toBe(false);
-      expect(host.sessions.has("C")).toBe(true);
       expect(disposed).toEqual(["A"]); // dispose ran before the slot was reused
       expect(phases.get("A")).toEqual([
         "queued",
@@ -123,13 +141,67 @@ describe("ModelRuntimeHost", () => {
       const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 4 });
       host.admit({ sessionId: "bad", onState: onState("bad") });
       host.admit({ sessionId: "good", onState: onState("good") });
-      yield* sleep(20);
+      yield* waitFor(
+        () =>
+          host.sessions.has("good") &&
+          (phases.get("bad")?.includes("died") ?? false),
+        "bad died, good live",
+      );
 
       // The bad one died; the pump kept going and admitted the good one.
       expect(phases.get("bad")).toEqual(["queued", "warming", "died"]);
       expect(host.sessions.has("bad")).toBe(false);
-      expect(host.sessions.has("good")).toBe(true);
       expect(host.occupancy).toBe(1);
+    });
+  });
+
+  it("refuses a duplicate sessionId without orphaning the live one", async () => {
+    const { served, started, disposed } = fakeHarness();
+    const { onState } = stateCollector();
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 4 });
+      host.admit({ sessionId: "X", onState: onState("X") });
+      yield* waitFor(() => host.sessions.has("X"), "X live");
+
+      // A second admit of the SAME id must be refused — never a second
+      // materialise, never an overwrite of the live record.
+      const dupPhases: string[] = [];
+      host.admit({ sessionId: "X", onState: (s) => dupPhases.push(s.phase) });
+      yield* sleep(20); // give the pump every chance to (wrongly) re-materialise
+
+      expect(dupPhases).toEqual(["died"]); // the duplicate was refused
+      expect(host.occupancy).toBe(1); // still exactly one X
+      expect(started.filter((id) => id === "X")).toHaveLength(1); // materialised once
+      expect(disposed).toEqual([]); // the live X was NOT disposed/orphaned
+    });
+  });
+
+  it("survives an onState callback that throws (one bad observer can't sink the host)", async () => {
+    const { served } = fakeHarness();
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 2 });
+      // A throwing observer fires inside the pump fiber — it must not abort it.
+      host.admit({
+        sessionId: "T",
+        onState: () => {
+          throw new Error("boom");
+        },
+      });
+      yield* waitFor(
+        () => host.sessions.has("T"),
+        "T admitted despite a throwing onState",
+      );
+      expect(host.occupancy).toBe(1);
+
+      // The pump is still alive — a subsequent admission still works.
+      host.admit({ sessionId: "U", onState: () => {} });
+      yield* waitFor(
+        () => host.sessions.has("U"),
+        "U admitted after a throwing observer",
+      );
+      expect(host.occupancy).toBe(2);
     });
   });
 });

--- a/packages/host/test/host.test.ts
+++ b/packages/host/test/host.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { run, sleep, suspend, call, createSignal, type Operation } from "effection";
+import { createBus } from "@lloyal-labs/binding";
+import { createModelRuntimeHost } from "../src/host";
+import type { Materialised, ServedHarness, SessionState } from "../src/types";
+
+/**
+ * A fake `ServedHarness` — no model, no GPU. `materialise` records the admission
+ * and hands back a trivial substrate; `run` suspends forever (a live session)
+ * until the host halts it. Lets us prove the host's admission/lifecycle plane in
+ * isolation (the "prove-with-two-types" gate) without any native cost.
+ */
+function fakeHarness(): {
+  served: ServedHarness;
+  started: string[];
+  disposed: string[];
+  ran: string[];
+} {
+  const started: string[] = [];
+  const disposed: string[] = [];
+  const ran: string[] = [];
+  const served: ServedHarness = {
+    // eslint-disable-next-line @typescript-eslint/require-await
+    async materialise(id: string): Promise<Materialised> {
+      started.push(id);
+      return {
+        context: { id },
+        uiChannel: createBus<unknown>(),
+        commands: createSignal<unknown, void>(),
+        dispose() {
+          disposed.push(id);
+        },
+      };
+    },
+    *run(_m: Materialised, id: string): Operation<void> {
+      ran.push(id);
+      yield* suspend(); // a live session — runs until the host halts it
+    },
+  };
+  return { served, started, disposed, ran };
+}
+
+/** Collect each session's ordered `SessionState.phase` transitions. */
+function stateCollector() {
+  const phases = new Map<string, string[]>();
+  const onState = (id: string) => (s: SessionState) => {
+    const list = phases.get(id) ?? [];
+    list.push(s.phase);
+    phases.set(id, list);
+  };
+  return { phases, onState };
+}
+
+describe("ModelRuntimeHost", () => {
+  it("admits up to the cap, queues the rest FIFO, and frees a slot on release", async () => {
+    const { served, started, disposed } = fakeHarness();
+    const { phases, onState } = stateCollector();
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 2 });
+
+      host.admit({ sessionId: "A", onState: onState("A") });
+      host.admit({ sessionId: "B", onState: onState("B") });
+      host.admit({ sessionId: "C", onState: onState("C") });
+      yield* sleep(20); // let the pump materialise A + B (materialise is async)
+
+      // Cap holds: 2 live, 1 queued. `sessions.size` is the ledger.
+      expect(host.occupancy).toBe(2);
+      expect(host.queueDepth).toBe(1);
+      expect([...host.sessions.keys()].sort()).toEqual(["A", "B"]);
+      // Construction is serialised through the pump, in admission order.
+      expect(started).toEqual(["A", "B"]);
+      // C is parked at `queued` (never materialised).
+      expect(phases.get("C")).toEqual(["queued"]);
+      expect(phases.get("A")).toEqual(["queued", "warming", "live"]);
+
+      // Release A → its context disposes, the slot frees, and the FIFO head (C)
+      // is admitted into it. Await the halt (deterministic teardown), then a beat
+      // for the re-pump to materialise C.
+      yield* call(() => host.release("A"));
+      yield* sleep(20);
+
+      expect(host.occupancy).toBe(2);
+      expect(host.sessions.has("A")).toBe(false);
+      expect(host.sessions.has("C")).toBe(true);
+      expect(disposed).toEqual(["A"]); // dispose ran before the slot was reused
+      expect(phases.get("A")).toEqual([
+        "queued",
+        "warming",
+        "live",
+        "draining",
+        "reaped",
+      ]);
+      expect(phases.get("C")).toEqual(["queued", "warming", "live"]);
+      expect(started).toEqual(["A", "B", "C"]);
+    });
+
+    // Host scope unwound → every remaining session was halted + disposed.
+    expect(disposed.sort()).toEqual(["A", "B", "C"]);
+  });
+
+  it("a failed materialise dies that session without stalling the pump", async () => {
+    const { onState, phases } = stateCollector();
+    const disposed: string[] = [];
+    const served: ServedHarness = {
+      async materialise(id: string): Promise<Materialised> {
+        if (id === "bad") throw new Error("no context");
+        return {
+          context: { id },
+          uiChannel: createBus<unknown>(),
+          commands: createSignal<unknown, void>(),
+          dispose() {
+            disposed.push(id);
+          },
+        };
+      },
+      *run(): Operation<void> {
+        yield* suspend();
+      },
+    };
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 4 });
+      host.admit({ sessionId: "bad", onState: onState("bad") });
+      host.admit({ sessionId: "good", onState: onState("good") });
+      yield* sleep(20);
+
+      // The bad one died; the pump kept going and admitted the good one.
+      expect(phases.get("bad")).toEqual(["queued", "warming", "died"]);
+      expect(host.sessions.has("bad")).toBe(false);
+      expect(host.sessions.has("good")).toBe(true);
+      expect(host.occupancy).toBe(1);
+    });
+  });
+});

--- a/packages/host/test/host.test.ts
+++ b/packages/host/test/host.test.ts
@@ -293,6 +293,98 @@ describe("ModelRuntimeHost", () => {
     });
   });
 
+  it("release cancels a still-queued Session (never materialises, frees the id)", async () => {
+    const { served, started, disposed } = fakeHarness();
+    const { phases, onState } = stateCollector();
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 2 });
+      host.admit({ sessionId: "A", onState: onState("A") });
+      host.admit({ sessionId: "B", onState: onState("B") });
+      host.admit({ sessionId: "C", onState: onState("C") });
+      yield* waitFor(
+        () => host.occupancy === 2 && host.queueDepth === 1,
+        "A + B live, C queued",
+      );
+
+      // Release C while it is still queued behind the cap. It must leave the
+      // queue and never materialise a consumer-less harness.
+      yield* call(() => host.release("C"));
+      expect(host.queueDepth).toBe(0);
+      expect(phases.get("C")).toEqual(["queued", "reaped"]); // never warmed
+      expect(started).toEqual(["A", "B"]); // C never materialised
+      expect(host.occupancy).toBe(2); // cap unaffected
+
+      // Its id is freed — a fresh admit of "C" is accepted (would be refused if
+      // release hadn't cleared `admitted`) and queues behind the cap.
+      host.admit({ sessionId: "C", onState: onState("C") });
+      yield* waitFor(() => host.queueDepth === 1, "fresh C re-queued");
+    });
+
+    // Host scope unwound → only the two live sessions had contexts to dispose;
+    // the cancelled C never built one.
+    expect(disposed.sort()).toEqual(["A", "B"]);
+  });
+
+  it("release during warming discards the just-built context (never spawns a harness)", async () => {
+    const started: string[] = [];
+    const disposed: string[] = [];
+    const phasesW: string[] = [];
+    // Hold the FIRST materialise pending so its session parks in `warming`.
+    let releaseMaterialise!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      releaseMaterialise = resolve;
+    });
+    let firstBlocked = false;
+    const served: ServedHarness = {
+      async materialise(id: string): Promise<Materialised> {
+        started.push(id);
+        if (!firstBlocked) {
+          firstBlocked = true;
+          await gate;
+        }
+        return {
+          context: { id },
+          uiChannel: createBus<unknown>(),
+          commands: createSignal<unknown, void>(),
+          dispose() {
+            disposed.push(id);
+          },
+        };
+      },
+      *run(): Operation<void> {
+        yield* suspend();
+      },
+    };
+
+    await run(function* () {
+      const host = yield* createModelRuntimeHost({ served, maxNativeSessions: 2 });
+      host.admit({ sessionId: "W", onState: (s) => phasesW.push(s.phase) });
+      yield* waitFor(
+        () => started.includes("W") && !host.sessions.has("W"),
+        "W is warming (materialise in flight)",
+      );
+
+      // Release W mid-warming, THEN let its materialise resolve. The pump must
+      // discard the freshly-built context, not spawn a consumer-less harness.
+      yield* call(() => host.release("W"));
+      releaseMaterialise();
+      yield* waitFor(
+        () => disposed.includes("W"),
+        "W's just-built context was disposed",
+      );
+
+      expect(host.sessions.has("W")).toBe(false); // never went live
+      expect(host.occupancy).toBe(0); // slot freed
+      expect(phasesW).toEqual(["queued", "warming", "reaped"]);
+      expect(started.filter((id) => id === "W")).toHaveLength(1); // built once
+
+      // The id freed and the pump is healthy — a fresh admit still goes live.
+      host.admit({ sessionId: "W2", onState: () => {} });
+      yield* waitFor(() => host.sessions.has("W2"), "host still admits after a warming cancel");
+    });
+  });
+
   it("survives an onState callback that throws (one bad observer can't sink the host)", async () => {
     const { served } = fakeHarness();
 

--- a/packages/host/tsconfig.json
+++ b/packages/host/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [{ "path": "../binding" }]
+}


### PR DESCRIPTION
New FSL package **`@lloyal-labs/host`** — the box **model-runtime host** for B serving ("one resident model → many users"). Stage 1 of the serving spine.

## What
`ModelRuntimeHost` multiplexes **N native harness sessions over ONE resident model**:
- **FIFO admission** behind a `maxNativeSessions` cap; `sessions.size` is the ledger (no separate counter).
- A **single-writer, non-reentrant pump** — the doorman, not the dispatcher. It serialises *context construction* (`materialise`), but the harness scopes it spawns run **fully concurrently**; the pump never touches a running harness again.
- Each harness runs as a **structured Effection child** (`spawn`, not a captured scope); **dispose-before-drop** teardown — a released context frees *before* its slot is reused and *before* the queue re-pumps, so occupancy never understates resident memory.
- **`SessionState` authoring** (`queued → warming → live → draining → reaped`, or `died`) via an `onState` callback the transport consumes.

## Harness-agnostic
Generic over the context type and driven by an injected `ServedHarness { materialise, run }` seam — so this package imports **no harness and no `@lloyal-labs/sdk`**. Runtime deps are `@lloyal-labs/binding` + `effection` only. A harness (e.g. reasoning.run) supplies the `ServedHarness`; a driver bridges the two.

## Notes
- The admission wake is a race-free `action` latch (a plain `createSignal` pulse would be lost if `admit` fired before the pump subscribed).
- `release()` returns the halt promise — fire-and-forget for a transport callback, awaitable for a graceful drain.

## Tests
`tsc -b` clean + a unit test with a **fake `ServedHarness`** (no model, no GPU) proving: cap, FIFO queue, serialised materialise, dispose-before-drop teardown, the full `SessionState` sequence, and failed-materialise-doesn't-stall-the-pump.

## Scope
Just the host core. reasoning.run's served export, the `wss` front door, and the Metal web pilot are follow-ups.
