### PR TITLE
feat(rig): verified project-local model catalog + resolveModel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2579,7 +2579,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.1.4",
+      "version": "3.2.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.0.0",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.1.4",
+  "version": "3.2.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -17,7 +17,7 @@
  */
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { createHash } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { Readable, Transform } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 
@@ -47,6 +47,21 @@ export interface ModelCatalogEntry {
 }
 
 const USER_AGENT = '@lloyal-labs/rig model-fetch';
+
+/**
+ * A path segment safe to interpolate into `models/<role>/<id>.gguf` — a plain
+ * name: no path separators, no `..`, no leading dot. Guards a config `id` or
+ * `role` from escaping the project's `models/` directory.
+ */
+const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+function assertSafeSegment(kind: 'role' | 'id', value: string): void {
+  if (!SAFE_SEGMENT.test(value)) {
+    throw new Error(
+      `Invalid model ${kind} "${value}": expected a plain name ` +
+        `([A-Za-z0-9][A-Za-z0-9._-]*), with no path separators.`,
+    );
+  }
+}
 
 /**
  * The platform's default catalog. Extend by adding an entry — no plumbing
@@ -99,6 +114,8 @@ export interface ResolveModelOpts {
   /** The `harness.yml` entry for this role (may be omitted → scan the slot). */
   spec?: ModelSpec;
   onProgress?: ModelProgress;
+  /** Inject a non-default `fetch` (proxied network, or tests). Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
 }
 
 /**
@@ -111,7 +128,8 @@ export interface ResolveModelOpts {
  *   no id                             → exactly one `.gguf` in the role dir → adopt; >1 → fail clearly
  */
 export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
-  const { projectRoot, role, spec, onProgress } = opts;
+  const { projectRoot, role, spec, onProgress, fetchImpl } = opts;
+  assertSafeSegment('role', role);
   const roleDir = path.join(projectRoot, 'models', role);
 
   // 1. explicit path — trusted by possession
@@ -125,6 +143,7 @@ export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
 
   // 2/3. configured id → slot; fetch + verify if absent
   if (spec?.id) {
+    assertSafeSegment('id', spec.id);
     const slot = path.join(roleDir, `${spec.id}.gguf`);
     if (fs.existsSync(slot)) return slot;
     const entry = catalogEntry(role, spec.id);
@@ -134,7 +153,7 @@ export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
           `Drop the .gguf there, or set a known catalog id.`,
       );
     }
-    return fetchVerified(entry, slot, onProgress);
+    return fetchVerified(entry, slot, { onProgress, fetchImpl });
   }
 
   // 4. no id / no path → adopt the sole .gguf in the role dir, or fail clearly
@@ -154,24 +173,34 @@ export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
   );
 }
 
