### PR TITLE
feat(harness-cli): blank template on the harness contract + verified model fetch

### DIFF
--- a/packages/harness-cli/src/commands/create.ts
+++ b/packages/harness-cli/src/commands/create.ts
@@ -22,9 +22,9 @@ const USAGE = [
   '  --dir <path>  Parent directory to create the harness in (default: cwd)',
   '  -h, --help    Show this help',
   '',
-  'Emits a runnable harness: parallel research pool + synth, wired to the',
-  'lloyal/wikipedia app via the signed-channel canonical URL. Plug in your',
-  'own model in harness.json and run `npm install && npm run dev "<query>"`.',
+  'Emits a runnable harness: a parallel research pool + synth over a resident',
+  'model (fetched + verified on first run — no API key), wired to the signed',
+  'lloyal/wikipedia app. Run `npm install && npm start`.',
 ].join('\n');
 
 // Same grammar as `harness.dev app`: identifier-safe lowercase that
@@ -76,7 +76,7 @@ export const createCommand: Command = {
       // ENOENT — good
     }
 
-    const templateDir = resolveTemplateDir('harness');
+    const templateDir = resolveTemplateDir('blank');
     const substitutions = buildSubstitutions(name);
 
     try {
@@ -93,12 +93,11 @@ export const createCommand: Command = {
         '  next steps:\n' +
         `    cd ${name}\n` +
         '    npm install\n' +
-        '    edit harness.json — point model.path at a local .gguf file\n' +
-        `    npm run dev "What was the Cuban missile crisis?"\n` +
+        '    npm start\n' +
         '\n' +
-        '  the harness ships with the lloyal/wikipedia app preinstalled\n' +
-        '  (signed-channel canonical URL). Add more apps via:\n' +
-        '    npx harness.dev install lloyal/corpus\n',
+        '  No API key needed — the model is fetched + digest-verified on first\n' +
+        '  run and runs inside your app. The lloyal/wikipedia app is preinstalled;\n' +
+        '  add more via: npx harness.dev install <publisher>/<name>\n',
     );
     return 0;
   },
