### PR TITLE
refactor(agents,rig)!: rename AppModelRole → Service; publish agents 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2515,7 +2515,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "3.2.0",
+      "version": "3.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -2597,10 +2597,10 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@lloyal-labs/lloyal-agents": "^3.0.0",
+        "@lloyal-labs/lloyal-agents": "^3.3.0",
         "@lloyal-labs/sdk": "^3.0.0",
         "@mozilla/readability": "^0.6.0",
         "effection": "^4.0.2",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/lloyal-agents",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Multi-agent inference inside the decode loop — structured concurrency over shared KV state",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agents/src/app-types.ts
+++ b/packages/agents/src/app-types.ts
@@ -72,19 +72,22 @@ export interface AppHints {
 }
 
 /**
- * The auxiliary model roles an app can declare it needs, via
- * {@link AppManifest.requires}. A closed set — the disclosure sibling of
- * {@link AppHints.authKind} and the worker's `entitlements` taxonomy: the
- * harness provisions each required role and publishes the bound service on the
- * framework context the factory reads (`RerankerCtx`) *before* the factory
- * runs. `llm` is never listed — it is the harness's own trunk model, always
- * present; apps declare only the *auxiliary* roles they consume. `embedding`
- * is reserved (no consumer yet).
+ * The HDK **Services** an app can declare it needs, via {@link AppManifest.requires}.
+ * A Service is an auxiliary platform capability the harness provides as a shared,
+ * injected instance: the app declares the *service* (not a model), and the platform
+ * binds the implementation (which model backs it) one layer down at the
+ * harness/deploy level. A closed set today (`reranker`, `embedding`); extensible as
+ * the platform adds services. A disclosure sibling of {@link AppHints.authKind} and
+ * the worker's `entitlements` taxonomy: the harness provisions each required service
+ * and publishes the bound instance on the framework context the factory reads
+ * (`RerankerCtx`) *before* the factory runs. The trunk `llm` is never listed — it is
+ * the harness's own model, always present; apps declare only the *auxiliary* services
+ * they consume. `embedding` is reserved (no consumer yet).
  */
-export const APP_MODEL_ROLES = ['reranker', 'embedding'] as const;
+export const SERVICES = ['reranker', 'embedding'] as const;
 
-/** One of the closed {@link APP_MODEL_ROLES}. */
-export type AppModelRole = (typeof APP_MODEL_ROLES)[number];
+/** One of the closed {@link SERVICES} — an HDK service an app can require. */
+export type Service = (typeof SERVICES)[number];
 
 /**
  * The declarative app manifest — content of `app.json` plus the
@@ -108,14 +111,14 @@ export interface AppManifest {
   /** The model-facing identity. */
   readonly protocol: AppProtocol;
   /**
-   * The auxiliary model roles this app needs to function (e.g. `['reranker']`
-   * when a tool scores content). The harness reads this *before* the factory
-   * runs, provisions each role, and publishes the bound service on the
-   * framework context the factory reads (`RerankerCtx`). Absent / empty means
-   * the app needs only the trunk `llm`. A governed disclosure — projected into
-   * the attention surface + signed into the catalog, like `entitlements`.
+   * The HDK {@link Service}s this app needs to function (e.g. `['reranker']` when
+   * a tool scores content). The harness reads this *before* the factory runs,
+   * provisions each service, and publishes the bound instance on the framework
+   * context the factory reads (`RerankerCtx`). Absent / empty means the app needs
+   * only the trunk `llm`. A governed disclosure — a peer to `entitlements` (NOT the
+   * attention surface): signed into the catalog + shown to the reviewer.
    */