-/** Stream a catalog entry into `dest`, verify sha256 fail-closed, atomic rename.
- *  Walks `entry.urls` in fallback order; a truncated or tampered download is
- *  deleted and errored, never renamed into place. */
-async function fetchVerified(
+/** Options for {@link fetchVerified}. */
+export interface FetchVerifiedOpts {
+  onProgress?: ModelProgress;
+  /** Inject a non-default `fetch`. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Stream a catalog entry into `dest`, verify sha256 fail-closed, atomic rename.
+ * Walks `entry.urls` in fallback order; a truncated or tampered download is
+ * deleted and errored, never renamed into place. Exposed for reuse + testing.
+ */
+export async function fetchVerified(
   entry: ModelCatalogEntry,
   dest: string,
-  onProgress?: ModelProgress,
+  opts: FetchVerifiedOpts = {},
 ): Promise<string> {
   fs.mkdirSync(path.dirname(dest), { recursive: true });
-  const tmp = `${dest}.partial`;
-  try { fs.unlinkSync(tmp); } catch { /* stale or first run */ }
+  // Per-invocation temp name so concurrent fetches of the same model never
+  // race on — or delete — each other's partial.
+  const tmp = `${dest}.${process.pid}.${randomBytes(4).toString('hex')}.partial`;
 
   const errors: string[] = [];
   for (const url of entry.urls) {
     try {
-      return await streamOne(entry, url, tmp, dest, onProgress);
+      return await streamOne(entry, url, tmp, dest, opts);
     } catch (err) {
-      errors.push(`  ${url}: ${(err as Error).message}`);
+      errors.push(`  ${url}: ${err instanceof Error ? err.message : String(err)}`);
       try { fs.unlinkSync(tmp); } catch { /* best effort */ }
     }
   }
@@ -183,11 +212,16 @@ async function streamOne(
   url: string,
   tmp: string,
   dest: string,
-  onProgress?: ModelProgress,
+  opts: FetchVerifiedOpts,
 ): Promise<string> {
-  const res = await fetch(url, { redirect: 'follow', headers: { 'User-Agent': USER_AGENT } });
+  const doFetch = opts.fetchImpl ?? fetch;
+  const res = await doFetch(url, { redirect: 'follow', headers: { 'User-Agent': USER_AGENT } });
   if (!res.ok || !res.body) throw new Error(`HTTP ${res.status} ${res.statusText}`);
-  const total = Number(res.headers.get('content-length') ?? entry.sizeBytes);
+
+  // Content-Length is progress-display only; fall back to the catalog size
+  // unless the header is a positive finite number.
+  const headerLen = Number(res.headers.get('content-length'));
+  const total = Number.isFinite(headerLen) && headerLen > 0 ? headerLen : entry.sizeBytes;
 
   const hash = createHash('sha256');
   let got = 0;
@@ -197,15 +231,15 @@ async function streamOne(
       hash.update(chunk);
       got += chunk.length;
       const now = Date.now();
-      if (onProgress && now - lastEmit >= 200) {
+      if (opts.onProgress && now - lastEmit >= 200) {
         lastEmit = now;
-        onProgress(got, total, url);
+        opts.onProgress(got, total, url);
       }
       cb(null, chunk);
     },
   });
 
-  // Stream (never buffer 2.6 GB) with correct backpressure via pipeline.
+  // Stream (never buffer multi-GB weights) with correct backpressure via pipeline.
   await pipeline(
     Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]),
     meter,
@@ -220,6 +254,6 @@ async function streamOne(
     );
   }
   fs.renameSync(tmp, dest);
-  onProgress?.(got, total, url);
+  opts.onProgress?.(got, total, url);
   return dest;
 }

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -55,10 +55,10 @@ const USER_AGENT = '@lloyal-labs/rig model-fetch';
  */
 const SAFE_SEGMENT = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
 function assertSafeSegment(kind: 'role' | 'id', value: string): void {
-  if (!SAFE_SEGMENT.test(value)) {
+  if (!SAFE_SEGMENT.test(value) || value.includes('..')) {
     throw new Error(
       `Invalid model ${kind} "${value}": expected a plain name ` +
-        `([A-Za-z0-9][A-Za-z0-9._-]*), with no path separators.`,
+        `([A-Za-z0-9][A-Za-z0-9._-]*), with no path separators or "..".`,
     );
   }
 }
@@ -156,10 +156,20 @@ export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
     return fetchVerified(entry, slot, { onProgress, fetchImpl });
   }
 