@@ -110,7 +109,7 @@ export const createCommand: Command = {
  * `<pkg-root>/dist/commands/create.js`, so the templates are at
  * `<pkg-root>/templates/<kind>`.
  */
-function resolveTemplateDir(kind: 'app' | 'harness'): string {
+function resolveTemplateDir(kind: 'app' | 'harness' | 'blank'): string {
   const here = __dirname;
   const candidates = [
     resolve(here, '..', '..', 'templates', kind),

--- a/packages/harness-cli/templates/blank/.gitignore
+++ b/packages/harness-cli/templates/blank/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+dist/
+traces/
+
+# Model weights are fetched or dropped locally, never committed.
+models/**/*.gguf
+
+*.log
+.DS_Store

--- a/packages/harness-cli/templates/blank/LICENSE
+++ b/packages/harness-cli/templates/blank/LICENSE
@@ -1,0 +1,189 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept support,
+      warranty, indemnity, or other liability obligations and/or rights
+      consistent with this License. However, in accepting such obligations,
+      You may act only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Lloyal Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/harness-cli/templates/blank/README.md
+++ b/packages/harness-cli/templates/blank/README.md
@@ -1,0 +1,38 @@
+# __NAME__
+
+A vertical inference harness. The model lives *inside* the app — there is no API key, and nothing on the inference path touches the network.
+
+## Run it
+
+```sh
+npm install
+# point harness.json at a local .gguf model file, then:
+npm run dev "What was the Cuban missile crisis?"   # or just: npm start
+```
+
+`npm start` opens a terminal UI; type a question and watch two agents research it in parallel and a synth combine their notes.
+
+## The shape
+
+```
+harness/
+  harness.ts     ← the one file that's yours: your program, as code
+  protocol.ts    the events (↓) and commands (↑) your harness speaks
+  state.ts       how a view folds those events into renderable state
+targets/
+  cli.ts         run in a terminal (generated · rarely touched)
+  cli-view.tsx   the terminal view
+harness.json     model + settings
+```
+
+Everything under `targets/` is convention handled for you. The center —
+`harness/harness.ts` — is where you program what your intelligence does: which
+agents exist, how they collaborate, what evidence they trust, when work is done.
+
+## Add capabilities
+
+```sh
+npx harness.dev install lloyal/corpus   # a signed AgentApp from apps.lloyal.ai
+```
+
+Enable it in `harness/harness.ts` alongside `createWikipediaApp`.

--- a/packages/harness-cli/templates/blank/README.md
+++ b/packages/harness-cli/templates/blank/README.md
@@ -1,16 +1,15 @@
 # __NAME__
 
-A vertical inference harness. The model lives *inside* the app — there is no API key, and nothing on the inference path touches the network.
+A vertical inference harness. The model lives *inside* the app — no API key, and nothing on the inference path touches the network.
 
 ## Run it
 
 ```sh
 npm install
-# point harness.json at a local .gguf model file, then:
-npm run dev "What was the Cuban missile crisis?"   # or just: npm start
+npm start
 ```
 
-`npm start` opens a terminal UI; type a question and watch two agents research it in parallel and a synth combine their notes.
+The recommended model is fetched and **digest-verified** into `models/llm/` on first run — no key. (Prefer your own weight? Drop a `.gguf` in `models/llm/`, or point `model.llm.path` in `harness.yml` at one.) `npm start` opens a terminal UI; type a question and watch two agents research it in parallel while a synth combines their notes. For a fast inner loop without a build step, use `npm run dev`.
 
 ## The shape
 
@@ -18,21 +17,22 @@ npm run dev "What was the Cuban missile crisis?"   # or just: npm start
 harness/
   harness.ts     ← the one file that's yours: your program, as code
   protocol.ts    the events (↓) and commands (↑) your harness speaks
-  state.ts       how a view folds those events into renderable state
+  state.ts       node-free reduce(events) → AppState (every view folds it)
 targets/
-  cli.ts         run in a terminal (generated · rarely touched)
-  cli-view.tsx   the terminal view
-harness.json     model + settings
+  cli/
+    index.ts     boot: resolve the model, mount a view, run your harness
+    view.tsx     the terminal view (Ink) — swap it, or bring a whole app
+models/
+  llm/           the resident model (fetched on first run; gitignored)
+harness.yml      targets + model
 ```
 
-Everything under `targets/` is convention handled for you. The center —
-`harness/harness.ts` — is where you program what your intelligence does: which
-agents exist, how they collaborate, what evidence they trust, when work is done.
+Everything under `targets/` is convention handled for you — the boot mounts a view over a binding; a view is a sink that folds `reduce`. The center — `harness/harness.ts` — is where you program what your intelligence does: which agents exist, how they collaborate, what they trust, when work is done. `blank` runs a `parallel` pool + synth; `chain` is a one-line swap.
 
 ## Add capabilities
 
 ```sh
-npx harness.dev install lloyal/corpus   # a signed AgentApp from apps.lloyal.ai
+npx harness.dev install <publisher>/<name>   # a signed AgentApp from apps.lloyal.ai
 ```
 
 Enable it in `harness/harness.ts` alongside `createWikipediaApp`.

--- a/packages/harness-cli/templates/blank/bin/run.js
+++ b/packages/harness-cli/templates/blank/bin/run.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import("../dist/targets/cli/index.js");

--- a/packages/harness-cli/templates/blank/harness.yml
+++ b/packages/harness-cli/templates/blank/harness.yml
@@ -1,0 +1,9 @@
+# harness.yml — the deployment manifest. Your program lives in harness/harness.ts.
+# Every target listed explicitly; only the fields you chose are shown.
+
+targets: [cli]
+
+model:
+  llm:
+    id: "reasoning-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity — add a line to override
+    context: 32768

--- a/packages/harness-cli/templates/blank/harness/harness.ts
+++ b/packages/harness-cli/templates/blank/harness/harness.ts
@@ -1,0 +1,194 @@
+/**
+ * Your harness — the one file that's genuinely yours.
+ *
+ * It IS the platform contract: a headless generator `harness(ctx, events,
+ * commands)`. `ctx` is the resident model; `events` streams your
+ * `WorkflowEvent`s to whatever surface is mounted (terminal / Electron /
+ * browser); `commands` delivers that surface's `Command`s back. The runtime,
+ * the bindings, the targets, and the trust plumbing are conventions handled
+ * for you — this file is where you program what your intelligence does.
+ *
+ * `blank` is deliberately the floor: two agents research a query in parallel
+ * over a shared spine, a synth agent combines their notes. That's the whole
+ * grammar in miniature — topology (`parallel`), a shared spine (`withSpine`),
+ * a terminal tool (`report`), a reduce step (the synth). Replace it with your
+ * own program; nothing else in the project needs to know what you wrote here.
+ */
+import { spawn, each, call } from "effection";
+import type { Operation, Signal } from "effection";
+import type { EventBus } from "@lloyal-labs/binding";
+import type { Session, SessionContext } from "@lloyal-labs/sdk";
+import {
+  initAgents,
+  agentPool,
+  useAgent,
+  parallel,
+  withSpine,
+  renderTemplate,
+  DefaultAgentPolicy,
+  AppRegistryCtx,
+} from "@lloyal-labs/lloyal-agents";
+import type { App, AgentRenderCtx } from "@lloyal-labs/lloyal-agents";
+import {
+  createAppRegistry,
+  createInMemoryConfigStore,
+  reportTool,
+  renderSpine,
+  renderAgentPreamble,
+} from "@lloyal-labs/rig";
+import { createWikipediaApp } from "@lloyal-labs/wikipedia-app";
+import type { Command, WorkflowEvent } from "./protocol.js";
+
+const MAX_TURNS = 8;
+
+/** The whole "plan": two fixed research angles. A real harness would *compute*
+ *  these (an LLM planner, a routing rule, a workflow); blank keeps them static
+ *  so the file reads top-to-bottom. Grow this into whatever your domain needs. */
+const ANGLES = [
+  "Gather the core facts, dates, and definitions.",
+  "Gather context, significance, and differing viewpoints.",
+];
+
+const SYNTH_SYSTEM =
+  "You combine several research notes into one clear, accurate answer. " +
+  "Quote sources where the notes do. No preamble.";
+const SYNTH_USER =
+  "Question: <%= it.query %>\n\nResearch notes:\n<%= it.notes %>\n\nWrite the answer.";
+
+/**
+ * The one place blank subclasses `AgentPolicy`. A pool consults ONE policy per
+ * role; the synth agent has no tools, so its free text IS the result — but the
+ * default policy gates a free-text return behind ≥1 tool call. This overrides
+ * that single hook. (Every other decision uses the stock `DefaultAgentPolicy`.)
+ */
+class SynthPolicy extends DefaultAgentPolicy {
+  override onProduced(
+    ...args: Parameters<DefaultAgentPolicy["onProduced"]>
+  ): ReturnType<DefaultAgentPolicy["onProduced"]> {
+    const [, parsed] = args;
+    if (!parsed.toolCalls[0] && parsed.content) {
+      return { type: "free_text_return", content: parsed.content };
+    }
+    return super.onProduced(...args);
+  }
+}
+
+export function* harness(
+  ctx: SessionContext,
+  events: EventBus<WorkflowEvent>,
+  commands: Signal<Command, void>,
+): Operation<void> {
+  // Agent runtime over the resident model. `agentEvents` is the pool's own
+  // channel — forward it to the surface so every spawn / token / return streams
+  // live into the renderer. The spawned fiber auto-halts when this scope ends.
+  const { session, events: agentEvents } = yield* initAgents<WorkflowEvent>(ctx);
+  yield* spawn(function* () {
+    for (const ev of yield* each(agentEvents)) {
+      events.send(ev as WorkflowEvent);
+      yield* each.next();
+    }
+  });
+
+  // Compose your AgentApps. Wikipedia needs no reranker, config, or auth, so
+  // the config store stays empty. Install more with `harness.dev install <app>`
+  // and enable them here.
+  const registry = yield* createAppRegistry({
+    configStore: createInMemoryConfigStore(),
+  });
+  yield* registry.enable(createWikipediaApp);
+
+  events.send({ type: "ready" });
+
+  // The command loop. Ends on `quit` (or when the Session closes and the scope
+  // unwinds). Everything the surface can ask for is a member of `Command`.
+  for (const cmd of yield* each(commands)) {
+    if (cmd.type === "quit") return;
+    if (cmd.type === "submit_query") {
+      try {
+        const answer = yield* runQuery(cmd.query, session, events);
+        events.send({ type: "answer", text: answer });
+      } catch (err) {
+        events.send({
+          type: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    yield* each.next();
+  }
+}
+
+/** Per-agent system prompt — renders the app's `skill.eta` with the render ctx. */
+function agentPreamble(app: App, taskIndex: number): string {
+  return renderAgentPreamble(app, {
+    maxTurns: MAX_TURNS,
+    agentCount: ANGLES.length,
+    siblingTasks: [],
+    date: new Date().toISOString().slice(0, 10),
+    taskIndex,
+  } as AgentRenderCtx & Record<string, unknown>);
+}
+
+function* runQuery(
+  query: string,
+  session: Session,
+  _events: EventBus<WorkflowEvent>,
+): Operation<string> {
+  const registry = yield* AppRegistryCtx.expect();
+  const apps = registry.enabled();
+  const tools = [...apps.flatMap((a) => [...a.tools]), reportTool];
+  const spinePrompt = renderSpine({ apps });
+
+  // Two agents, in parallel, over one shared spine. `report` is the terminal
+  // tool; `pruneOnReturn` frees each agent's KV as it finishes.
+  const notes = yield* withSpine<string[]>(
+    { parent: session.trunk ?? undefined, systemPrompt: spinePrompt, tools },
+    function* (spine) {
+      const pool = yield* agentPool({
+        tools,
+        parent: spine,
+        terminal: reportTool,
+        maxTurns: MAX_TURNS,
+        pruneOnReturn: true,
+        policy: new DefaultAgentPolicy({ terminalToolName: "report" }),
+        enableThinking: true,
+        // Breadth: independent angles, in parallel, over one shared spine.
+        // For sequential DEPTH — each task building on the last via the spine —
+        // swap `parallel` for `chain(ANGLES, (angle, i) => ({ task: {...},
+        // userContent: `…` }))` (import `chain` from `@lloyal-labs/lloyal-agents`).
+        // The benchmark-tuned deep/flat research pipelines live in `research`.
+        orchestrate: parallel(
+          ANGLES.map((angle, i) => ({
+            content: `${query}\n\nFocus: ${angle}`,
+            systemPrompt: agentPreamble(apps[0], i),
+            seed: 1000 + i,
+          })),
+        ),
+      });
+      return pool.agents
+        .map((a) => a.result?.trim() ?? "")
+        .filter((r): r is string => r.length > 0);
+    },
+  );
+
+  if (notes.length === 0) {
+    return "No findings — the research agents returned nothing.";
+  }
+
+  // Synth: one agent, no tools, combines the notes. Committed to the session
+  // trunk so a follow-up query can build on it.
+  const synth = yield* useAgent({
+    systemPrompt: SYNTH_SYSTEM,
+    task: renderTemplate(SYNTH_USER, {
+      query,
+      notes: notes.map((n, i) => `[${i + 1}] ${n}`).join("\n\n"),
+    }),
+    parent: session.trunk ?? undefined,
+    policy: new SynthPolicy(),
+    maxTurns: MAX_TURNS,
+  });
+
+  const answer = synth.result?.trim() || notes.join("\n\n");
+  yield* call(() => session.commitTurn(query, answer));
+  return answer;
+}

--- a/packages/harness-cli/templates/blank/harness/harness.ts
+++ b/packages/harness-cli/templates/blank/harness/harness.ts
@@ -136,6 +136,11 @@ function* runQuery(
 ): Operation<string> {
   const registry = yield* AppRegistryCtx.expect();
   const apps = registry.enabled();
+  if (apps.length === 0) {
+    throw new Error(
+      "No AgentApp is enabled — enable one in harness.ts (e.g. `yield* registry.enable(createWikipediaApp)`).",
+    );
+  }
   const tools = [...apps.flatMap((a) => [...a.tools]), reportTool];
   const spinePrompt = renderSpine({ apps });
 

--- a/packages/harness-cli/templates/blank/harness/protocol.ts
+++ b/packages/harness-cli/templates/blank/harness/protocol.ts
@@ -1,0 +1,27 @@
+/**
+ * The events this harness emits (↓) and the commands its surfaces send (↑).
+ *
+ * This union is YOURS — the harness owns it. Every target (cli · desktop ·
+ * web) carries the same events over its binding, and the renderer folds them
+ * into UI state via `reduce` (see `state.ts`). Grow these two types as your
+ * harness grows; nothing else in the project needs to change when you do.
+ *
+ * `WorkflowEvent` re-exports the framework's `AgentEvent` because the harness
+ * forwards raw agent-pool events straight through — the renderer reduces them
+ * the same way in a terminal, an Electron window, or a browser tab.
+ */
+import type { AgentEvent } from "@lloyal-labs/lloyal-agents";
+
+export type WorkflowEvent =
+  // Forwarded verbatim from the agent pool (spawn / produce / return / …).
+  | AgentEvent
+  // Boot finished — the surface may accept a query.
+  | { type: "ready" }
+  // The answer for the last query.
+  | { type: "answer"; text: string }
+  // A recoverable error to show; the surface returns to accepting input.
+  | { type: "error"; message: string };
+
+export type Command =
+  | { type: "submit_query"; query: string }
+  | { type: "quit" };

--- a/packages/harness-cli/templates/blank/harness/state.ts
+++ b/packages/harness-cli/templates/blank/harness/state.ts
@@ -1,0 +1,123 @@
+/**
+ * How a view *accumulates* your events into renderable state.
+ *
+ * `reduce(state, event) → AppState` is a pure, node-free fold. It lives here —
+ * not in the harness, not in a view — for two reasons:
+ *   1. Only the small raw `WorkflowEvent` crosses a target boundary (IPC to
+ *      the desktop window, wss to the browser); the growing transcript never
+ *      does. So the fold has to happen in the *sink*. The harness stays a pure
+ *      emitter; the renderer stays a pure sink.
+ *   2. All three target views — the terminal (Ink), the desktop and the web
+ *      (React) — import this ONE `reduce`. Node-free so every runtime can.
+ *
+ * `AppState` is a standard shape the generic auto-view knows how to render.
+ * Grow it as your harness emits more events; add a `case` per event, keep the
+ * fold immutable (new `Map` + new object only for what changed), and the views
+ * update for free.
+ */
+import type { WorkflowEvent } from "./protocol.js";
+
+export type Phase = "booting" | "ready" | "working" | "answered" | "error";
+
+export type AgentStatus = "active" | "tool" | "done" | "failed";
+
+export interface AgentView {
+  id: number;
+  parentId: number;
+  status: AgentStatus;
+  /** Accumulated streamed text (`agent:produce` deltas). */
+  body: string;
+  tokens: number;
+  currentTool: string | null;
+  toolCalls: number;
+}
+
+export interface AppState {
+  phase: Phase;
+  /** Insertion-ordered by spawn — the auto-view renders the tree from `parentId`. */
+  agents: Map<number, AgentView>;
+  answer: string;
+  error: string | null;
+  /** KV pressure for the gauge (from `agent:tick`). */
+  kv: { used: number; total: number };
+}
+
+export const initialState: AppState = {
+  phase: "booting",
+  agents: new Map(),
+  answer: "",
+  error: null,
+  kv: { used: 0, total: 0 },
+};
+
+export function reduce(s: AppState, ev: WorkflowEvent): AppState {
+  switch (ev.type) {
+    // ── your harness's own events ──
+    case "ready":
+      return s.phase === "booting" ? { ...s, phase: "ready" } : s;
+    case "answer":
+      return { ...s, phase: "answered", answer: ev.text };
+    case "error":
+      return { ...s, phase: "error", error: ev.message };
+
+    // ── framework agent events (shared across every harness) ──
+    case "agent:spawn": {
+      const agents = new Map(s.agents);
+      agents.set(ev.agentId, {
+        id: ev.agentId,
+        parentId: ev.parentAgentId,
+        status: "active",
+        body: "",
+        tokens: 0,
+        currentTool: null,
+        toolCalls: 0,
+      });
+      return { ...s, phase: "working", agents };
+    }
+    case "agent:produce":
+      return patch(s, ev.agentId, (a) => ({
+        ...a,
+        status: "active",
+        currentTool: null,
+        body: a.body + ev.text,
+        tokens: a.tokens + ev.tokenCount,
+      }));
+    case "agent:tool_call":
+      return patch(s, ev.agentId, (a) => ({
+        ...a,
+        status: "tool",
+        currentTool: ev.tool,
+        toolCalls: a.toolCalls + 1,
+      }));
+    case "agent:tool_result":
+      return patch(s, ev.agentId, (a) => ({ ...a, status: "active", currentTool: null }));
+    case "agent:return":
+    case "agent:recovered":
+      return patch(s, ev.agentId, (a) => ({ ...a, status: "done", body: a.body || ev.result }));
+    case "agent:failed":
+      return patch(s, ev.agentId, (a) => ({ ...a, status: "failed" }));
+    case "agent:done":
+      return patch(s, ev.agentId, (a) =>
+        a.status === "active" || a.status === "tool" ? { ...a, status: "done" } : a,
+      );
+    case "agent:tick":
+      return { ...s, kv: { used: ev.cellsUsed, total: ev.nCtx } };
+
+    // agent:tool_progress / agent:tool_retry aren't shown in the austere view.
+    default:
+      return s;
+  }
+}
+
+/** Immutably replace one agent — new `Map`, new object, only for the change. */
+function patch(
+  s: AppState,
+  id: number,
+  fn: (a: AgentView) => AgentView,
+): AppState {
+  const cur = s.agents.get(id);
+  if (!cur) return s;
+  const agents = new Map(s.agents);
+  agents.set(id, fn(cur));
+  return { ...s, agents };
+}

--- a/packages/harness-cli/templates/blank/harness/state.ts
+++ b/packages/harness-cli/templates/blank/harness/state.ts
@@ -56,9 +56,9 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
     case "ready":
       return s.phase === "booting" ? { ...s, phase: "ready" } : s;
     case "answer":
-      return { ...s, phase: "answered", answer: ev.text };
+      return { ...s, phase: "answered", answer: ev.text, error: null };
     case "error":
-      return { ...s, phase: "error", error: ev.message };
+      return { ...s, phase: "error", error: ev.message, answer: "" };
 
     // ── framework agent events (shared across every harness) ──
     case "agent:spawn": {
@@ -72,7 +72,9 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
         currentTool: null,
         toolCalls: 0,
       });
-      return { ...s, phase: "working", agents };
+      // A new query begins — clear the prior answer/error so it doesn't
+      // linger while this run produces.
+      return { ...s, phase: "working", agents, answer: "", error: null };
     }
     case "agent:produce":
       return patch(s, ev.agentId, (a) => ({

--- a/packages/harness-cli/templates/blank/models/llm/.gitkeep
+++ b/packages/harness-cli/templates/blank/models/llm/.gitkeep
@@ -1,0 +1,1 @@
+# reasoning-4b.gguf is fetched here on first run (verified), or drop your own .gguf.

--- a/packages/harness-cli/templates/blank/package.json
+++ b/packages/harness-cli/templates/blank/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "dev": "tsx targets/cli/index.ts",
     "build": "tsc",
+    "prestart": "tsc",
     "start": "node bin/run.js"
   },
   "dependencies": {
@@ -25,7 +26,7 @@
     "@lloyal-labs/binding": "^0.1.0",
     "@lloyal-labs/lloyal-agents": "^3.0.0",
     "@lloyal-labs/lloyal.node": "^3.0.1",
-    "@lloyal-labs/rig": "^3.0.0",
+    "@lloyal-labs/rig": "^3.2.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.0.0.tgz",
     "effection": "^4.0.2",

--- a/packages/harness-cli/templates/blank/package.json
+++ b/packages/harness-cli/templates/blank/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "__NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A vertical inference harness scaffolded by `harness.dev`.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "__NAME__": "bin/run.js"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "harness.yml",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "dev": "tsx targets/cli/index.ts",
+    "build": "tsc",
+    "start": "node bin/run.js"
+  },
+  "dependencies": {
+    "@inkjs/ui": "^2.0.0",
+    "@lloyal-labs/binding": "^0.1.0",
+    "@lloyal-labs/lloyal-agents": "^3.0.0",
+    "@lloyal-labs/lloyal.node": "^3.0.1",
+    "@lloyal-labs/rig": "^3.0.0",
+    "@lloyal-labs/sdk": "^3.0.0",
+    "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.0.0.tgz",
+    "effection": "^4.0.2",
+    "ink": "^5.0.1",
+    "react": "^18.3.1",
+    "yaml": "^2.9.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.12",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/harness-cli/templates/blank/targets/cli/index.ts
+++ b/packages/harness-cli/templates/blank/targets/cli/index.ts
@@ -1,0 +1,101 @@
+/**
+ * The CLI target — where your harness runs in a terminal.
+ *
+ * Generated for you and rarely touched. It does three things: resolve the
+ * resident model, pick a surface, and run your harness over it. The surface
+ * pick is the whole "one harness, many targets" idea in miniature — the same
+ * `harness(ctx, events, commands)` mounts on Ink (a terminal), `ipc` (when a
+ * desktop shell forks this bin), or `ndjson` (a pipe), all over one binding.
+ *
+ * `blank`'s edge is a single boot: no config-reload / model-restart loop
+ * (that's a product's elaboration). The model is a file in `models/<role>/`,
+ * resolved from `harness.yml` and — on first run — fetched + digest-verified by
+ * the platform (`rig.resolveModel`), with no API key. Drop your own `.gguf`
+ * into `models/llm/` (or point `path:` at one) to skip the fetch entirely.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+import { main, call, ensure, createSignal } from "effection";
+import { createBus } from "@lloyal-labs/binding";
+import { ipc, ndjson } from "@lloyal-labs/binding/node";
+import { createContext } from "@lloyal-labs/lloyal.node";
+import { resolveModel } from "@lloyal-labs/rig/node";
+import { harness } from "../../harness/harness.js";
+import type { Command, WorkflowEvent } from "../../harness/protocol.js";
+import { renderCli } from "./view.js";
+
+interface ModelEntry {
+  id?: string;
+  path?: string;
+  context?: number;
+}
+interface HarnessConfig {
+  model?: { llm?: ModelEntry };
+}
+
+function loadConfig(): HarnessConfig {
+  const raw = readFileSync(join(process.cwd(), "harness.yml"), "utf8");
+  return (parse(raw) ?? {}) as HarnessConfig;
+}
+
+const llm: ModelEntry = loadConfig().model?.llm ?? {};
+const context = llm.context ?? 32768;
+
+main(function* () {
+  // The resident model — a file in models/llm/, fetched + digest-verified on
+  // first run (no API key). rig owns the verified fetch; the boot just asks.
+  let modelPath: string;
+  let fetching = false;
+  try {
+    modelPath = yield* call(() =>
+      resolveModel({
+        projectRoot: process.cwd(),
+        role: "llm",
+        spec: { id: llm.id, path: llm.path },
+        onProgress: (got, total) => {
+          fetching = true;
+          const pct = total > 0 ? Math.round((100 * got) / total) : 0;
+          process.stderr.write(`\rfetching ${llm.id ?? "model"} — ${pct}%   `);
+        },
+      }),
+    );
+  } catch (err) {
+    process.stderr.write(`\n${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+  if (fetching) process.stderr.write("\n");
+
+  const ctx = yield* call(() =>
+    createContext({
+      modelPath,
+      nCtx: context,
+      nSeqMax: 32,
+      typeK: "q4_0",
+      typeV: "q4_0",
+    }),
+  );
+
+  const events = createBus<WorkflowEvent>();
+  const commands = createSignal<Command, void>();
+  const dispatch = (c: Command): void => {
+    commands.send(c);
+  };
+  const bootstrap: WorkflowEvent[] = [];
+
+  // Surface pick — the same events/commands, a different binding.
+  if (process.env.RR_BRIDGE) {
+    // A desktop shell forked this bin: stream over the process channel.
+    ipc<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+  } else if (process.stdout.isTTY) {
+    // A terminal: mount the Ink view.
+    const dispose = renderCli(events, dispatch, bootstrap);
+    yield* ensure(() => dispose());
+  } else {
+    // A pipe: newline-delimited JSON.
+    ndjson<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+  }
+
+  // Run the harness. Returns when it sees `quit` (or the scope unwinds).
+  yield* harness(ctx, events, commands);
+});

--- a/packages/harness-cli/templates/blank/targets/cli/index.ts
+++ b/packages/harness-cli/templates/blank/targets/cli/index.ts
@@ -96,18 +96,20 @@ main(function* () {
   };
   const bootstrap: WorkflowEvent[] = [];
 
-  // Surface pick — the same events/commands, a different binding.
+  // Surface pick — the same events/commands, a different binding. Each binding
+  // returns a disposer; tie it to the scope so listeners are torn down on exit.
+  let dispose: () => void;
   if (process.env.RR_BRIDGE) {
     // A desktop shell forked this bin: stream over the process channel.
-    ipc<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+    dispose = ipc<WorkflowEvent, Command>()(events, dispatch, bootstrap);
   } else if (process.stdout.isTTY) {
     // A terminal: mount the Ink view.
-    const dispose = renderCli(events, dispatch, bootstrap);
-    yield* ensure(() => dispose());
+    dispose = renderCli(events, dispatch, bootstrap);
   } else {
     // A pipe: newline-delimited JSON.
-    ndjson<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+    dispose = ndjson<WorkflowEvent, Command>()(events, dispatch, bootstrap);
   }
+  yield* ensure(() => dispose());
 
   // Run the harness. Returns when it sees `quit` (or the scope unwinds).
   yield* harness(ctx, events, commands);

--- a/packages/harness-cli/templates/blank/targets/cli/index.ts
+++ b/packages/harness-cli/templates/blank/targets/cli/index.ts
@@ -35,8 +35,21 @@ interface HarnessConfig {
 }
 
 function loadConfig(): HarnessConfig {
-  const raw = readFileSync(join(process.cwd(), "harness.yml"), "utf8");
-  return (parse(raw) ?? {}) as HarnessConfig;
+  let raw: string;
+  try {
+    raw = readFileSync(join(process.cwd(), "harness.yml"), "utf8");
+  } catch {
+    process.stderr.write("harness.yml not found — run from your harness project root.\n");
+    process.exit(1);
+  }
+  try {
+    return (parse(raw) ?? {}) as HarnessConfig;
+  } catch (err) {
+    process.stderr.write(
+      `harness.yml is not valid YAML: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
 }
 
 const llm: ModelEntry = loadConfig().model?.llm ?? {};

--- a/packages/harness-cli/templates/blank/targets/cli/view.tsx
+++ b/packages/harness-cli/templates/blank/targets/cli/view.tsx
@@ -1,0 +1,118 @@
+/**
+ * The terminal view — a `render`-style binding: `(bus, dispatch, bootstrap) =>
+ * dispose`. It subscribes to your events, folds them through `reduce`
+ * (state.ts), and renders the standard `AppState`. It knows nothing about your
+ * domain — swap it, or grow it, or keep it; the harness never changes.
+ *
+ * Austere on purpose: a header, the agent list, a KV gauge, the streaming
+ * answer, an input line. This is the floor, not a ceiling — a real surface can
+ * be an entire React/Vite/Next app; the framework holds the binding seam
+ * (events ↓ / commands ↑ / `reduce`), never the UI.
+ */
+import React, { useEffect, useReducer } from "react";
+import { Box, Text, render, useApp, useInput } from "ink";
+import { TextInput } from "@inkjs/ui";
+import type { EventBus } from "@lloyal-labs/binding";
+import { initialState, reduce } from "../../harness/state.js";
+import type { AgentView, AppState } from "../../harness/state.js";
+import type { Command, WorkflowEvent } from "../../harness/protocol.js";
+
+const seed = (bootstrap: WorkflowEvent[]): AppState =>
+  bootstrap.reduce(reduce, initialState);
+
+const glyph = (s: AgentView["status"]): string =>
+  s === "active" ? "●" : s === "tool" ? "◍" : s === "done" ? "✓" : "✗";
+
+function Gauge({ used, total }: { used: number; total: number }): React.ReactElement | null {
+  if (!total) return null;
+  const pct = Math.min(100, Math.round((100 * used) / total));
+  const width = 16;
+  const filled = Math.round((pct / 100) * width);
+  return (
+    <Text color="gray">
+      KV {"█".repeat(filled)}
+      {"░".repeat(width - filled)} {pct}%
+    </Text>
+  );
+}
+
+function View({
+  bus,
+  dispatch,
+  bootstrap,
+}: {
+  bus: EventBus<WorkflowEvent>;
+  dispatch: (c: Command) => void;
+  bootstrap: WorkflowEvent[];
+}): React.ReactElement {
+  const [state, apply] = useReducer(reduce, bootstrap, seed);
+  const app = useApp();
+
+  useEffect(() => bus.subscribe((ev) => apply(ev)), [bus]);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") {
+      dispatch({ type: "quit" });
+      app.exit();
+    }
+  });
+
+  const working = state.phase === "working";
+  const agents = [...state.agents.values()];
+  const streaming =
+    state.answer ||
+    agents
+      .filter((a) => a.status !== "failed")
+      .map((a) => a.body)
+      .join("")
+      .trim();
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box flexDirection="column">
+        <Text bold>{"__NAME__"}</Text>
+        <Text color="gray">Model      resident · no API key</Text>
+        <Text color="gray">Inference  local · no provider</Text>
+        <Text color="gray">Surface    cli</Text>
+      </Box>
+
+      {agents.length > 0 && (
+        <Box flexDirection="column">
+          {agents.map((a) => (
+            <Text key={a.id}>
+              {glyph(a.status)} agent {a.id}
+              {a.currentTool ? ` · ${a.currentTool}` : ""} · {a.tokens} tok
+            </Text>
+          ))}
+          <Gauge used={state.kv.used} total={state.kv.total} />
+        </Box>
+      )}
+
+      {streaming && <Text color="cyan">{streaming}</Text>}
+      {state.error && <Text color="red">error: {state.error}</Text>}
+
+      {!working && (
+        <Box>
+          <Text color="green">› </Text>
+          <TextInput
+            placeholder="type a question, ctrl-c to stop"
+            onSubmit={(q: string) => {
+              if (q.trim()) dispatch({ type: "submit_query", query: q });
+            }}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function renderCli(
+  bus: EventBus<WorkflowEvent>,
+  dispatch: (c: Command) => void,
+  bootstrap: WorkflowEvent[],
+): () => void {
+  const instance = render(
+    <View bus={bus} dispatch={dispatch} bootstrap={bootstrap} />,
+  );
+  return () => instance.unmount();
+}

--- a/packages/harness-cli/templates/blank/tsconfig.json
+++ b/packages/harness-cli/templates/blank/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["harness/**/*", "targets/**/*"]
+}


### PR DESCRIPTION
## What

Rebuilds the `blank` scaffold on the platform contract and wires `create` to emit it.

- **`harness.yml`** manifest (declarative — `targets: [cli]` + one local `model:`), parsed via `yaml`.
- **`targets/cli/{index.ts, view.tsx}`** — the self-contained per-surface folder (no `views/` dir, no `-view` suffix). The boot reads `harness.yml`, resolves the model via **`rig.resolveModel`** (fetch + fail-closed digest verify, no API key), and mounts the Ink view over a binding.
- **`models/<role>/`** layout + `.gitignore` (weights ignored, structure kept via `.gitkeep`).
- **`harness.ts`** — an authored `parallel` pool with `chain` a commented one-line swap (the tuned deep/flat pipelines live in the `research` template).
- **`create`** now emits `blank` (superseding the old CLI-only `harness` toy) with a key-free next-steps message.

The node-free core (`harness/{harness,protocol,state}.ts`) is unchanged.

## Verification

- `harness-cli` + the generated project both **build green** against the published `@lloyal-labs/rig@3.2.0` (whose `resolveModel` the boot calls).
- **`create` smoke**: `create my-harness` emits the full blank tree with `__NAME__` substituted; next-steps prints `npm install && npm start`, no key.
- Boot path runs cleanly through config → `resolveModel` → `createContext`; full live inference needs the native `lloyal.node` backend present (a real `create`d project fetches it via backend-pack — verified runtime-side by reasoning.run/Artifact on the same machine).

## Notes

- Depends on `rig@3.2.0` (#46, merged + published).
- The interactive `create` flow (surface/model/template selection) is deferred; this lands `blank` as the default template.