-  readonly requires?: readonly AppModelRole[];
+  readonly requires?: readonly Service[];
   /** Optional UX/marketplace metadata. */
   readonly hints?: AppHints;
   /**

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -67,7 +67,7 @@ export type {
   AppManifest,
   AppProtocol,
   AppHints,
-  AppModelRole,
+  Service,
   AppRegistry,
   AppFactory,
   AppState,
@@ -77,7 +77,7 @@ export type {
   ExamplesTemplateFn,
   ConfigFlow,
 } from './app-types';
-export { APP_MODEL_ROLES } from './app-types';
+export { SERVICES } from './app-types';
 
 export type { AppConfigStore } from './app-config';
 export type { GrantStore } from './grant-store';

--- a/packages/agents/test/services.test.ts
+++ b/packages/agents/test/services.test.ts
@@ -1,18 +1,18 @@
 /**
- * Tests for the app model-role capability surface: the closed
- * {@link APP_MODEL_ROLES} set, `AppManifest.requires`, and the static
- * `AppFactory.requires` the harness boot reads without running the factory.
+ * Tests for the app **Services** capability surface: the closed {@link SERVICES}
+ * set, `AppManifest.requires`, and the manifest an `AppFactory` carries
+ * statically for the harness boot to read without running the factory.
  *
  * @category Testing
  */
 import { describe, it, expect } from 'vitest';
-import { APP_MODEL_ROLES } from '../src/index';
-import type { App, AppFactory, AppManifest, AppModelRole } from '../src/index';
+import { SERVICES } from '../src/index';
+import type { App, AppFactory, AppManifest, Service } from '../src/index';
 