-  // 4. no id / no path → adopt the sole .gguf in the role dir, or fail clearly
-  const present = fs.existsSync(roleDir)
-    ? fs.readdirSync(roleDir).filter((f) => f.endsWith('.gguf'))
-    : [];
+  // 4. no id / no path → adopt the sole .gguf in the role dir, or fail clearly.
+  // Guard for a real directory (a file at models/<role> shouldn't ENOTDIR) and
+  // count only regular `.gguf` files (not a directory that happens to end .gguf).
+  let present: string[] = [];
+  try {
+    if (fs.statSync(roleDir).isDirectory()) {
+      present = fs
+        .readdirSync(roleDir, { withFileTypes: true })
+        .filter((d) => d.isFile() && d.name.endsWith('.gguf'))
+        .map((d) => d.name);
+    }
+  } catch {
+    // roleDir absent or not statable → no local models for this role
+  }
   if (present.length === 1) return path.join(roleDir, present[0]);
   if (present.length === 0) {
     throw new Error(

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -1,0 +1,225 @@
+/**
+ * Model catalog + verified, project-local resolution/fetch.
+ *
+ * The platform's curated default models, and the one walk that turns a
+ * `harness.yml` model spec + a role into a concrete `.gguf` path — fetching
+ * into the project's `models/<role>/<id>.gguf` slot on first use, **fail-closed
+ * digest-verified** against the catalog's `sha256`. This lives in the platform
+ * (a dep of the generated project), not in user-editable scaffold code, so the
+ * integrity check can't be weakened downstream — the same trust bar as the
+ * signed app channel, from the opposite direction.
+ *
+ * Node-only (node:fs / node:crypto / streaming fetch). Import from
+ * `@lloyal-labs/rig/node`.
+ *
+ * @packageDocumentation
+ * @category Rig
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+import { Readable, Transform } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+/** The model roles a harness provisions. `llm` always; `reranker` when an app
+ *  requires it; `embedding` reserved for the first consumer. */
+export type ModelRole = 'llm' | 'reranker' | 'embedding';
+
+/**
+ * A curated default model. `sha256` is the platform trust root — every catalog
+ * fetch is verified against it, fail-closed. It never lives in `harness.yml`; a
+ * dropped or `path:`-referenced weight is trusted by possession.
+ */
+export interface ModelCatalogEntry {
+  /** Stable id; the on-disk slot is `models/<role>/<id>.gguf`. */
+  id: string;
+  role: ModelRole;
+  /** Human label for progress + errors. */
+  label: string;
+  /** Download URLs in fallback order (upstream first, lloyal mirror second). */
+  urls: string[];
+  /** Fail-closed digest, lowercase hex. */
+  sha256: string;
+  /** Approx size, for a progress ETA when Content-Length is absent. */
+  sizeBytes: number;
+  /** Suggested `context` (nCtx) when the harness doesn't set one. */
+  recommendedContext?: number;
+}
+
+const USER_AGENT = '@lloyal-labs/rig model-fetch';
+
+/**
+ * The platform's default catalog. Extend by adding an entry — no plumbing
+ * change. `id`s are the friendly, dx-facing names (`reasoning-4b`), decoupled
+ * from the upstream filename.
+ */
+export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
+  {
+    id: 'reasoning-4b',
+    role: 'llm',
+    label: 'Reasoning 4B · Q4_K_M',
+    urls: [
+      'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf',
+      'https://models.lloyal.ai/Qwen3.5-4B-Q4_K_M.gguf',
+    ],
+    sha256: '00fe7986ff5f6b463e62455821146049db6f9313603938a70800d1fb69ef11a4',
+    sizeBytes: 2_600_000_000,
+    recommendedContext: 32768,
+  },
+  {
+    id: 'qwen3-reranker-0.6b-q8',
+    role: 'reranker',
+    label: 'Qwen3 Reranker 0.6B · Q8_0',
+    urls: [
+      'https://huggingface.co/ggml-org/Qwen3-Reranker-0.6B-Q8_0-GGUF/resolve/main/qwen3-reranker-0.6b-q8_0.gguf',
+      'https://models.lloyal.ai/qwen3-reranker-0.6b-q8_0.gguf',
+    ],
+    sha256: '22c9979ce4fbcdc5acdc310c6641c32797eff1aa980b8f7a2db8a8ea23429a48',
+    sizeBytes: 630_000_000,
+  },
+];
+
+/** Look up a catalog entry by role + id. */
+export function catalogEntry(role: ModelRole, id: string): ModelCatalogEntry | undefined {
+  return MODEL_CATALOG.find((e) => e.role === role && e.id === id);
+}
+
+export type ModelProgress = (got: number, total: number, url: string) => void;
+
+/** A `harness.yml` model spec (one role): either a catalog `id` or an explicit `path`. */
+export interface ModelSpec {
+  id?: string;
+  path?: string;
+}
+
+export interface ResolveModelOpts {
+  /** Project root (where `models/` lives). */
+  projectRoot: string;
+  role: ModelRole;
+  /** The `harness.yml` entry for this role (may be omitted → scan the slot). */
+  spec?: ModelSpec;
+  onProgress?: ModelProgress;
+}
+
+/**
+ * Resolve a `(role, spec)` to a concrete local `.gguf` path, fetching +
+ * verifying if needed. The walk (dx.md §3.2):
+ *
+ *   explicit `path:`                  → use as-is (no copy; trusted by possession)
+ *   `models/<role>/<id>.gguf` present → use it
+ *   `id:`                             → catalog fetch + fail-closed digest → write the slot
+ *   no id                             → exactly one `.gguf` in the role dir → adopt; >1 → fail clearly
+ */
+export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
+  const { projectRoot, role, spec, onProgress } = opts;
+  const roleDir = path.join(projectRoot, 'models', role);
+
+  // 1. explicit path — trusted by possession
+  if (spec?.path) {
+    const p = path.resolve(projectRoot, spec.path);
+    if (!fs.existsSync(p)) {
+      throw new Error(`Model path not found for role "${role}": ${p}`);
+    }
+    return p;
+  }
+
+  // 2/3. configured id → slot; fetch + verify if absent
+  if (spec?.id) {
+    const slot = path.join(roleDir, `${spec.id}.gguf`);
+    if (fs.existsSync(slot)) return slot;
+    const entry = catalogEntry(role, spec.id);
+    if (!entry) {
+      throw new Error(
+        `Model "${spec.id}" (role "${role}") isn't at ${slot} and isn't in the catalog. ` +
+          `Drop the .gguf there, or set a known catalog id.`,
+      );
+    }
+    return fetchVerified(entry, slot, onProgress);
+  }
+
+  // 4. no id / no path → adopt the sole .gguf in the role dir, or fail clearly
+  const present = fs.existsSync(roleDir)
+    ? fs.readdirSync(roleDir).filter((f) => f.endsWith('.gguf'))
+    : [];
+  if (present.length === 1) return path.join(roleDir, present[0]);
+  if (present.length === 0) {
+    throw new Error(
+      `No model configured for role "${role}" and none in models/${role}/. ` +
+        `Set an id/path in harness.yml, or drop a .gguf there.`,
+    );
+  }
+  throw new Error(
+    `Ambiguous model for role "${role}": ${present.length} .gguf files in models/${role}/ ` +
+      `(${present.join(', ')}). Set an explicit id/path in harness.yml.`,
+  );
+}
+
+/** Stream a catalog entry into `dest`, verify sha256 fail-closed, atomic rename.
+ *  Walks `entry.urls` in fallback order; a truncated or tampered download is
+ *  deleted and errored, never renamed into place. */
+async function fetchVerified(
+  entry: ModelCatalogEntry,
+  dest: string,
+  onProgress?: ModelProgress,
+): Promise<string> {
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  const tmp = `${dest}.partial`;
+  try { fs.unlinkSync(tmp); } catch { /* stale or first run */ }
+
+  const errors: string[] = [];
+  for (const url of entry.urls) {
+    try {
+      return await streamOne(entry, url, tmp, dest, onProgress);
+    } catch (err) {
+      errors.push(`  ${url}: ${(err as Error).message}`);
+      try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    }
+  }
+  throw new Error(`Failed to fetch ${entry.label} from any source:\n${errors.join('\n')}`);
+}
+
+async function streamOne(
+  entry: ModelCatalogEntry,
+  url: string,
+  tmp: string,
+  dest: string,
+  onProgress?: ModelProgress,
+): Promise<string> {
+  const res = await fetch(url, { redirect: 'follow', headers: { 'User-Agent': USER_AGENT } });
+  if (!res.ok || !res.body) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+  const total = Number(res.headers.get('content-length') ?? entry.sizeBytes);
+
+  const hash = createHash('sha256');
+  let got = 0;
+  let lastEmit = 0;
+  const meter = new Transform({
+    transform(chunk: Buffer, _enc, cb): void {
+      hash.update(chunk);
+      got += chunk.length;
+      const now = Date.now();
+      if (onProgress && now - lastEmit >= 200) {
+        lastEmit = now;
+        onProgress(got, total, url);
+      }
+      cb(null, chunk);
+    },
+  });
+
+  // Stream (never buffer 2.6 GB) with correct backpressure via pipeline.
+  await pipeline(
+    Readable.fromWeb(res.body as Parameters<typeof Readable.fromWeb>[0]),
+    meter,
+    fs.createWriteStream(tmp),
+  );
+
+  const digest = hash.digest('hex');
+  if (digest !== entry.sha256) {
+    try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    throw new Error(
+      `Digest mismatch for ${entry.label}: expected ${entry.sha256}, got ${digest} — refusing to load.`,
+    );
+  }
+  fs.renameSync(tmp, dest);
+  onProgress?.(got, total, url);
+  return dest;
+}

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -132,11 +132,17 @@ export async function resolveModel(opts: ResolveModelOpts): Promise<string> {
   assertSafeSegment('role', role);
   const roleDir = path.join(projectRoot, 'models', role);
 
-  // 1. explicit path — trusted by possession
+  // 1. explicit path — trusted by possession, but must be a real file
   if (spec?.path) {
     const p = path.resolve(projectRoot, spec.path);
-    if (!fs.existsSync(p)) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(p);
+    } catch {
       throw new Error(`Model path not found for role "${role}": ${p}`);
+    }
+    if (!stat.isFile()) {
+      throw new Error(`Model path for role "${role}" is not a file: ${p}`);
     }
     return p;
   }

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -253,7 +253,18 @@ async function streamOne(
       `Digest mismatch for ${entry.label}: expected ${entry.sha256}, got ${digest} — refusing to load.`,
     );
   }
