### PR TITLE
chore(harness-cli): repoint blank wikipedia dep to 1.1.0

### DIFF
--- a/packages/harness-cli/templates/blank/package.json
+++ b/packages/harness-cli/templates/blank/package.json
@@ -35,7 +35,7 @@
     "@lloyal-labs/lloyal.node": "^3.0.1",
     "@lloyal-labs/rig": "^3.2.0",
     "@lloyal-labs/sdk": "^3.0.0",
-    "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.0.0.tgz",
+    "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.1.0.tgz",
     "effection": "^4.0.2",
     "ink": "^5.0.1",
     "react": "^18.3.1",


### PR DESCRIPTION
## What

The blank template's default AgentApp dep still pointed at `lloyal__wikipedia-1.0.0.tgz` — a **pre-reshape** tarball published before `defineApp(manifest, setup)`. Under current rig it throws `manifest.name must be a string` at `enable`, so a stranger's `create`(blank) → `npm install` → run failed on the default app.

wikipedia was republished at **1.1.0** (rebuilt against the current shape; floors agents `^3.4.0` / rig `^3.5.0`) and is **live in the signed catalog** (HTTP 200, verified). This repoints the template to it — the last blocker to a clean end-to-end blank on all three targets (cli · desktop · web).

## Change

One line — `templates/blank/package.json`:

```diff
-    "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.0.0.tgz",
+    "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.1.0.tgz",
```

No version bump — `harness.dev` stays held at 0.5.1; this reaches users on the next CLI republish.