### PR TITLE
refactor(agents,rig)!: rename AppManifest field requires → services

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2515,7 +2515,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -2597,10 +2597,10 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.4.0",
+      "version": "3.5.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@lloyal-labs/lloyal-agents": "^3.3.0",
+        "@lloyal-labs/lloyal-agents": "^3.4.0",
         "@lloyal-labs/sdk": "^3.0.0",
         "@mozilla/readability": "^0.6.0",
         "effection": "^4.0.2",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/lloyal-agents",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "Multi-agent inference inside the decode loop — structured concurrency over shared KV state",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/agents/src/app-types.ts
+++ b/packages/agents/src/app-types.ts
@@ -72,7 +72,7 @@ export interface AppHints {
 }
 
 /**
- * The HDK **Services** an app can declare it needs, via {@link AppManifest.requires}.
+ * The HDK **Services** an app can declare it needs, via {@link AppManifest.services}.
  * A Service is an auxiliary platform capability the harness provides as a shared,
  * injected instance: the app declares the *service* (not a model), and the platform
  * binds the implementation (which model backs it) one layer down at the
@@ -118,7 +118,7 @@ export interface AppManifest {
    * only the trunk `llm`. A governed disclosure — a peer to `entitlements` (NOT the
    * attention surface): signed into the catalog + shown to the reviewer.
    */
-  readonly requires?: readonly Service[];
+  readonly services?: readonly Service[];
   /** Optional UX/marketplace metadata. */
   readonly hints?: AppHints;
   /**
@@ -294,7 +294,7 @@ export interface App {
  *
  * The factory also carries its {@link AppManifest} statically as
  * {@link AppFactory.manifest}, so the harness boot can read what the app needs
- * (e.g. `manifest.requires`) *without* running the factory — provisioning must
+ * (e.g. `manifest.services`) *without* running the factory — provisioning must
  * happen before construction. Apps set it from their `app.json` (the scaffold
  * does this).
  */
