### PR TITLE
feat(rig): ReportTool schema-extension seam (extraProperties/extraRequired)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2597,7 +2597,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.4.0",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/index.ts
+++ b/packages/rig/src/index.ts
@@ -24,6 +24,7 @@ export type {
   DelegateToolOpts,
   KeylessSearchOptions,
   PlanToolOpts,
+  ReportToolOpts,
   PlanResult, PlanIntent, ResearchTask,
   SearchProvider, SearchResult,
   Reranker, ScoredChunk, ScoredResult,

--- a/packages/rig/src/tools/index.ts
+++ b/packages/rig/src/tools/index.ts
@@ -23,6 +23,7 @@ export type { SearchProvider, SearchResult } from './web-search';
 export { createKeylessSearchProvider } from './keyless-search';
 export type { KeylessSearchOptions } from './keyless-search';
 export { ReportTool } from './report';
+export type { ReportToolOpts } from './report';
 export { DelegateTool } from './delegate';
 export type { DelegateToolOpts } from './delegate';
 export type { Reranker, ScoredChunk, ScoredResult } from './types';

--- a/packages/rig/src/tools/report.ts
+++ b/packages/rig/src/tools/report.ts
@@ -38,9 +38,12 @@ export interface ReportToolOpts {
   extraProperties?: Record<string, JsonSchema>;
   /**
    * Property names (from {@link extraProperties}) to mark `required` alongside
-   * `result`. Note the grammar forces a required field's PRESENCE and SHAPE, not
-   * its contents: a required array without `minItems` still permits `[]`, and a
-   * bare `{ type: 'string' }` url permits any string.
+   * `result`. Every name must be defined in `extraProperties` (or be the reserved
+   * `result`) — an unknown name throws, since a required-but-undefined property is
+   * an invalid schema the grammar can't force. Note the grammar forces a required
+   * field's PRESENCE and SHAPE, not its contents: a required array without
+   * `minItems` still permits `[]`, and a bare `{ type: 'string' }` url permits any
+   * string.
    */
   extraRequired?: string[];
 }
@@ -76,6 +79,19 @@ export class ReportTool extends Tool<{ result: string }> {
     // the first property — the extension is strictly additive.
     const extra = { ...(opts?.extraProperties ?? {}) };
     delete extra.result;
+    // Fail loud on a required name with no schema: `result` is always defined
+    // (the base property); any other required name must have been supplied in
+    // extraProperties, else the schema requires an untyped property the grammar
+    // can't force — a caller typo, caught here rather than silently dropped.
+    const extraRequired = opts?.extraRequired ?? [];
+    for (const name of extraRequired) {
+      if (name !== 'result' && !Object.prototype.hasOwnProperty.call(extra, name)) {
+        throw new Error(
+          `ReportTool: extraRequired references "${name}", which is not defined in extraProperties. ` +
+            `Add it to extraProperties, or remove it from extraRequired.`,
+        );
+      }
+    }
     this.parameters = {
       type: 'object',
       properties: {
@@ -89,7 +105,7 @@ export class ReportTool extends Tool<{ result: string }> {
       // De-duplicate (Set preserves insertion order → `result` stays first), so a
       // caller repeating a name or passing `result` in extraRequired can't emit an
       // invalid `required` array.
-      required: [...new Set(['result', ...(opts?.extraRequired ?? [])])],
+      required: [...new Set(['result', ...extraRequired])],
     };
   }
 

--- a/packages/rig/src/tools/report.ts
+++ b/packages/rig/src/tools/report.ts
@@ -3,13 +3,58 @@ import { Tool } from '@lloyal-labs/lloyal-agents';
 import type { JsonSchema } from '@lloyal-labs/lloyal-agents';
 
 /**
- * Terminal tool for submitting agent results
+ * Options for {@link ReportTool}.
+ *
+ * @category Rig
+ */
+export interface ReportToolOpts {
+  /** Override the tool description shown in the agent's tool schema. */
+  description?: string;
+  /** Override the `result` parameter description. */
+  resultDescription?: string;
+  /**
+   * Extra JSON-schema properties merged into `parameters.properties` alongside
+   * `result`. Their shape is grammar-forced when the model emits the report
+   * call, so a harness can require structured fields (e.g. a
+   * `sources: [{title, url}]` array for inline citations) WITHOUT re-declaring a
+   * parallel `report` tool. The pool still captures only the `result` string;
+   * a policy override reads the sibling fields off the same tool call.
+   *
+   * @example
+   * new ReportTool({
+   *   extraProperties: {
+   *     sources: {
+   *       type: 'array',
+   *       items: { type: 'object', properties: { title: { type: 'string' }, url: { type: 'string' } }, required: ['title', 'url'] },
+   *     },
+   *   },
+   *   extraRequired: ['sources'],
+   * });
+   */
+  extraProperties?: Record<string, JsonSchema>;
+  /**
+   * Property names (from {@link extraProperties}) to mark `required` alongside
+   * `result`. Note the grammar forces a required field's PRESENCE and SHAPE, not
+   * its contents: a required array without `minItems` still permits `[]`, and a
+   * bare `{ type: 'string' }` url permits any string.
+   */
+  extraRequired?: string[];
+}
+
+/**
+ * Terminal tool for submitting agent results.
  *
  * Used as the `terminalToolName` in agent pools — when an agent calls
  * this tool, the pool records the result string and marks the agent
  * as finished. The tool's `execute()` code-path is not reached; the
  * agent pool intercepts the call at the policy layer and extracts the
  * `result` argument as the agent's return value.
+ *
+ * **Schema extension.** The default schema is `{ result: string }`. Pass
+ * {@link ReportToolOpts.extraProperties} / {@link ReportToolOpts.extraRequired}
+ * to merge additional grammar-forced fields into `parameters` — the seam a
+ * harness uses to force structured `sources` for inline citations instead of
+ * shadowing this tool with a hand-synced copy.
  *
  * @category Rig
  */
@@ -18,12 +63,7 @@ export class ReportTool extends Tool<{ result: string }> {
   readonly description: string;
   readonly parameters: JsonSchema;
 
-  constructor(opts?: {
-    /** Override the tool description shown in the agent's tool schema. */
-    description?: string;
-    /** Override the result parameter description. */
-    resultDescription?: string;
-  }) {
+  constructor(opts?: ReportToolOpts) {
     super();
     this.description = opts?.description ??
       'Submit your final research findings with specific evidence, direct quotes, data points, and source URLs from the pages you read. State what you found AND what you checked but could not find. Do not summarize — preserve detail.';
@@ -35,8 +75,9 @@ export class ReportTool extends Tool<{ result: string }> {
           description: opts?.resultDescription ??
             'Detailed findings with direct quotes, data points, and source URLs. Include what was found and what was not found.',
         },
+        ...(opts?.extraProperties ?? {}),
       },
-      required: ['result'],
+      required: ['result', ...(opts?.extraRequired ?? [])],
     };
   }
 

--- a/packages/rig/src/tools/report.ts
+++ b/packages/rig/src/tools/report.ts
@@ -20,6 +20,10 @@ export interface ReportToolOpts {
    * parallel `report` tool. The pool still captures only the `result` string;
    * a policy override reads the sibling fields off the same tool call.
    *
+   * `result` is RESERVED and cannot be overridden here — the pool's terminal
+   * capture reads `.result`, so it is always the canonical string schema. A
+   * `result` key in `extraProperties` is ignored (use `resultDescription`).
+   *
    * @example
    * new ReportTool({
    *   extraProperties: {
@@ -67,6 +71,11 @@ export class ReportTool extends Tool<{ result: string }> {
     super();
     this.description = opts?.description ??
       'Submit your final research findings with specific evidence, direct quotes, data points, and source URLs from the pages you read. State what you found AND what you checked but could not find. Do not summarize — preserve detail.';
+    // `result` is reserved: strip it from the extras so it can't be overridden
+    // (the pool's terminal capture reads `.result`) and set it canonically as
+    // the first property — the extension is strictly additive.
+    const extra = { ...(opts?.extraProperties ?? {}) };
+    delete extra.result;
     this.parameters = {
       type: 'object',
       properties: {
@@ -75,9 +84,12 @@ export class ReportTool extends Tool<{ result: string }> {
           description: opts?.resultDescription ??
             'Detailed findings with direct quotes, data points, and source URLs. Include what was found and what was not found.',
         },
-        ...(opts?.extraProperties ?? {}),
+        ...extra,
       },
-      required: ['result', ...(opts?.extraRequired ?? [])],
+      // De-duplicate (Set preserves insertion order → `result` stays first), so a
+      // caller repeating a name or passing `result` in extraRequired can't emit an
+      // invalid `required` array.
+      required: [...new Set(['result', ...(opts?.extraRequired ?? [])])],
     };
   }
 

--- a/packages/rig/test/tool-construction.test.ts
+++ b/packages/rig/test/tool-construction.test.ts
@@ -41,6 +41,30 @@ describe('new ReportTool(opts)', () => {
     const props = tool.parameters.properties as { result: { description: string } };
     expect(props.result.description).toBe('custom result desc');
   });
+
+  it('merges extraProperties + extraRequired into the schema (the citation seam)', () => {
+    const sources = {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: { title: { type: 'string' }, url: { type: 'string' } },
+        required: ['title', 'url'],
+      },
+    };
+    const tool = new ReportTool({ extraProperties: { sources }, extraRequired: ['sources'] });
+    const props = tool.parameters.properties as Record<string, unknown>;
+    // `result` is preserved; `sources` is merged in alongside it.
+    expect(props).toHaveProperty('result');
+    expect(props.sources).toEqual(sources);
+    // Both are required — `result` first, extras appended.
+    expect(tool.parameters.required).toEqual(['result', 'sources']);
+  });
+
+  it('leaves the schema at the default {result} shape when no extras are passed', () => {
+    const tool = new ReportTool();
+    expect(Object.keys(tool.parameters.properties as object)).toEqual(['result']);
+    expect(tool.parameters.required).toEqual(['result']);
+  });
 });
 
 describe('new DelegateTool(opts)', () => {

--- a/packages/rig/test/tool-construction.test.ts
+++ b/packages/rig/test/tool-construction.test.ts
@@ -65,6 +65,32 @@ describe('new ReportTool(opts)', () => {
     expect(Object.keys(tool.parameters.properties as object)).toEqual(['result']);
     expect(tool.parameters.required).toEqual(['result']);
   });
+
+  it('reserves `result`: extraProperties cannot override the built-in result schema', () => {
+    const tool = new ReportTool({
+      resultDescription: 'canonical result desc',
+      extraProperties: {
+        result: { type: 'number', description: 'bogus override' },
+        sources: { type: 'array' },
+      },
+    });
+    const props = tool.parameters.properties as {
+      result: { type: string; description: string };
+    };
+    // result stays the canonical string schema, not the caller's override…
+    expect(props.result.type).toBe('string');
+    expect(props.result.description).toBe('canonical result desc');
+    // …and remains first, with the non-reserved extra merged after it.
+    expect(Object.keys(tool.parameters.properties as object)).toEqual(['result', 'sources']);
+  });
+
+  it('de-duplicates `required` (result first) when extraRequired repeats or includes result', () => {
+    const tool = new ReportTool({
+      extraProperties: { sources: { type: 'array' } },
+      extraRequired: ['result', 'sources', 'sources'],
+    });
+    expect(tool.parameters.required).toEqual(['result', 'sources']);
+  });
 });
 
 describe('new DelegateTool(opts)', () => {

--- a/packages/rig/test/tool-construction.test.ts
+++ b/packages/rig/test/tool-construction.test.ts
@@ -91,6 +91,14 @@ describe('new ReportTool(opts)', () => {
     });
     expect(tool.parameters.required).toEqual(['result', 'sources']);
   });
+
+  it('throws when extraRequired names a property missing from extraProperties', () => {
+    // typo / extraRequired without the matching extraProperties → invalid schema
+    expect(() => new ReportTool({ extraRequired: ['sources'] })).toThrow(/not defined in extraProperties/);
+    expect(
+      () => new ReportTool({ extraProperties: { sources: { type: 'array' } }, extraRequired: ['sauces'] }),
+    ).toThrow(/"sauces"/);
+  });
 });
 
 describe('new DelegateTool(opts)', () => {


### PR DESCRIPTION
## What

`ReportTool` gains two constructor options — `extraProperties` and `extraRequired` (typed via the new exported `ReportToolOpts`) — that merge additional JSON-schema properties into the terminal `report` tool's `parameters`. This lets a harness force structured fields alongside `result` (e.g. a `sources: [{title, url}]` array for inline citations) **through** rig, rather than shadowing `report` with a hand-synced parallel tool.

## Why

Today `ReportTool.parameters` is `readonly` and fixed to `{ result: string }`, and the constructor exposes only `description`/`resultDescription`. A harness that wants a grammar-forced `sources` field must therefore re-declare a whole parallel `report` tool and keep its `name`/no-op/terminal contract byte-aligned by hand — a sync hazard. This adds the missing seam so the capability lives in one place.

The pool still captures only the `result` string; a policy override reads the sibling fields off the same tool call.

## Notes

- **No behavior change by default**: with no opts, the schema stays `{ result }` with `required: ['result']`.
- Grammar-forcing covers a required field's **presence and shape**, not its contents (a required array without `minItems` still permits `[]`; a bare `string` url permits any string) — documented on `ReportToolOpts`.
- `rig` 3.6.0 → 3.7.0.

## Tests

`packages/rig/test/tool-construction.test.ts` — added the merge case (`extraProperties`/`extraRequired` land in the schema, `required` = `['result','sources']`) and a default-shape guard (no extras ⇒ unchanged). Full rig suite: 167 passing.