### PR TITLE
chore(wikipedia): bump 1.0.0 → 1.1.0 for the defineApp(manifest, setup) reshape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2550,11 +2550,11 @@
     },
     "packages/apps/wikipedia": {
       "name": "@lloyal-labs/wikipedia-app",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^3.0.0",
-        "@lloyal-labs/rig": "^3.0.0",
+        "@lloyal-labs/lloyal-agents": "^3.4.0",
+        "@lloyal-labs/rig": "^3.5.0",
         "effection": "^4.0.2"
       }
     },

--- a/packages/apps/wikipedia/package.json
+++ b/packages/apps/wikipedia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/wikipedia-app",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "private": true,
   "description": "HDK reference app — Wikipedia research (search + fetch over Wikipedia's public REST). No auth required. Distributed via the signed-channel, never public npm.",
   "license": "SEE LICENSE IN LICENSE",
@@ -24,8 +24,8 @@
     "build": "tsc -b"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^3.0.0",
-    "@lloyal-labs/rig": "^3.0.0",
+    "@lloyal-labs/lloyal-agents": "^3.4.0",
+    "@lloyal-labs/rig": "^3.5.0",
     "effection": "^4.0.2"
   }
 }


### PR DESCRIPTION
The published `@lloyal-labs/wikipedia-app@1.0.0` predates the `defineApp(manifest, setup)` app reshape and throws under current rig — so a freshly `harness.dev create`d blank project (which installs it as the **default app**) fails at `enable`. Same version-skew class as corpus/web (already fixed at 1.3.0).

## Change
- `version` 1.0.0 → **1.1.0**
- peerDeps floored to the reshape-aware framework: `@lloyal-labs/lloyal-agents ^3.4.0`, `@lloyal-labs/rig ^3.5.0`
- source already uses `defineApp(manifest, setup)` and declares no `services` (Wikipedia needs no reranker)
- `dist/` is gitignored + built fresh at publish (`npm pack`); the rebuilt dist emits `defineApp(manifest, function*(){})`

## Publish flow (your TTY — the agent shell can't SSO)
1. Merge this.
2. In `packages/apps/wikipedia`: `npm run build` then `harness.dev publish` (submits 1.1.0) → approve in the console — exactly the corpus/web@1.3.0 flow.
3. Follow-up: repoint the blank template dep URL `lloyal__wikipedia-1.0.0.tgz` → `-1.1.0.tgz` (one-line change; folds into PR #54 or its own).

Unblocks a clean stranger `create`→`npm install`→run of the blank template (all three targets landed in #54).