@@ -302,7 +302,7 @@ export interface AppFactory {
   (): Operation<App>;
   /**
    * The app's declarative {@link AppManifest}, advertised statically so the
-   * harness boot can read what the app needs (e.g. `manifest.requires`) BEFORE
+   * harness boot can read what the app needs (e.g. `manifest.services`) BEFORE
    * running the factory. Apps set it from their `app.json`; a factory that
    * doesn't advertise one is still valid — the boot just can't pre-provision
    * for it (it falls back to the factory's own construction-time reads).

--- a/packages/agents/test/services.test.ts
+++ b/packages/agents/test/services.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for the app **Services** capability surface: the closed {@link SERVICES}
- * set, `AppManifest.requires`, and the manifest an `AppFactory` carries
+ * set, `AppManifest.services`, and the manifest an `AppFactory` carries
  * statically for the harness boot to read without running the factory.
  *
  * @category Testing
@@ -15,17 +15,17 @@ describe('app services', () => {
     expect(SERVICES).not.toContain('llm');
   });
 
-  it('a factory carries its manifest statically — requires readable without running it', () => {
+  it('a factory carries its manifest statically — services readable without running it', () => {
     const manifest: AppManifest = {
       name: 'demo',
       protocol: { name: 'demo_research', useWhen: 'demoing', tools: ['demo_tool'] },
-      requires: ['reranker'],
+      services: ['reranker'],
     };
     const f = function* (): Generator<never, App, unknown> {
       throw new Error('not run');
     };
     const factory: AppFactory = Object.assign(f as unknown as AppFactory, { manifest });
-    expect(factory.manifest?.requires).toEqual(['reranker']);
+    expect(factory.manifest?.services).toEqual(['reranker']);
   });
 
   it('a factory with no manifest reads as undefined', () => {
@@ -35,13 +35,13 @@ describe('app services', () => {
     expect(factory.manifest).toBeUndefined();
   });
 
-  it('AppManifest.requires typechecks as the closed Service set', () => {
-    const services: readonly Service[] = ['reranker'];
+  it('AppManifest.services typechecks as the closed Service set', () => {
+    const svcs: readonly Service[] = ['reranker'];
     const m: AppManifest = {
       name: 'demo',
       protocol: { name: 'demo_research', useWhen: 'demoing', tools: ['demo_tool'] },
-      requires: services,
+      services: svcs,
     };
-    expect(m.requires).toEqual(['reranker']);
+    expect(m.services).toEqual(['reranker']);
   });
 });

--- a/packages/apps/corpus/app.json
+++ b/packages/apps/corpus/app.json
@@ -6,7 +6,7 @@
     "useWhen": "investigating a local document corpus — finding occurrences of terms, reading specific files at line offsets, semantic retrieval over indexed corpus content.",
     "tools": ["grep", "read_file", "search"]
   },
-  "requires": ["reranker"],
+  "services": ["reranker"],
   "configSchema": {
     "type": "object",
     "required": ["corpusPath"],

--- a/packages/apps/corpus/src/index.ts
+++ b/packages/apps/corpus/src/index.ts
@@ -25,7 +25,7 @@ export type { Bm25Opts, Bm25Hit } from "./bm25";
 
 // The declarative manifest + skill template, read once at module load. The
 // manifest is handed to defineApp, which advertises it on the factory — so the
-// harness boot reads `requires: ['reranker']` and provisions before enabling.
+// harness boot reads `services: ['reranker']` and provisions before enabling.
 const dir = join(__dirname, "..");
 const manifest = JSON.parse(readFileSync(join(dir, "app.json"), "utf8")) as AppManifest;
 const skill = readFileSync(join(dir, "skill.eta"), "utf8");
@@ -35,7 +35,7 @@ const skill = readFileSync(join(dir, "skill.eta"), "utf8");
  * config, loads + chunks the corpus, tokenizes the chunks through the shared
  * reranker (from `RerankerCtx`), and wires the three corpus tools.
  *
- * `requires: ['reranker']` (from `app.json`) rides the factory's manifest, so
+ * `services: ['reranker']` (from `app.json`) rides the factory's manifest, so
  * the harness provisions + sets `RerankerCtx` before this runs — the
  * `RerankerCtx.expect()` below is a guaranteed read, not a gamble.
  */
@@ -47,7 +47,7 @@ export const createCorpusApp = defineApp(manifest, function* () {
     throw new Error(
       "createCorpusApp: the corpus app requires a reranker (its `search` tool scores " +
         "chunks), but RerankerCtx is unset. The harness boot normally provisions it from " +
-        "the app's `requires: ['reranker']` — call provisionAppModels({ apps, projectRoot }) " +
+        "the app's `services: ['reranker']` — call provisionAppModels({ apps, projectRoot }) " +
         "(or otherwise set RerankerCtx) before enabling this app.",
     );
   }

--- a/packages/apps/web/app.json
+++ b/packages/apps/web/app.json
@@ -6,7 +6,7 @@
     "useWhen": "gathering evidence from the open web — verifying current claims, retrieving primary sources from URLs, surveying official documentation and authoritative discussion.",
     "tools": ["web_search", "fetch_page"]
   },
-  "requires": ["reranker"],
+  "services": ["reranker"],
   "configSchema": {
     "type": "object",
     "properties": {

--- a/packages/apps/web/src/index.ts
+++ b/packages/apps/web/src/index.ts
@@ -20,7 +20,7 @@ export { WebSource } from "./source";
 export type { WebSourceOpts } from "./source";
 
 // The declarative manifest + skill template, read once at module load. The
-// manifest (with `requires: ['reranker']`) rides the factory — so the harness
+// manifest (with `services: ['reranker']`) rides the factory — so the harness
 // provisions the reranker before enabling web research.
 const dir = join(__dirname, "..");
 const manifest = JSON.parse(readFileSync(join(dir, "app.json"), "utf8")) as AppManifest;
@@ -29,7 +29,7 @@ const skill = readFileSync(join(dir, "skill.eta"), "utf8");
 /**
  * Construct the web research app. Provider selection: a `tavilyKey` in the
  * app's stored config (or `TAVILY_API_KEY`) → Tavily; otherwise a keyless
- * DuckDuckGo provider. `requires: ['reranker']` makes the harness provision +
+ * DuckDuckGo provider. `services: ['reranker']` makes the harness provision +
  * set `RerankerCtx` before this runs, so the reranker is always present — the
  * `catch` below stays only as a defensive guard.
  */

--- a/packages/apps/wikipedia/src/index.ts
+++ b/packages/apps/wikipedia/src/index.ts
@@ -18,7 +18,7 @@ export { WikipediaSource } from "./source";
 export type { WikipediaSourceOpts } from "./source";
 
 // The declarative manifest + skill template, read once at module load; the
-// manifest rides the factory (wikipedia declares no `requires`).
+// manifest rides the factory (wikipedia declares no `services`).
 const dir = join(__dirname, "..");
 const manifest = JSON.parse(readFileSync(join(dir, "app.json"), "utf8")) as AppManifest;
 const skill = readFileSync(join(dir, "skill.eta"), "utf8");

--- a/packages/harness-cli/templates/app/src/index.ts
+++ b/packages/harness-cli/templates/app/src/index.ts
@@ -4,9 +4,9 @@
  * An app = its declarative manifest (`app.json`) + a `setup` that constructs the
  * runtime pieces. `defineApp` pairs them and returns the factory the harness
  * enables; it also advertises the manifest, so the harness can provision any
- * models you declare in `requires` (e.g. a reranker) before enabling.
+ * models you declare in `services` (e.g. a reranker) before enabling.
  *
- * To customize for your domain: edit `app.json` (name, `useWhen`, `requires`),
+ * To customize for your domain: edit `app.json` (name, `useWhen`, `services`),
  * the tool `dispatch` bodies in `src/tools/`, and the per-spawn skill template
  * `skill.eta`.
  *

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@lloyal-labs/lloyal-agents": "^3.3.0",
+    "@lloyal-labs/lloyal-agents": "^3.4.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@mozilla/readability": "^0.6.0",
     "effection": "^4.0.2",

--- a/packages/rig/src/define-app.ts
+++ b/packages/rig/src/define-app.ts
@@ -5,7 +5,7 @@
  * `skill`, ...), and returns the {@link AppFactory} the harness enables.
  *
  * The returned factory also carries its `manifest` statically, so the harness
- * boot can read what the app needs (e.g. `manifest.requires`) BEFORE running
+ * boot can read what the app needs (e.g. `manifest.services`) BEFORE running
  * the factory — provisioning happens before construction.
  *
  * Validation is split by what's knowable when:
@@ -15,8 +15,8 @@
  *   is a non-empty unique array of names matching the same regex;
  *   `protocol.useWhen` is a single bounded sentence with no chat-role markers,
  *   code fences, or newlines (metadata sanitization); `appProtocolVersion` (if
- *   declared) is in `SUPPORTED_APP_PROTOCOL_VERSIONS`; `requires` (if present)
- *   is an array of the closed model-role set. A malformed manifest fails the
+ *   declared) is in `SUPPORTED_APP_PROTOCOL_VERSIONS`; `services` (if present)
+ *   is an array of the closed service set. A malformed manifest fails the
  *   moment the app module is imported.
  * - **At factory run (enable time):** the setup output. The `tools` map keys
  *   equal `manifest.protocol.tools[]` as a set (every declared tool has an
@@ -174,21 +174,21 @@ function assertProtocolTools(tools: readonly string[]): void {
   }
 }
 
-function assertRequires(requires: unknown): void {
-  // `requires` comes from `app.json` (parsed as untrusted JSON), so validate it
+function assertServices(services: unknown): void {
+  // `services` comes from `app.json` (parsed as untrusted JSON), so validate it
   // like the rest of the manifest: absent is fine; otherwise it must be an array
   // of the closed {@link SERVICES} set. A malformed value would silently break
-  // pre-provisioning (the boot reads `manifest.requires` before enable).
-  if (requires === undefined) return;
-  if (!Array.isArray(requires)) {
+  // pre-provisioning (the boot reads `manifest.services` before enable).
+  if (services === undefined) return;
+  if (!Array.isArray(services)) {
     throw new Error(
-      `defineApp: manifest.requires must be an array of service names, got ${typeof requires}`,
+      `defineApp: manifest.services must be an array of service names, got ${typeof services}`,
     );
   }
-  for (const service of requires) {
+  for (const service of services) {
     if (typeof service !== 'string' || !(SERVICES as readonly string[]).includes(service)) {
       throw new Error(
-        `defineApp: manifest.requires contains unknown service ${JSON.stringify(service)}; ` +
+        `defineApp: manifest.services contains unknown service ${JSON.stringify(service)}; ` +
           `supported services are ${JSON.stringify(SERVICES)}.`,
       );
     }
@@ -316,7 +316,7 @@ export function defineApp(
   assertIdentifier(manifest.protocol.name, 'manifest.protocol.name');
   assertUseWhen(manifest.protocol.useWhen);
   assertProtocolTools(manifest.protocol.tools);
-  assertRequires(manifest.requires);
+  assertServices(manifest.services);
 
   const factory = function* (): Operation<App> {
     const parts = yield* setup();
@@ -344,6 +344,6 @@ export function defineApp(
   };
 
   // Advertise the manifest statically so the harness boot can read it (e.g.
-  // `requires`) before running the factory.
+  // `services`) before running the factory.
   return Object.assign(factory, { manifest });
 }

--- a/packages/rig/src/node.ts
+++ b/packages/rig/src/node.ts
@@ -34,6 +34,6 @@ export type {
 } from './models';
 
 // Node-only: provision the auxiliary models an enabled app set requires
-// (aggregates AppFactory.requires → resolveModel + createReranker + RerankerCtx)
+// (aggregates each factory's manifest.services → resolveModel + createReranker + RerankerCtx)
 export { provisionAppModels } from './provision';
 export type { ProvisionAppModelsOpts } from './provision';

--- a/packages/rig/src/provision.ts
+++ b/packages/rig/src/provision.ts
@@ -2,7 +2,7 @@
  * Provision the HDK Services an enabled app set declares.
  *
  * An AgentApp declares the auxiliary Services it needs (`reranker`, `embedding`)
- * via its manifest's `requires` (carried statically on the `AppFactory`, mirrored
+ * via its manifest's `services` (carried statically on the `AppFactory`, mirrored
  * from `app.json`) — it declares the *service*, not a model. The harness boot
  * passes the same factory list it will enable; this reads the aggregate
  * requirement and — for each service some app needs — resolves + loads the model
@@ -31,7 +31,7 @@ import { createReranker } from './reranker';
 /** Options for {@link provisionAppModels}. */
 export interface ProvisionAppModelsOpts {
   /**
-   * The app factories the harness will enable. Their static `requires` is read
+   * The app factories the harness will enable. Their static `services` is read
    * to decide which auxiliary Services to load — the factories are NOT run here.
    */
   apps: readonly AppFactory[];
@@ -46,7 +46,7 @@ export interface ProvisionAppModelsOpts {
 }
 
 /**
- * Read the aggregate `requires` of `apps`, provision each required Service, and
+ * Read the aggregate `services` of `apps`, provision each required Service, and
  * publish the bound instance on its framework context — so `registry.enable`
  * injects it. Call once at boot, BEFORE `createAppRegistry`/`enable`, in the
  * scope the harness runs in: the reranker resource + `RerankerCtx` value both
@@ -57,7 +57,7 @@ export interface ProvisionAppModelsOpts {
  * harness) — nothing is fetched or loaded.
  */
 export function* provisionAppModels(opts: ProvisionAppModelsOpts): Operation<void> {
-  const services = new Set<Service>(opts.apps.flatMap((a) => a.manifest?.requires ?? []));
+  const services = new Set<Service>(opts.apps.flatMap((a) => a.manifest?.services ?? []));
 
   // Fail fast on unsupported services BEFORE provisioning anything, so an
   // unimplemented requirement can't leave a half-loaded reranker behind.

--- a/packages/rig/test/define-app.test.ts
+++ b/packages/rig/test/define-app.test.ts
@@ -213,25 +213,25 @@ describe('defineApp appProtocolVersion', () => {
   });
 });
 
-// ── requires (auxiliary services) — eager, untrusted app.json ──
+// ── services (auxiliary) — eager, untrusted app.json ──
 
-describe('defineApp requires validation', () => {
-  it('accepts a valid requires array', () => {
-    expect(() => build({ ...baseManifest, requires: ['reranker'] })).not.toThrow();
+describe('defineApp services validation', () => {
+  it('accepts a valid services array', () => {
+    expect(() => build({ ...baseManifest, services: ['reranker'] })).not.toThrow();
   });
 
-  it('accepts an absent requires', () => {
-    expect(() => build({ ...baseManifest, requires: undefined })).not.toThrow();
+  it('accepts an absent services', () => {
+    expect(() => build({ ...baseManifest, services: undefined })).not.toThrow();
   });
 
-  it('rejects a non-array requires (malformed app.json)', () => {
-    expect(() => build({ ...baseManifest, requires: 'reranker' } as unknown as AppManifest)).toThrow(
-      /requires must be an array/,
+  it('rejects a non-array services (malformed app.json)', () => {
+    expect(() => build({ ...baseManifest, services: 'reranker' } as unknown as AppManifest)).toThrow(
+      /services must be an array/,
     );
   });
 
-  it('rejects an unknown service in requires', () => {
-    expect(() => build({ ...baseManifest, requires: ['bogus'] } as unknown as AppManifest)).toThrow(
+  it('rejects an unknown service in services', () => {
+    expect(() => build({ ...baseManifest, services: ['bogus'] } as unknown as AppManifest)).toThrow(
       /unknown service/,
     );
   });

--- a/packages/rig/test/provision.test.ts
+++ b/packages/rig/test/provision.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests for {@link provisionAppModels} — the boot helper that reads the
- * aggregate model requirements (`manifest.requires`, carried on each
+ * aggregate service requirements (`manifest.services`, carried on each
  * `AppFactory`) of an app set and provisions the auxiliary models (today: the
  * shared reranker, published on `RerankerCtx`).
  *
@@ -41,14 +41,14 @@ vi.mock('../src/reranker', () => ({ createReranker }));
 const { provisionAppModels } = await import('../src/provision');
 
 /** A factory that carries its manifest statically and throws if actually run. */
-function factory(requires?: readonly ('reranker' | 'embedding')[]): AppFactory {
+function factory(services?: readonly ('reranker' | 'embedding')[]): AppFactory {
   const f = function* (): Generator<never, App, unknown> {
     throw new Error('provisionAppModels must NOT run the factory');
   };
   const manifest = {
     name: 'test',
     protocol: { name: 'test_research', useWhen: 'testing', tools: ['test_tool'] },
-    ...(requires ? { requires } : {}),
+    ...(services ? { services } : {}),
   } as AppManifest;
   return Object.assign(f as unknown as AppFactory, { manifest });
 }


### PR DESCRIPTION
## What

Renames the `AppManifest` field an app uses to declare its auxiliary HDK **Services**:

- `AppManifest.requires` → `AppManifest.services` (`services: readonly Service[]`)
- `app.json` key `"requires"` → `"services"` (corpus, web)

The `Service`/`SERVICES` type and the values (`reranker`/`embedding`) are unchanged. This unifies the concept for HDK app authors — the field, its values, and the type all read as one word — matching `tools: Tool[]` and lowering cognitive load.

## Scope

Field renamed everywhere: `agents/app-types.ts` (`AppManifest`), `rig/define-app.ts` (`assertRequires` → `assertServices`, reads `manifest.services`), `rig/provision.ts` (aggregation), corpus/web `app.json`, blank + app-scaffold doc comments, and the three test files. `corpus`/`web`/`wikipedia` are **not** re-published in this PR — that follows once the publish worker projects the renamed field.

## Versions (breaking — public `AppManifest` field)

- **agents 3.3.0 → 3.4.0**
- **rig 3.4.0 → 3.5.0**, agents floor `^3.3.0` → `^3.4.0` (fresh installs resolve the `services`-carrying `AppManifest`)
- lockfile reconciled

## Verification

- Build green across all packages, incl. corpus/web/wikipedia (apps compile against the renamed field)
- **555 passed / 2 skipped**
- Grep-clean: zero `requires`-field code references remain

## Release

Tag `v3.5.0-rig` after merge → publishes agents@3.4.0 + rig@3.5.0.
