### PR TITLE
ci(release): publish @lloyal-labs/host alongside binding + relay

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,16 @@ jobs:
           test -f packages/binding/dist/web.js
           test -f packages/relay/dist/index.js
           test -f packages/relay/dist/index.d.ts
+          test -f packages/host/dist/index.js
+          test -f packages/host/dist/index.d.ts
 
       - name: Typecheck
-        run: npx tsc -b packages/sdk packages/agents packages/rig packages/binding packages/relay
+        run: npx tsc -b packages/sdk packages/agents packages/rig packages/binding packages/relay packages/host
 
       - name: Publish packages
         if: success() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.skip_publish))
         run: |
-          for pkg in packages/sdk packages/agents packages/rig packages/harness-cli packages/binding packages/relay; do
+          for pkg in packages/sdk packages/agents packages/rig packages/harness-cli packages/binding packages/relay packages/host; do
             name=$(node -p "require('./$pkg/package.json').name")
             version=$(node -p "require('./$pkg/package.json').version")
             if npm view "$name@$version" version >/dev/null 2>&1; then


### PR DESCRIPTION
## Gap

`@lloyal-labs/host@0.1.0` merged in #43 but `release.yml` never referenced it. A `v*` tag today would build/verify/publish sdk, agents, rig, harness-cli, binding, relay — **but not host** — so the package is unpublishable through the pipeline despite being fully publish-ready (`private: false`, `repository.directory` set for `--provenance`, `files`/`main`/`types` correct, `dist/index.{js,d.ts}` emitted).

## Fix

Add `packages/host` to the three package-scoped steps, identical to how binding/relay are wired:
- **dist-verify** — `test -f packages/host/dist/index.{js,d.ts}`
- **typecheck** — appended to `tsc -b …`
- **publish loop** — appended after `binding`/`relay`

The publish loop already skips anything already on npm (`npm view … && skip`), so the next `v*` tag publishes `@lloyal-labs/host@0.1.0` (confirmed absent from npm) and no-ops every already-published package.

Unblocks the B serving driver, which imports `@lloyal-labs/host` from a repo outside this monorepo.