### PR TITLE
feat(rig): provisionAppModels rerankerLoad opts (tune the shared reranker)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2525,26 +2525,26 @@
     },
     "packages/apps/corpus": {
       "name": "@lloyal-labs/corpus-app",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^3.0.0",
+        "@lloyal-labs/lloyal-agents": "^3.4.0",
         "@lloyal-labs/lloyal.node": "^3.1.1",
-        "@lloyal-labs/rig": "^3.0.0",
+        "@lloyal-labs/rig": "^3.5.0",
         "effection": "^4.0.2"
       }
     },
     "packages/apps/web": {
       "name": "@lloyal-labs/web-app",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@mozilla/readability": "^0.6.0",
         "linkedom": "^0.18.12"
       },
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^3.0.0",
-        "@lloyal-labs/rig": "^3.0.0",
+        "@lloyal-labs/lloyal-agents": "^3.4.0",
+        "@lloyal-labs/rig": "^3.5.0",
         "effection": "^4.0.2"
       }
     },
@@ -2597,7 +2597,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.5.0",
+      "version": "3.6.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.4.0",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/node.ts
+++ b/packages/rig/src/node.ts
@@ -17,6 +17,7 @@ export * from './index';
 
 // Node-only: Reranker factory (requires @lloyal-labs/lloyal.node)
 export { createReranker } from './reranker';
+export type { RerankerLoadOpts } from './reranker';
 
 // Node-only: Resource loading (requires node:fs)
 export { loadResources, chunkResources, resolveCorpusInput } from './resources';

--- a/packages/rig/src/provision.ts
+++ b/packages/rig/src/provision.ts
@@ -27,6 +27,7 @@ import type { AppFactory, Service } from '@lloyal-labs/lloyal-agents';
 import { MODEL_CATALOG, resolveModel } from './models';
 import type { ModelProgress, ModelSpec } from './models';
 import { createReranker } from './reranker';
+import type { RerankerLoadOpts } from './reranker';
 
 /** Options for {@link provisionAppModels}. */
 export interface ProvisionAppModelsOpts {
@@ -42,6 +43,13 @@ export interface ProvisionAppModelsOpts {
    * `model.reranker`. Absent → the platform catalog's reranker default.
    */
   reranker?: ModelSpec;
+  /**
+   * Optional context-sizing overrides for the reranker load (`nSeqMax`/`nCtx`/
+   * `nBatch`), threaded into `createReranker`. Absent → its defaults (nSeqMax
+   * 10 · nCtx 4096). Lets a harness tune the shared reranker without
+   * hand-loading it — e.g. a larger `nCtx` for longer rerank inputs.
+   */
+  rerankerLoad?: RerankerLoadOpts;
   onProgress?: ModelProgress;
 }
 
@@ -84,7 +92,7 @@ export function* provisionAppModels(opts: ProvisionAppModelsOpts): Operation<voi
         onProgress: opts.onProgress,
       }),
     );
-    const reranker = yield* createReranker(modelPath);
+    const reranker = yield* createReranker(modelPath, opts.rerankerLoad);
     yield* RerankerCtx.set(reranker);
   }
 }