-  fs.renameSync(tmp, dest);
+  // Atomic replace. POSIX `rename` replaces silently; Windows `rename` fails if
+  // `dest` exists — and a concurrent fetch may already have placed a
+  // (digest-verified) copy there, in which case an existing `dest` is fine.
+  try {
+    fs.renameSync(tmp, dest);
+  } catch (err) {
+    if (fs.existsSync(dest)) {
+      try { fs.unlinkSync(tmp); } catch { /* best effort */ }
+    } else {
+      throw err;
+    }
+  }
   opts.onProgress?.(got, total, url);
   return dest;
 }

--- a/packages/rig/src/node.ts
+++ b/packages/rig/src/node.ts
@@ -23,11 +23,12 @@ export { loadResources, chunkResources, resolveCorpusInput } from './resources';
 
 // Node-only: model catalog + verified project-local resolution/fetch
 // (requires node:fs / node:crypto / streaming fetch)
-export { MODEL_CATALOG, catalogEntry, resolveModel } from './models';
+export { MODEL_CATALOG, catalogEntry, resolveModel, fetchVerified } from './models';
 export type {
   ModelRole,
   ModelCatalogEntry,
   ModelSpec,
   ModelProgress,
   ResolveModelOpts,
+  FetchVerifiedOpts,
 } from './models';