-describe('app model roles', () => {
-  it('APP_MODEL_ROLES is the closed reranker+embedding set (trunk llm excluded)', () => {
-    expect(APP_MODEL_ROLES).toEqual(['reranker', 'embedding']);
-    expect(APP_MODEL_ROLES).not.toContain('llm');
+describe('app services', () => {
+  it('SERVICES is the closed reranker+embedding set (trunk llm excluded)', () => {
+    expect(SERVICES).toEqual(['reranker', 'embedding']);
+    expect(SERVICES).not.toContain('llm');
   });
 
   it('a factory carries its manifest statically — requires readable without running it', () => {
@@ -35,11 +35,12 @@ describe('app model roles', () => {
     expect(factory.manifest).toBeUndefined();
   });
 
-  it('AppManifest.requires typechecks as the closed set', () => {
+  it('AppManifest.requires typechecks as the closed Service set', () => {
+    const services: readonly Service[] = ['reranker'];
     const m: AppManifest = {
       name: 'demo',
       protocol: { name: 'demo_research', useWhen: 'demoing', tools: ['demo_tool'] },
-      requires: ['reranker'],
+      requires: services,
     };
     expect(m.requires).toEqual(['reranker']);
   });

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@lloyal-labs/lloyal-agents": "^3.0.0",
+    "@lloyal-labs/lloyal-agents": "^3.3.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@mozilla/readability": "^0.6.0",
     "effection": "^4.0.2",

--- a/packages/rig/src/define-app.ts
+++ b/packages/rig/src/define-app.ts
@@ -44,7 +44,7 @@ import type {
   ConfigFlow,
   AppHints,
 } from '@lloyal-labs/lloyal-agents';
-import { APP_MODEL_ROLES } from '@lloyal-labs/lloyal-agents';
+import { SERVICES } from '@lloyal-labs/lloyal-agents';
 import { SUPPORTED_APP_PROTOCOL_VERSIONS } from './protocol';
 
 /**
@@ -177,19 +177,19 @@ function assertProtocolTools(tools: readonly string[]): void {
 function assertRequires(requires: unknown): void {
   // `requires` comes from `app.json` (parsed as untrusted JSON), so validate it
   // like the rest of the manifest: absent is fine; otherwise it must be an array
-  // of the closed {@link APP_MODEL_ROLES} set. A malformed value would silently
-  // break pre-provisioning (the boot reads `manifest.requires` before enable).
+  // of the closed {@link SERVICES} set. A malformed value would silently break
+  // pre-provisioning (the boot reads `manifest.requires` before enable).
   if (requires === undefined) return;
   if (!Array.isArray(requires)) {
     throw new Error(
-      `defineApp: manifest.requires must be an array of model roles, got ${typeof requires}`,
+      `defineApp: manifest.requires must be an array of service names, got ${typeof requires}`,
     );
   }
-  for (const role of requires) {
-    if (typeof role !== 'string' || !(APP_MODEL_ROLES as readonly string[]).includes(role)) {
+  for (const service of requires) {
+    if (typeof service !== 'string' || !(SERVICES as readonly string[]).includes(service)) {
       throw new Error(
-        `defineApp: manifest.requires contains unknown role ${JSON.stringify(role)}; ` +
-          `supported roles are ${JSON.stringify(APP_MODEL_ROLES)}.`,
+        `defineApp: manifest.requires contains unknown service ${JSON.stringify(service)}; ` +
+          `supported services are ${JSON.stringify(SERVICES)}.`,
       );
     }
   }

--- a/packages/rig/src/provision.ts
+++ b/packages/rig/src/provision.ts
@@ -1,17 +1,18 @@
 /**
- * Provision the auxiliary model roles an enabled app set declares.
+ * Provision the HDK Services an enabled app set declares.
  *
- * An AgentApp declares the non-`llm` models it needs via its manifest's
- * `requires` (carried statically on the `AppFactory`, mirrored from `app.json`).
- * The harness boot passes the same
- * factory list it will enable; this reads the aggregate requirement and — for
- * each role some app needs — resolves + loads the model and publishes it on the
- * framework context apps read at construction, BEFORE any factory runs.
+ * An AgentApp declares the auxiliary Services it needs (`reranker`, `embedding`)
+ * via its manifest's `requires` (carried statically on the `AppFactory`, mirrored
+ * from `app.json`) — it declares the *service*, not a model. The harness boot
+ * passes the same factory list it will enable; this reads the aggregate
+ * requirement and — for each service some app needs — resolves + loads the model
+ * that backs it and publishes the bound instance on the framework context apps
+ * read at construction, BEFORE any factory runs.
  *
  * Today only `reranker` is wired (`RerankerCtx`). The reranker is
  * one-cross-encoder-per-harness, so a single shared instance is loaded IFF some
  * enabled app requires it — a conditional populate of the existing global
- * context, not a per-app service. `embedding` is reserved (no consumer yet).
+ * context, not a per-app instance. `embedding` is reserved (no consumer yet).
  *
  * Node-only (`resolveModel` + `createReranker` touch `node:fs` / the native
  * runtime). Import from `@lloyal-labs/rig/node`.
@@ -22,7 +23,7 @@
 import { call } from 'effection';
 import type { Operation } from 'effection';
 import { RerankerCtx } from '@lloyal-labs/lloyal-agents';
-import type { AppFactory, AppModelRole } from '@lloyal-labs/lloyal-agents';
+import type { AppFactory, Service } from '@lloyal-labs/lloyal-agents';
 import { MODEL_CATALOG, resolveModel } from './models';
 import type { ModelProgress, ModelSpec } from './models';
 import { createReranker } from './reranker';
@@ -31,13 +32,13 @@ import { createReranker } from './reranker';
 export interface ProvisionAppModelsOpts {
   /**
    * The app factories the harness will enable. Their static `requires` is read
-   * to decide which auxiliary models to load — the factories are NOT run here.
+   * to decide which auxiliary Services to load — the factories are NOT run here.
    */
   apps: readonly AppFactory[];
   /** Project root (where `models/<role>/` lives). */
   projectRoot: string;
   /**
-   * Optional model spec for the reranker role, from `harness.yml`
+   * Optional model spec for the reranker service, from `harness.yml`
    * `model.reranker`. Absent → the platform catalog's reranker default.
    */
   reranker?: ModelSpec;
@@ -45,22 +46,22 @@ export interface ProvisionAppModelsOpts {
 }
 
 /**
- * Read the aggregate `requires` of `apps`, provision each required role, and
- * publish the bound service on its framework context — so `registry.enable`
+ * Read the aggregate `requires` of `apps`, provision each required Service, and
+ * publish the bound instance on its framework context — so `registry.enable`
  * injects it. Call once at boot, BEFORE `createAppRegistry`/`enable`, in the
  * scope the harness runs in: the reranker resource + `RerankerCtx` value both
  * attach to that scope (the same "set the context in the caller's scope"
  * pattern as `createAppRegistry`), living for its lifetime.
  *
- * No-op when no enabled app requires an auxiliary role (e.g. a wikipedia-only
+ * No-op when no enabled app requires an auxiliary Service (e.g. a wikipedia-only
  * harness) — nothing is fetched or loaded.
  */
 export function* provisionAppModels(opts: ProvisionAppModelsOpts): Operation<void> {
-  const roles = new Set<AppModelRole>(opts.apps.flatMap((a) => a.manifest?.requires ?? []));
+  const services = new Set<Service>(opts.apps.flatMap((a) => a.manifest?.requires ?? []));
 
-  // Fail fast on unsupported roles BEFORE provisioning anything, so an
+  // Fail fast on unsupported services BEFORE provisioning anything, so an
   // unimplemented requirement can't leave a half-loaded reranker behind.
-  if (roles.has('embedding')) {
+  if (services.has('embedding')) {
     throw new Error(
       "provisionAppModels: an enabled app requires an 'embedding' model, but " +
         'embedding provisioning is not implemented yet (EmbeddingCtx/Embedder ' +
@@ -68,7 +69,7 @@ export function* provisionAppModels(opts: ProvisionAppModelsOpts): Operation<voi
     );
   }
 
-  if (roles.has('reranker')) {
+  if (services.has('reranker')) {
     // Pin from harness.yml only when it actually NAMES a model (id or path); a
     // `reranker:` block with only tuning (e.g. `context:`) must NOT suppress the
     // catalog fallback and leave resolveModel with an id-less, path-less spec.

--- a/packages/rig/test/define-app.test.ts
+++ b/packages/rig/test/define-app.test.ts
@@ -213,7 +213,7 @@ describe('defineApp appProtocolVersion', () => {
   });
 });
 
-// ── requires (auxiliary model roles) — eager, untrusted app.json ──
+// ── requires (auxiliary services) — eager, untrusted app.json ──
 
 describe('defineApp requires validation', () => {
   it('accepts a valid requires array', () => {
@@ -230,9 +230,9 @@ describe('defineApp requires validation', () => {
     );
   });
 
-  it('rejects an unknown role in requires', () => {
+  it('rejects an unknown service in requires', () => {
     expect(() => build({ ...baseManifest, requires: ['bogus'] } as unknown as AppManifest)).toThrow(
-      /unknown role/,
+      /unknown service/,
     );
   });
 });


### PR DESCRIPTION
## What

Renames the app service-declaration type across `@lloyal-labs/lloyal-agents` + `@lloyal-labs/rig`:

- `AppModelRole` → `Service`
- `APP_MODEL_ROLES` → `SERVICES`

An AgentApp declares the auxiliary HDK **Service** it needs via `AppManifest.requires` (`reranker`/`embedding` today; the set is extensible). It declares the *service*, not a model — the app receives a `Reranker` interface via `RerankerCtx` and is model-agnostic; the platform binds which model backs the service one layer down (`harness.yml`'s `model.reranker`, or the catalog default). "Model" was wrong (it's a service, not a model) and "Role" read too IAM-ish; "Service" matches the concept. Values (`reranker`/`embedding`) are unchanged.

Canonical-docs follow-up: #49.

## Also fixes a latent break in `rig@3.3.0`

#48 added `APP_MODEL_ROLES` (a runtime **value**) to `@lloyal-labs/lloyal-agents` but bumped only `rig`, not `agents` — so agents on npm stayed at **3.2.0 without the export**. A fresh `npm install @lloyal-labs/rig@3.3.0` pulls agents@3.2.0, and `defineApp(manifest-with-requires)` crashes on the missing symbol. Not yet live (blank ships wikipedia = no `requires`; corpus/web aren't re-published), but it must be fixed before the governance slice.

- **agents 3.2.0 → 3.3.0** (publishes `SERVICES`)
- **rig 3.3.0 → 3.4.0**, agents floor `^3.0.0` → `^3.3.0`
- `corpus`/`web`/`wikipedia` source untouched (they don't import the renamed symbol)

## Verification

- Build green across all packages, incl. corpus/web/wikipedia (proves the apps typecheck against renamed agents)
- **555 passed / 2 skipped**
- Grep-clean: zero `AppModelRole` / `APP_MODEL_ROLES`
- rig's residency `ModelRole` (`models.ts`) is a separate layer, correctly untouched

## Release

Tagging `v3.4.0-rig` after merge publishes **both** agents@3.3.0 and rig@3.4.0 (neither version is on npm) — that is what closes the `rig@3.3.0` defect above.