--- a/packages/rig/src/reranker.ts
+++ b/packages/rig/src/reranker.ts
@@ -6,6 +6,21 @@ import type { Operation } from "effection";
 import type { Chunk, Reranker, ScoredResult } from "@lloyal-labs/lloyal-agents";
 
 /**
+ * Context-sizing overrides for {@link createReranker}. All optional; each
+ * defaults inside `createReranker` (nSeqMax 10 · nCtx 4096 · nBatch derived).
+ * Threaded through `provisionAppModels` (its `rerankerLoad`) so a harness can
+ * tune the shared reranker without hand-loading it.
+ */
+export interface RerankerLoadOpts {
+  /** Max parallel scoring sequences (default 10). */
+  nSeqMax?: number;
+  /** Reranker model context window (default 4096). */
+  nCtx?: number;
+  /** Decode batch size (default floor(nCtx / nSeqMax)). */
+  nBatch?: number;
+}
+
+/**
  * Create a {@link Reranker} backed by a dedicated reranking model context,
  * as an Effection `resource()`.
  *
@@ -23,14 +38,14 @@ import type { Chunk, Reranker, ScoredResult } from "@lloyal-labs/lloyal-agents";
  * resource finally and an explicit call don't double-free.
  *
  * @param modelPath - Absolute path to the reranking model file (GGUF)
- * @param opts - Optional context sizing overrides
- * @param opts.nSeqMax - Maximum parallel scoring sequences (default 8)
+ * @param opts - Optional context sizing overrides ({@link RerankerLoadOpts})
+ * @param opts.nSeqMax - Maximum parallel scoring sequences (default 10)
  * @param opts.nCtx - Context window size for the reranker model (default 4096)
  * @returns An Effection resource yielding a ready-to-use reranker
  *
  * @example
  * ```ts
- * const reranker = yield* createReranker(rerankerPath, { nSeqMax: 8, nCtx: 4096 });
+ * const reranker = yield* createReranker(rerankerPath, { nSeqMax: 10, nCtx: 4096 });
  * yield* RerankerCtx.set(reranker);
  * // ... pool work ...
  * // reranker disposes automatically on scope exit
@@ -40,7 +55,7 @@ import type { Chunk, Reranker, ScoredResult } from "@lloyal-labs/lloyal-agents";
  */
 export function createReranker(
   modelPath: string,
-  opts?: { nSeqMax?: number; nCtx?: number; nBatch?: number },
+  opts?: RerankerLoadOpts,
 ): Operation<Reranker> {
   return resource(function* (provide) {
     // Default bumped 8→10: warm-trunk + per-query branch consume 2 leases in

--- a/packages/rig/test/provision.test.ts
+++ b/packages/rig/test/provision.test.ts
@@ -69,7 +69,7 @@ describe('provisionAppModels', () => {
     });
     expect(resolveModel).toHaveBeenCalledOnce();
     expect(resolveModel.mock.calls[0][0]).toMatchObject({ role: 'reranker', projectRoot: '/proj' });
-    expect(createReranker).toHaveBeenCalledWith(RERANKER_PATH);
+    expect(createReranker).toHaveBeenCalledWith(RERANKER_PATH, undefined);
     expect(bound).toBe(fakeReranker);
   });
 
@@ -146,5 +146,16 @@ describe('provisionAppModels', () => {
       });
     });
     expect(createReranker).toHaveBeenCalledOnce();
+  });
+
+  it('rerankerLoad is threaded into createReranker (tuning the shared reranker)', async () => {
+    await run(function* () {
+      yield* provisionAppModels({
+        apps: [factory(['reranker'])],
+        projectRoot: '/proj',
+        rerankerLoad: { nCtx: 16384 },
+      });
+    });
+    expect(createReranker).toHaveBeenCalledWith(RERANKER_PATH, { nCtx: 16384 });
   });
 });


### PR DESCRIPTION
## What

`provisionAppModels` loaded the shared reranker with `createReranker(modelPath)` — no context-sizing overrides. This adds an optional **`rerankerLoad`** ({ nSeqMax?, nCtx?, nBatch? }) to `ProvisionAppModelsOpts`, threaded straight into `createReranker`. To stay DRY, `createReranker`'s previously-inline opts are extracted into a named, exported **`RerankerLoadOpts`** and reused. Absent → `createReranker` defaults (nSeqMax 10 · nCtx 4096), so existing callers are unchanged.

## Why

The `research` template substrate (reasoning.run) provisions its reranker via `provisionAppModels` but runs it at `nCtx: 16384`; without this, adopting the helper would silently drop that to the 4096 default.

## Verification

- `npm run build` (tsc -b) green across the workspace.
- Full rig suite **165/165** (new `rerankerLoad` pass-through assertion; existing reranker assertion updated to the 2-arg call).
- Grep-clean: no remaining inline reranker-opts shapes.

rig **3.5.0 → 3.6.0**.