### PR TITLE
chore(apps): corpus + web 1.3.0 — carry services + services-aware framework floors

### DIFF
--- a/packages/apps/corpus/package.json
+++ b/packages/apps/corpus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/corpus-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "HDK reference app \u2014 local-corpus research (Source + tools + contract). Distributed via the signed-bundle channel, never public npm.",
   "license": "SEE LICENSE IN LICENSE",
@@ -25,9 +25,9 @@
     "build": "tsc -b"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^3.0.0",
+    "@lloyal-labs/lloyal-agents": "^3.4.0",
     "@lloyal-labs/lloyal.node": "^3.1.1",
-    "@lloyal-labs/rig": "^3.0.0",
+    "@lloyal-labs/rig": "^3.5.0",
     "effection": "^4.0.2"
   }
 }

--- a/packages/apps/web/package.json
+++ b/packages/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/web-app",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "HDK reference app \u2014 web research (Source + tools + contract). Distributed via the signed-bundle channel, never public npm.",
   "license": "SEE LICENSE IN LICENSE",
@@ -29,8 +29,8 @@
     "linkedom": "^0.18.12"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^3.0.0",
-    "@lloyal-labs/rig": "^3.0.0",
+    "@lloyal-labs/lloyal-agents": "^3.4.0",
+    "@lloyal-labs/rig": "^3.5.0",
     "effection": "^4.0.2"
   }
 }


### PR DESCRIPTION
## What

Prep to re-publish the first-party **corpus** and **web** AgentApps through the signed channel so their tarballs carry the `services` field.

- **version 1.2.0 → 1.3.0** (both) — the signed channel is immutable per version; re-publishing requires a new semver.
- **peer floors** agents `^3.0.0` → `^3.4.0`, rig `^3.0.0` → `^3.5.0` — the 1.3.0 dist is built against the reshaped `defineApp(manifest, setup)` (rig 3.3.0) and `services`-aware `provisionAppModels` / `AppManifest.services` (agents 3.4.0 / rig 3.5.0); the old `^3.0.0` floor could resolve an incompatible framework.

`services: ["reranker"]` is already present in both `app.json`s (from #51). Build green across all packages.

## Next

After merge, corpus/web are re-published via `harness.dev publish`; a reviewer approves them into the signed catalog — now seeing the new **"Services the app requires"** card (lloyal-infra#12).