--- a/packages/rig/src/node.ts
+++ b/packages/rig/src/node.ts
@@ -20,3 +20,14 @@ export { createReranker } from './reranker';
 
 // Node-only: Resource loading (requires node:fs)
 export { loadResources, chunkResources, resolveCorpusInput } from './resources';
+
+// Node-only: model catalog + verified project-local resolution/fetch
+// (requires node:fs / node:crypto / streaming fetch)
+export { MODEL_CATALOG, catalogEntry, resolveModel } from './models';
+export type {
+  ModelRole,
+  ModelCatalogEntry,
+  ModelSpec,
+  ModelProgress,
+  ResolveModelOpts,
+} from './models';

--- a/packages/rig/test/models.test.ts
+++ b/packages/rig/test/models.test.ts
@@ -141,6 +141,17 @@ describe('fetchVerified — streaming digest verification', () => {
     expect(fs.readFileSync(dest)).toEqual(Buffer.from(bytes));
   });
 
+  it('dest already present (concurrent winner) → resolves without error', async () => {
+    const dest = path.join(root, 'models/llm/t.gguf');
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.writeFileSync(dest, Buffer.from(bytes)); // a prior/concurrent verified copy
+    const out = await fetchVerified(entry(sha256(bytes), ['mock://ok']), dest, {
+      fetchImpl: mockFetch({ 'mock://ok': bytes }),
+    });
+    expect(out).toBe(dest);
+    expect(fs.readFileSync(dest)).toEqual(Buffer.from(bytes));
+  });
+
   it('all URLs fail → aggregated error naming each source', async () => {
     const dest = path.join(root, 'models/llm/t.gguf');
     await expect(

--- a/packages/rig/test/models.test.ts
+++ b/packages/rig/test/models.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Tests for the verified, project-local model resolver ({@link resolveModel})
+ * and the streaming digest-verified download ({@link fetchVerified}).
+ *
+ * Behaviours verified:
+ *  1. `path:` resolution (as-is, no copy) + missing-path error.
+ *  2. `id:` with an existing slot → used without a fetch.
+ *  3. No-spec adoption: sole `.gguf` adopted; `>1` → ambiguous error; empty → clear error.
+ *  4. Path-traversal guard on `id`/`role` (no escape from `models/`).
+ *  5. `fetchVerified`: digest match writes the slot; **digest mismatch deletes the
+ *     `.partial` and throws** (nothing written); URL fallback; all-fail aggregation.
+ *
+ * @category Testing
+ */
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { createHash } from 'node:crypto';
+import {
+  resolveModel,
+  fetchVerified,
+  type ModelCatalogEntry,
+  type ModelRole,
+} from '../src/models';
+
+let root: string;
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'rig-models-'));
+});
+afterEach(() => {
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function put(rel: string, content = 'x'): string {
+  const p = path.join(root, rel);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+const sha256 = (b: Uint8Array): string => createHash('sha256').update(b).digest('hex');
+
+/** A `fetch` stub: each url maps to bytes (200 OK) or an Error (thrown). */
+function mockFetch(map: Record<string, Uint8Array | Error>): typeof fetch {
+  return (async (input: unknown): Promise<Response> => {
+    const url = String(input);
+    const v = map[url];
+    if (v instanceof Error) throw v;
+    if (v === undefined) throw new Error(`no mock for ${url}`);
+    return new Response(v);
+  }) as unknown as typeof fetch;
+}
+
+describe('resolveModel — filesystem walk', () => {
+  it('explicit path: resolves absolute, no copy', async () => {
+    put('weights/my.gguf');
+    const out = await resolveModel({ projectRoot: root, role: 'llm', spec: { path: 'weights/my.gguf' } });
+    expect(out).toBe(path.join(root, 'weights/my.gguf'));
+  });
+
+  it('explicit path: missing → throws', async () => {
+    await expect(
+      resolveModel({ projectRoot: root, role: 'llm', spec: { path: 'nope.gguf' } }),
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('id with an existing slot → used without a fetch', async () => {
+    put('models/llm/reasoning-4b.gguf');
+    const out = await resolveModel({ projectRoot: root, role: 'llm', spec: { id: 'reasoning-4b' } });
+    expect(out).toBe(path.join(root, 'models/llm/reasoning-4b.gguf'));
+  });
+
+  it('no spec + sole .gguf → adopted', async () => {
+    put('models/llm/whatever.gguf');
+    const out = await resolveModel({ projectRoot: root, role: 'llm' });
+    expect(out).toBe(path.join(root, 'models/llm/whatever.gguf'));
+  });
+
+  it('no spec + >1 .gguf → fails clearly (never guesses)', async () => {
+    put('models/llm/a.gguf');
+    put('models/llm/b.gguf');
+    await expect(resolveModel({ projectRoot: root, role: 'llm' })).rejects.toThrow(/Ambiguous/);
+  });
+
+  it('no spec + empty role dir → clear error', async () => {
+    await expect(resolveModel({ projectRoot: root, role: 'llm' })).rejects.toThrow(/No model configured/);
+  });
+
+  it('id with path traversal → rejected (no escape from models/)', async () => {
+    await expect(
+      resolveModel({ projectRoot: root, role: 'llm', spec: { id: '../../etc/passwd' } }),
+    ).rejects.toThrow(/Invalid model id/);
+  });
+
+  it('role with path traversal → rejected', async () => {
+    await expect(
+      resolveModel({ projectRoot: root, role: '../evil' as ModelRole }),
+    ).rejects.toThrow(/Invalid model role/);
+  });
+});
+
+describe('fetchVerified — streaming digest verification', () => {
+  const bytes = new TextEncoder().encode('GGUF-TEST-BYTES');
+  const entry = (sha: string, urls: string[]): ModelCatalogEntry => ({
+    id: 't',
+    role: 'llm',
+    label: 'Test Model',
+    urls,
+    sha256: sha,
+    sizeBytes: bytes.length,
+  });
+
+  it('digest match → writes the slot, returns its path', async () => {
+    const dest = path.join(root, 'models/llm/t.gguf');
+    const out = await fetchVerified(entry(sha256(bytes), ['mock://ok']), dest, {
+      fetchImpl: mockFetch({ 'mock://ok': bytes }),
+    });
+    expect(out).toBe(dest);
+    expect(fs.readFileSync(dest)).toEqual(Buffer.from(bytes));
+  });
+
+  it('digest mismatch → throws + deletes .partial (nothing written)', async () => {
+    const dest = path.join(root, 'models/llm/t.gguf');
+    await expect(
+      fetchVerified(entry('de'.repeat(32), ['mock://bad']), dest, {
+        fetchImpl: mockFetch({ 'mock://bad': bytes }),
+      }),
+    ).rejects.toThrow(/Digest mismatch/);
+    expect(fs.existsSync(dest)).toBe(false);
+    const leftover = fs.readdirSync(path.dirname(dest)).filter((f) => f.includes('.partial'));
+    expect(leftover).toHaveLength(0);
+  });
+
+  it('URL fallback → first fails, second succeeds', async () => {
+    const dest = path.join(root, 'models/llm/t.gguf');
+    const out = await fetchVerified(entry(sha256(bytes), ['mock://down', 'mock://up']), dest, {
+      fetchImpl: mockFetch({ 'mock://down': new Error('ECONNREFUSED'), 'mock://up': bytes }),
+    });
+    expect(out).toBe(dest);
+    expect(fs.readFileSync(dest)).toEqual(Buffer.from(bytes));
+  });
+
+  it('all URLs fail → aggregated error naming each source', async () => {
+    const dest = path.join(root, 'models/llm/t.gguf');
+    await expect(
+      fetchVerified(entry(sha256(bytes), ['mock://a', 'mock://b']), dest, {
+        fetchImpl: mockFetch({ 'mock://a': new Error('boom-a'), 'mock://b': new Error('boom-b') }),
+      }),
+    ).rejects.toThrow(/Failed to fetch[\s\S]*boom-a[\s\S]*boom-b/);
+  });
+});

--- a/packages/rig/test/models.test.ts
+++ b/packages/rig/test/models.test.ts
@@ -65,6 +65,13 @@ describe('resolveModel — filesystem walk', () => {
     ).rejects.toThrow(/not found/);
   });
 
+  it('explicit path: pointing at a directory → rejected (must be a file)', async () => {
+    fs.mkdirSync(path.join(root, 'weights'), { recursive: true });
+    await expect(
+      resolveModel({ projectRoot: root, role: 'llm', spec: { path: 'weights' } }),
+    ).rejects.toThrow(/not a file/);
+  });
+
   it('id with an existing slot → used without a fetch', async () => {
     put('models/llm/reasoning-4b.gguf');
     const out = await resolveModel({ projectRoot: root, role: 'llm', spec: { id: 'reasoning-4b' } });

--- a/packages/rig/test/models.test.ts
+++ b/packages/rig/test/models.test.ts
@@ -98,6 +98,23 @@ describe('resolveModel — filesystem walk', () => {
       resolveModel({ projectRoot: root, role: '../evil' as ModelRole }),
     ).rejects.toThrow(/Invalid model role/);
   });
+
+  it('id containing ".." → rejected (matches the docstring)', async () => {
+    await expect(
+      resolveModel({ projectRoot: root, role: 'llm', spec: { id: 'a..b' } }),
+    ).rejects.toThrow(/Invalid model id/);
+  });
+
+  it('role path is a file (not a directory) → clear error, no ENOTDIR crash', async () => {
+    fs.mkdirSync(path.join(root, 'models'), { recursive: true });
+    fs.writeFileSync(path.join(root, 'models', 'llm'), 'oops'); // models/llm is a FILE
+    await expect(resolveModel({ projectRoot: root, role: 'llm' })).rejects.toThrow(/No model configured/);
+  });
+
+  it('a directory named *.gguf is not adopted (regular files only)', async () => {
+    fs.mkdirSync(path.join(root, 'models', 'llm', 'notamodel.gguf'), { recursive: true });
+    await expect(resolveModel({ projectRoot: root, role: 'llm' })).rejects.toThrow(/No model configured/);
+  });
 });
 
 describe('fetchVerified — streaming digest verification', () => {


### PR DESCRIPTION
## What

Verified, project-local model resolution in `@lloyal-labs/rig/node`:

- **`MODEL_CATALOG`** — the platform's curated defaults with **pinned sha256 digests** (`reasoning-4b` llm, `qwen3-reranker-0.6b-q8`). `id`s are the friendly, dx-facing names, decoupled from upstream filenames.
- **`resolveModel({ projectRoot, role, spec })`** — the `harness.yml` → `models/<role>/<id>.gguf` walk: explicit `path:` (as-is, no copy) → `<id>.gguf` slot present → catalog `id` (fetch) → no-id (sole `.gguf` adopted; `>1` → fail clearly).
- **Fail-closed streaming verify** — streams (never buffers multi-GB weights; backpressure via `pipeline`), hashes inline, URL fallback (HF → lloyal mirror). A digest mismatch **deletes the `.partial` and throws** — a truncated or tampered download is never renamed into place.

The integrity check lives in the platform dep, not in user-editable scaffold code — the same trust bar as the signed app channel (Ed25519), from the opposite direction.

## Why

The `harness.dev create` blank template is batteries-included: `npm start` fetches a default model with **no API key**, and a stranger must be able to trust the largest artifact. The prior model fetch had no digest and no post-download verification; this is the platform-owned, verified replacement the generated project's boot will call.

## Notes

- Node-only (`node:fs` / `node:crypto` / streaming fetch), exported from `@lloyal-labs/rig/node`.
- Additive, no breaking changes. rig 3.1.4 → 3.2.0 (+ lockfile).
- `tsc -b` green; exports confirmed in `dist/node.d.ts`.
