### PR TITLE
feat(harness-cli): research template + create --template flag

### DIFF
--- a/packages/harness-cli/src/commands/create.ts
+++ b/packages/harness-cli/src/commands/create.ts
@@ -104,9 +104,9 @@ export const createCommand: Command = {
 
     const appsNote =
       template === 'research'
-        ? '  run and runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
+        ? '  it runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
           '  preinstalled (grounded multi-agent research);\n'
-        : '  run and runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
+        : '  it runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
 
     process.stdout.write(
       `scaffolded ${name} (${template}) at ${dest}\n` +
@@ -115,7 +115,7 @@ export const createCommand: Command = {
         '    npm install\n' +
         '    npm start\n' +
         '\n' +
-        '  No API key needed — the model is fetched + digest-verified on first\n' +
+        '  No API key needed — the model is fetched + digest-verified on first run;\n' +
         appsNote +
         '  add more via: npx harness.dev install <publisher>/<name>\n',
     );

--- a/packages/harness-cli/src/commands/create.ts
+++ b/packages/harness-cli/src/commands/create.ts
@@ -13,19 +13,24 @@ const USAGE = [
   'harness.dev — scaffold a new harness project (the default action)',
   '',
   'Usage:',
-  '  npx harness.dev <name> [--dir <path>]',
+  '  npx harness.dev <name> [--template <blank|research>] [--dir <path>]',
   '',
   'Arguments:',
   '  <name>        Harness project name — also the directory created.',
   '',
   'Options:',
+  '  --template <blank|research>',
+  '                Starting point (default: blank). blank = a minimal parallel',
+  '                pool + synth; research = the tuned recon→plan→agents→synth',
+  '                pipeline (grounded multi-agent research).',
   '  --dir <path>  Parent directory to create the harness in (default: cwd)',
   '  -h, --help    Show this help',
   '',
-  'Emits a runnable harness: a parallel research pool + synth over a resident',
-  'model (fetched + verified on first run — no API key), wired to the signed',
-  'lloyal/wikipedia app. Run `npm install && npm start`.',
+  'Emits a runnable harness on cli + desktop + web off one center, on a resident',
+  'model (fetched + verified on first run — no API key). Run `npm install && npm start`.',
 ].join('\n');
+
+type TemplateKind = 'blank' | 'research';
 
 // Same grammar as `harness.dev app`: identifier-safe lowercase that
 // satisfies both directory and npm package-name conventions.
@@ -41,6 +46,7 @@ export const createCommand: Command = {
       options: {
         help: { type: 'boolean', short: 'h' },
         dir: { type: 'string' },
+        template: { type: 'string' },
       },
       allowPositionals: true,
     });
@@ -62,6 +68,14 @@ export const createCommand: Command = {
       return 1;
     }
 
+    const template = (values.template ?? 'blank') as TemplateKind;
+    if (template !== 'blank' && template !== 'research') {
+      process.stderr.write(
+        `harness.dev: invalid --template "${values.template}" — expected "blank" or "research".\n`,
+      );
+      return 1;
+    }
+
     const parentDir = resolve(values.dir ?? process.cwd());
     const dest = join(parentDir, name);
 
@@ -76,7 +90,7 @@ export const createCommand: Command = {
       // ENOENT — good
     }
 
-    const templateDir = resolveTemplateDir('blank');
+    const templateDir = resolveTemplateDir(template);
     const substitutions = buildSubstitutions(name);
 
     try {
@@ -88,15 +102,21 @@ export const createCommand: Command = {
       return 1;
     }
 
+    const appsNote =
+      template === 'research'
+        ? '  run and runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
+          '  preinstalled (grounded multi-agent research);\n'
+        : '  run and runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
+
     process.stdout.write(
-      `scaffolded ${name} at ${dest}\n` +
+      `scaffolded ${name} (${template}) at ${dest}\n` +
         '  next steps:\n' +
         `    cd ${name}\n` +
         '    npm install\n' +
         '    npm start\n' +
         '\n' +
         '  No API key needed — the model is fetched + digest-verified on first\n' +
-        '  run and runs inside your app. The lloyal/wikipedia app is preinstalled;\n' +
+        appsNote +
         '  add more via: npx harness.dev install <publisher>/<name>\n',
     );
     return 0;
@@ -109,7 +129,7 @@ export const createCommand: Command = {
  * `<pkg-root>/dist/commands/create.js`, so the templates are at
  * `<pkg-root>/templates/<kind>`.
  */
-function resolveTemplateDir(kind: 'app' | 'harness' | 'blank'): string {
+function resolveTemplateDir(kind: 'app' | 'harness' | 'blank' | 'research'): string {
   const here = __dirname;
   const candidates = [
     resolve(here, '..', '..', 'templates', kind),

--- a/packages/harness-cli/templates/research/.gitignore
+++ b/packages/harness-cli/templates/research/.gitignore
@@ -1,0 +1,14 @@
+node_modules/
+dist/
+traces/
+
+# Build outputs: cli (dist/ above), desktop (electron-vite → out/),
+# web (vite → dist-web/).
+out/
+dist-web/
+
+# Model weights are fetched or dropped locally, never committed.
+models/**/*.gguf
+
+*.log
+.DS_Store

--- a/packages/harness-cli/templates/research/LICENSE
+++ b/packages/harness-cli/templates/research/LICENSE
@@ -1,0 +1,189 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept support,
+      warranty, indemnity, or other liability obligations and/or rights
+      consistent with this License. However, in accepting such obligations,
+      You may act only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2026 Lloyal Labs
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/harness-cli/templates/research/README.md
+++ b/packages/harness-cli/templates/research/README.md
@@ -1,0 +1,73 @@
+# __NAME__
+
+A grounded multi-agent research harness. The models live *inside* the app — no
+API key, and nothing on the inference path touches the network. Given a question
+it runs a pre-flight recon probe of each source, plans a set of research tasks, and
+dispatches a pool of agents that gather evidence in parallel (or in a dependency
+chain), then synthesizes one cited answer.
+
+> **SNAPSHOT: reasoning.run @ 0.8.0.** This template is a curated separate copy of
+> reasoning.run's RACE/DRB-tuned pipeline, conforming to the `harness.dev create`
+> conventions — a real, editable starter, not a dependency. Drift from upstream is
+> expected.
+
+## Run it
+
+```sh
+npm install
+npm start
+```
+
+Two models are fetched and **digest-verified** on first run — no key: the reasoning
+LLM into `models/llm/`, and the reranker the sources score retrievals with into
+`models/reranker/`. (Prefer your own weight? Drop a `.gguf` in the role folder, or
+point a `path:` in `harness.yml` at one.) `npm start` opens a terminal UI; type a
+question and watch recon → plan → agents → synth run on-device.
+
+`npm start` builds with **esbuild** (`--loader:.eta=text`) rather than plain `tsc`,
+because the harness inlines the tuned prompt templates from `prompts/*.eta`.
+
+The SAME harness runs on two more surfaces — same `harness(ctx, events, commands)`,
+same `reduce`, a different binding:
+
+```sh
+npm run dev:desktop   # a native window (Electron): forks this cli as the engine
+npm run serve         # a local host serving browsers over ws://127.0.0.1:8787
+npm run dev:web       # …and the browser app that talks to it (Vite, :5173)
+```
+
+## The shape
+
+```
+harness/
+  harness.ts     ← the one file that's yours: the command loop + app boot
+  pipeline.ts    the tuned recon → plan → research → synth pipeline + policies
+  protocol.ts    the events (↓) and commands (↑) your harness speaks
+  state.ts       node-free reduce(events) → AppState (every view folds it)
+  runner.ts      this harness's edge substrate (the reranker + config seam)
+prompts/         the 7 RACE/DRB-tuned .eta prompts — edit one to override it
+targets/
+  cli/
+    index.ts     boot: resolve the models, mount a view, run your harness
+    view.tsx     the terminal view (Ink) — swap it, or bring a whole app
+  desktop/       the same harness in a native window (Electron + ipc binding)
+    App.tsx      the shared React view (desktop + web) — folds the same reduce
+  web/           a local host (serve.ts) + browser app, over the wss binding
+models/
+  llm/           the resident reasoning model (fetched on first run; gitignored)
+  reranker/      the resident cross-encoder      (fetched on first run; gitignored)
+harness.yml      targets + models
+```
+
+Everything under `targets/` is convention handled for you. The center —
+`harness/harness.ts` + `harness/pipeline.ts` — is where you program what your
+intelligence does. Drop a `prompts/<name>.eta` into the tree to override any tuned
+prompt; an empty `prompts/` is byte-identical to the baked defaults.
+
+## Add capabilities
+
+```sh
+npx harness.dev install <publisher>/<name>   # a signed AgentApp from apps.lloyal.ai
+```
+
+Enable it in `harness/harness.ts` by adding its factory to `apps`.

--- a/packages/harness-cli/templates/research/README.md
+++ b/packages/harness-cli/templates/research/README.md
@@ -44,7 +44,9 @@ harness/
   pipeline.ts    the tuned recon → plan → research → synth pipeline + policies
   protocol.ts    the events (↓) and commands (↑) your harness speaks
   state.ts       node-free reduce(events) → AppState (every view folds it)
-  runner.ts      this harness's edge substrate (the reranker + config seam)
+  runner-ctx.ts  this harness's edge Runner seam (config + lifecycle) — RunnerCtx
+  served-runtime.ts  the edge/served Runner factories + per-session model context
+  served-session.ts  the served (web) per-session boot: provision services → run harness
 prompts/         the 7 RACE/DRB-tuned .eta prompts — edit one to override it
 targets/
   cli/

--- a/packages/harness-cli/templates/research/bin/run.js
+++ b/packages/harness-cli/templates/research/bin/run.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+import("../dist/targets/cli/index.mjs");

--- a/packages/harness-cli/templates/research/bin/serve.js
+++ b/packages/harness-cli/templates/research/bin/serve.js
@@ -1,0 +1,1 @@
+import("../dist/targets/web/serve.mjs");

--- a/packages/harness-cli/templates/research/electron.vite.config.ts
+++ b/packages/harness-cli/templates/research/electron.vite.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, externalizeDepsPlugin } from "electron-vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+
+/**
+ * The desktop target's 3-process build (`npm run dev:desktop` / `build:desktop`).
+ * `main` + `preload` run in Node (externalize node_modules; the local
+ * `harness/*` sources bundle in — they're node-free). The `renderer` is a normal
+ * Vite React app rooted at `targets/desktop`, folding `harness/state.ts`'s
+ * `reduce`. Source lives in `targets/desktop/`; this config is at the project
+ * root because that's where `electron-vite` looks for it.
+ */
+export default defineConfig({
+  main: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      lib: { entry: resolve(__dirname, "targets/desktop/main.ts") },
+    },
+  },
+  preload: {
+    plugins: [externalizeDepsPlugin()],
+    build: {
+      lib: { entry: resolve(__dirname, "targets/desktop/preload.ts") },
+    },
+  },
+  renderer: {
+    root: resolve(__dirname, "targets/desktop"),
+    plugins: [react()],
+    build: {
+      rollupOptions: { input: resolve(__dirname, "targets/desktop/index.html") },
+    },
+  },
+});

--- a/packages/harness-cli/templates/research/harness.yml
+++ b/packages/harness-cli/templates/research/harness.yml
@@ -1,0 +1,18 @@
+# harness.yml — the deployment manifest. Your program lives in harness/harness.ts.
+# Every surface listed explicitly; only the fields you chose are shown.
+#
+#   cli      a terminal app       (npm start)
+#   desktop  a native window      (npm run dev:desktop)
+#   web      a browser app + host (npm run serve · npm run dev:web)
+#
+# One harness over a binding, folding the one reduce in harness/state.ts.
+targets: [cli, desktop, web]
+
+model:
+  llm:
+    id: "reasoning-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity
+    context: 32768
+  # The corpus + web apps score retrievals with a reranker. It's resolved +
+  # digest-verified into models/reranker/ on first run, then created per-boot.
+  reranker:
+    id: "qwen3-reranker-0.6b-q8"

--- a/packages/harness-cli/templates/research/harness/commands.ts
+++ b/packages/harness-cli/templates/research/harness/commands.ts
@@ -1,0 +1,56 @@
+/**
+ * UI → main.ts command boundary.
+ *
+ * The Ink component tree dispatches commands through the `useCommand`
+ * hook; main.ts drains them from an Effection Signal and runs the
+ * corresponding Operation (runPlanner, runResearch, saveConfig, ...).
+ *
+ * Keep the union small and explicit. No generic "send arbitrary event"
+ * escape hatch — that's what makes the UI <-> harness boundary auditable.
+ */
+
+export type Command =
+  | { type: 'submit_query'; query: string; mode: 'flat' | 'deep'; skipPlanner?: boolean }
+  | { type: 'submit_clarification'; answer: string }
+  | { type: 'accept_plan' }
+  | { type: 'cancel_plan' }
+  | { type: 'edit_plan'; query: string }
+  | { type: 'change_mode'; mode: 'flat' | 'deep' }
+  | { type: 'update_task_description'; index: number; description: string }
+  | { type: 'add_task'; afterIndex: number }
+  | { type: 'delete_task'; index: number }
+  | { type: 'move_task'; from: number; to: number }
+  | { type: 'set_app_config'; name: string; values: Record<string, unknown> }
+  | { type: 'set_output_dir'; path: string }
+  // Global run-effort setting (pure policy preset). Set in Settings → Effort;
+  // persisted to harness.json and applied to every subsequent query.
+  | { type: 'set_effort'; effort: 'low' | 'medium' | 'high' | 'ultra' }
+  | { type: 'set_model_path'; path: string }
+  | { type: 'set_reranker_path'; path: string }
+  // GPU backend variant (persisted as model.gpu; main.ts restarts the boot so
+  // ctx + reranker reload on the new backend). Values mirror lloyal.node's
+  // GpuVariant; 'default' = the platform binary's built-in backend.
+  | { type: 'set_gpu'; gpu: 'default' | 'cuda' | 'vulkan' }
+  // Boot-time BACKEND_DL pack offer (uiPhase 'backend_pack_offer'). Accept
+  // downloads + installs the pack for this and every future boot; decline
+  // persists model.backendPack=false so the offer never re-fires.
+  | { type: 'accept_backend_pack' }
+  | { type: 'decline_backend_pack' }
+  | { type: 'toggle_participation'; name: string }
+  // Escape hatch: interrupt the in-flight run (planner / research / synth) and
+  // return to the composer. Handled in main.ts's command loop by halting the
+  // spawned run Task (Effection halt tears down the run scope + cancels any
+  // parked tool fetch via cancellable-fetch's scope-signal) and sending
+  // `ui:composer`. No-op when no run is active. Never kills the loop/process.
+  | { type: 'stop' }
+  // Graceful "Wrap up": drain the in-flight run to a fast best-effort answer
+  // instead of aborting it. Handled in main.ts by sending the WindDown signal
+  // (NOT halting) — the pool stops spawning, reaps active agents, lets in-flight
+  // tools settle, and folds the cohort into a recovered answer + synth. No-op
+  // when no run is active. Distinct from `stop` (abort → composer).
+  | { type: 'wrap_up' }
+  // Per-agent cancel: discard one LIVE flat-mode research agent (halt its tool +
+  // prune its KV + terminal agent:failed(user_cancel)); siblings keep running. The
+  // renderer only offers this on a live, non-recovering flat-mode card.
+  | { type: 'cancel_agent'; agentId: number }
+  | { type: 'quit' };

--- a/packages/harness-cli/templates/research/harness/config-types.ts
+++ b/packages/harness-cli/templates/research/harness/config-types.ts
@@ -1,0 +1,114 @@
+/**
+ * The harness config *schema* — the node-free type block.
+ *
+ * Carved from reasoning.run's `src/tui-ink/config.ts` (the `Config` family +
+ * `ConfigOrigin` + `SaveResult`). NO `node:fs`/`node:path` — a browser/renderer
+ * surface, the `reduce` graph, and the served-runner factory all import these
+ * types, so the file must stay runtime-free. The config *loaders*
+ * (`loadConfig`/`saveConfig`) that touched disk are deliberately NOT copied —
+ * this template's runner (`makeEdgeRunner`) holds config in memory.
+ */
+
+export interface ConfigSources {
+  /** Where per-query run-dirs (report.md + annexure-N.md) and the session
+   *  trace.jsonl get written. Default = process.cwd() at boot. This is
+   *  harness config — NOT a per-app config object. */
+  outputDir?: string;
+}
+
+/** Per-app stored config, keyed by `manifest.name` → the app's config object
+ *  (whatever the app's `configSchema` declares; e.g. `{ corpusPath }`,
+ *  `{ tavilyKey }`). The harness never reads inside these objects — it
+ *  whole-replaces an app's entry and hands it to the registry, which
+ *  validates against the app's `configSchema` on enable. Secrets (e.g.
+ *  `tavilyKey`) live here verbatim; env-provided secrets win at the app
+ *  factory and are never written back. */
+export type ConfigApps = Record<string, Record<string, unknown>>;
+
+export interface ConfigDefaults {
+  reasoningMode: 'flat' | 'deep';
+  /** Run effort preset — the session default for the composer's effort control
+   *  (pure policy: budget + planner breadth + recovery cap). @default 'high' */
+  effort: 'low' | 'medium' | 'high' | 'ultra';
+  maxTurns: number;
+}
+
+/** GPU backend variant — mirrors lloyal.node's `GpuVariant` union (config
+ *  deliberately takes no lloyal.node dependency). 'default' = the platform
+ *  package's built-in backend (Metal on darwin, CPU elsewhere). */
+export type ConfigGpu = 'default' | 'cuda' | 'vulkan';
+
+export const CONFIG_GPU_VALUES: readonly ConfigGpu[] = [
+  'default',
+  'cuda',
+  'vulkan',
+];
+
+export function isConfigGpu(v: unknown): v is ConfigGpu {
+  return typeof v === 'string' && (CONFIG_GPU_VALUES as readonly string[]).includes(v);
+}
+
+export interface ConfigModel {
+  /** Filesystem path OR catalog id (e.g. `qwen3.5-4b-q4`). Resolution is
+   *  the caller's concern — config just stores whatever the user typed. */
+  path?: string;
+  reranker?: string;
+  /** LLM context window size. Null/undefined falls through to CLI/env/default. */
+  nCtx?: number;
+  /** GPU backend variant. Null/undefined falls through to CLI/env/default
+   *  (env source: LLOYAL_GPU). */
+  gpu?: ConfigGpu;
+  /** BACKEND_DL pack consent. `false` = user declined the boot-time offer
+   *  ("won't ask again"); undefined = never asked / may offer. Never `true`:
+   *  acceptance is evidenced by the cache itself, not a config bit. */
+  backendPack?: boolean;
+}
+
+export interface Config {
+  version: 1;
+  sources: ConfigSources;
+  /** Per-app stored config, keyed by `manifest.name`. The harness seeds
+   *  `configStore` from this on boot (loop over entries) and whole-replaces
+   *  an app's entry on `set_app_config`. Persisted under `apps[name]`. */
+  apps: ConfigApps;
+  defaults: ConfigDefaults;
+  model: ConfigModel;
+}
+
+/** Which layer supplied a given harness-level field — used for composer UI
+ *  hints. Per-app config lives in `Config.apps` and carries no origin
+ *  tracking (apps validate their own config at enable time). */
+export interface ConfigOrigin {
+  reasoningMode: 'cli' | 'file' | 'default';
+  modelPath: 'cli' | 'file' | 'default';
+  reranker: 'cli' | 'file' | 'default';
+  nCtx: 'cli' | 'env' | 'file' | 'default';
+  gpu: 'cli' | 'env' | 'file' | 'default';
+  outputDir: 'cli' | 'file' | 'default';
+}
+
+export interface LoadedConfig {
+  config: Config;
+  origin: ConfigOrigin;
+  path: string;
+  /** true iff harness.json existed on disk and was read successfully. */
+  loadedFromFile: boolean;
+}
+
+export interface CliOverrides {
+  reasoningMode?: 'flat' | 'deep';
+  modelPath?: string;
+  reranker?: string;
+  nCtx?: number;
+  gpu?: ConfigGpu;
+  outputDir?: string;
+}
+
+export interface SaveResult {
+  path: string;
+  /** true iff this save appended `harness.json` to `.gitignore` during this
+   *  call. Only ever true on the very first save in a git repo. */
+  gitignored: boolean;
+  /** Fields that were IN the patch but deliberately skipped (env won). */
+  skipped: string[];
+}

--- a/packages/harness-cli/templates/research/harness/config-types.ts
+++ b/packages/harness-cli/templates/research/harness/config-types.ts
@@ -34,8 +34,9 @@ export interface ConfigDefaults {
 }
 
 /** GPU backend variant — mirrors lloyal.node's `GpuVariant` union (config
- *  deliberately takes no lloyal.node dependency). 'default' = the platform
- *  package's built-in backend (Metal on darwin, CPU elsewhere). */
+ *  deliberately takes no lloyal.node dependency). Per the SDK `GpuVariant` docs,
+ *  'default' is the portable CPU-capable build (works everywhere); 'cuda' /
+ *  'vulkan' request an accelerated build, falling back to CPU if unavailable. */
 export type ConfigGpu = 'default' | 'cuda' | 'vulkan';
 
 export const CONFIG_GPU_VALUES: readonly ConfigGpu[] = [

--- a/packages/harness-cli/templates/research/harness/config-types.ts
+++ b/packages/harness-cli/templates/research/harness/config-types.ts
@@ -34,9 +34,11 @@ export interface ConfigDefaults {
 }
 
 /** GPU backend variant — mirrors lloyal.node's `GpuVariant` union (config
- *  deliberately takes no lloyal.node dependency). Per the SDK `GpuVariant` docs,
- *  'default' is the portable CPU-capable build (works everywhere); 'cuda' /
- *  'vulkan' request an accelerated build, falling back to CPU if unavailable. */
+ *  deliberately takes no lloyal.node dependency). 'default' is the portable
+ *  CPU-capable build (works everywhere); 'cuda' / 'vulkan' request an accelerated
+ *  build. An explicitly configured variant is a deliberate deploy choice — the
+ *  served boot fails fast on an unavailable one (`LLOYAL_NO_FALLBACK`, see
+ *  `applyServedGpuEnv`) rather than silently dropping to CPU. */
 export type ConfigGpu = 'default' | 'cuda' | 'vulkan';
 
 export const CONFIG_GPU_VALUES: readonly ConfigGpu[] = [

--- a/packages/harness-cli/templates/research/harness/effort-presets.ts
+++ b/packages/harness-cli/templates/research/harness/effort-presets.ts
@@ -1,0 +1,91 @@
+/**
+ * Run-effort presets — pure policy (KV/time budget + planner breadth + recovery
+ * cap), NO prompt/semantic effect (that is `reasoningMode`'s job). Shared by the
+ * harness (which applies them via `createResearchPolicy` / `runPlanner`) and the
+ * Settings UI (which displays them). Plain data — no engine deps — so both the
+ * engine bundle and the renderer can import it without dragging in `agents`.
+ *
+ * `high` reproduces the historical values byte-for-byte. The `medium`/`low`
+ * numbers are starting estimates; calibration against live runs is expected.
+ * The effort levers are: KV reserve (`context`), time budget, planner breadth
+ * (`maxTasks`), and the reranker explore→exploit threshold (`shouldExplore`).
+ */
+export type Effort = 'low' | 'medium' | 'high' | 'ultra'
+
+export interface EffortPreset {
+  budget: {
+    context: { softLimit: number; hardLimit: number }
+    time: { softLimit: number; hardLimit: number }
+  }
+  /** Planner task cap — the fan-out breadth. */
+  maxTasks: number
+  /** Recovery-report token cap; omitted = headroom-derived (the fold default). */
+  reportBudget?: number
+  /**
+   * Reranker explore→exploit KV threshold (`DefaultAgentPolicy.shouldExplore`).
+   * `context` = the fraction of KV that must still be AVAILABLE to keep EXPLORING
+   * (relaxed retrieval that can surface novel facts); below it, switch to EXPLOIT
+   * (strict dual-entailment scoring vs the task AND the original query). LOWER
+   * `context` = explores LONGER. Omitted = framework default (0.4). See
+   * reference_exploit_mode (strict `min(taskScore, queryScore)` vs relaxed).
+   */
+  shouldExplore?: { context: number }
+}
+
+export const EFFORT_PRESETS: Record<Effort, EffortPreset> = {
+  // ULTRA — the ceiling tier, hand-tuned for a large (~1M-token) nCtx. NOTE: the
+  // context limits are ABSOLUTE free-KV reserve floors, NOT nCtx-derived — nothing
+  // here auto-scales from the context window; these are hand-authored (see the
+  // module header). `maxTasks: 10` is past the planner's tested `>6` boundary
+  // ("shared-spine overflow" territory) — unproven, worth a real run to calibrate.
+  ultra: {
+    budget: {
+      // ~4× high — extra recovery/report headroom for a 10-task fan-out at ~1M nCtx.
+      context: { softLimit: 8192, hardLimit: 4096 },
+      // 10 min soft / 15 min hard — 10 tasks against a large model.
+      time: { softLimit: 600_000, hardLimit: 900_000 },
+    },
+    maxTasks: 10,
+    // Explore until 75% KV used (25% available) — hunts novel facts even longer
+    // than high (0.4) before tightening to strict dual-entailment retrieval.
+    shouldExplore: { context: 0.25 },
+  },
+  high: {
+    budget: {
+      context: { softLimit: 2048, hardLimit: 1024 },
+      time: { softLimit: 240_000, hardLimit: 360_000 },
+    },
+    maxTasks: 6,
+    // Explore until 60% KV used (40% available), then exploit — the framework
+    // default; high hunts novel facts the longest before tightening.
+    shouldExplore: { context: 0.4 },
+  },
+  medium: {
+    // Reserve ~20-25% of a 32k context so the parallel (low/medium) in-loop
+    // recovery reports bin-pack whole. Interim ABSOLUTE values — nCtx-relative
+    // scaling is the follow-up. reportBudget dropped: the in-loop headroom share
+    // (clamped to MAX_REPORT_BUDGET=2048) governs, so the reserve makes reports
+    // whole without a hard per-report cap.
+    budget: {
+      context: { softLimit: 8192, hardLimit: 6144 },
+      time: { softLimit: 150_000, hardLimit: 240_000 },
+    },
+    maxTasks: 4,
+    // Explore until 40% KV used (60% available), then exploit — some novelty up
+    // front, then lock to strict relevance with recovery room still banked.
+    shouldExplore: { context: 0.6 },
+  },
+  low: {
+    budget: {
+      context: { softLimit: 10240, hardLimit: 8192 },
+      time: { softLimit: 90_000, hardLimit: 150_000 },
+    },
+    maxTasks: 2,
+    // Always exploit — strict on-topic (dual-entailment) retrieval from turn 1.
+    // Quick + shallow: converge on relevance fastest, recovery fits easily.
+    shouldExplore: { context: 1.0 },
+  },
+}
+
+/** Display order for UI (lightest → heaviest). */
+export const EFFORT_ORDER: readonly Effort[] = ['low', 'medium', 'high', 'ultra']

--- a/packages/harness-cli/templates/research/harness/events.ts
+++ b/packages/harness-cli/templates/research/harness/events.ts
@@ -1,0 +1,121 @@
+/**
+ * Event union consumed by the Ink reducer.
+ *
+ * These mirror the StepEvent variants emitted by examples/deep-research/harness.ts
+ * (formerly in examples/deep-research/tui.ts) plus the AgentEvent stream coming
+ * from @lloyal-labs/lloyal-agents. The harness continues to emit the same events
+ * — only the rendering layer is replaced.
+ */
+
+import type { AgentEvent } from '@lloyal-labs/lloyal-agents';
+import type { PlanIntent, ResearchTask } from '@lloyal-labs/rig';
+import type { AppDescriptor, OpTiming } from './state-core.js';
+import type { Config, ConfigOrigin } from './config-types.js';
+
+export type StepEvent =
+  | { type: 'query'; query: string; warm: boolean }
+  | {
+      type: 'plan';
+      intent: PlanIntent;
+      tasks: ResearchTask[];
+      clarifyQuestions: string[];
+      tokenCount: number;
+      timeMs: number;
+    }
+  | { type: 'research:start'; agentCount: number; mode: 'flat' | 'deep' }
+  | { type: 'research:done'; totalTokens: number; totalToolCalls: number; timeMs: number }
+  | { type: 'fanout:tasks'; tasks: ResearchTask[] }
+  | { type: 'spine:task'; taskIndex: number; taskCount: number; description: string }
+  | { type: 'spine:source'; taskIndex: number; source: string }
+  | { type: 'spine:task:done'; taskIndex: number; stageFindings: number; accumulated: number }
+  | { type: 'synthesize:start' }
+  | {
+      type: 'synthesize:done';
+      agentId: number;
+      ppl: number;
+      tokenCount: number;
+      toolCallCount: number;
+      timeMs: number;
+    }
+  | { type: 'answer'; text: string }
+  | {
+      type: 'stats';
+      timings: OpTiming[];
+      kvLine?: string;
+      ctxPct: number;
+      ctxPos: number;
+      ctxTotal: number;
+    }
+  | { type: 'complete'; data: Record<string, unknown> }
+  // ── UI / config events driven by main.ts ────────────────────────
+  | { type: 'config:loaded'; config: Config; origin: ConfigOrigin; path: string }
+  | {
+      type: 'config:updated';
+      config: Config;
+      origin: ConfigOrigin;
+      savedTo: string;
+      gitignored: boolean;
+      skipped: string[];
+    }
+  // ── Pre-flight recon (RFC: multi-app composition) — a recon agent probes
+  // ── each source for the query's entities BEFORE planning to ground routing.
+  // ── Its probe calls also stream as agent:* events (rendered live), so these
+  // ── two only bracket the phase; the per-probe detail is the agent stream.
+  | { type: 'preflight:start'; query: string; appCount: number }
+  | {
+      type: 'preflight:done';
+      coverage: string;
+      tokens: number;
+      toolCalls: number;
+      timeMs: number;
+    }
+  | { type: 'plan:start'; query: string; mode: 'flat' | 'deep' }
+  // ── Plan-edit events: user-driven mutations of state.plan.tasks before
+  // ── accept_plan. afterIndex: -1 means prepend; out-of-bounds indices
+  // ── on the others are reducer no-ops (defensive).
+  | { type: 'plan:task_updated'; index: number; description: string }
+  | { type: 'plan:task_added'; afterIndex: number }
+  | { type: 'plan:task_deleted'; index: number }
+  | { type: 'plan:task_moved'; from: number; to: number }
+  | { type: 'ui:composer'; prefill?: string }
+  | { type: 'ui:plan_review' }
+  | { type: 'ui:error'; message: string }
+  // ── Boot-phase events: download progress + weight-loading spinner ──
+  /** Pre-populates `state.downloads` with the full set of files about to
+   *  be fetched. Sent ONCE before any individual download:start so the
+   *  dynamic tree size is fixed from the moment 'downloading' begins. */
+  | { type: 'download:plan'; entries: { id: string; label: string; sizeBytes: number }[] }
+  | { type: 'download:start'; id: string; label: string; sizeBytes: number }
+  | { type: 'download:progress'; id: string; got: number; total: number; url?: string }
+  | { type: 'download:complete'; id: string }
+  | { type: 'weights:start'; label: string }
+  | { type: 'weights:label'; label: string }
+  | { type: 'weights:done' }
+  | { type: 'corpus:indexed'; corpusPath: string; fileCount: number; chunkCount: number }
+  | { type: 'boot:error'; kind: 'llm' | 'reranker' | 'backend-pack'; message: string }
+  /** Boot-time BACKEND_DL pack offer: a CUDA GPU was probed and a signed
+   *  full-arch pack is available for it. Rendered as a Download / Not now
+   *  dialog (uiPhase 'backend_pack_offer'); answered via the
+   *  accept_backend_pack / decline_backend_pack commands. */
+  | {
+      type: 'backendpack:offer';
+      gpuName: string;
+      sizeBytes: number;
+      needsRuntime: boolean;
+      runtimeSizeBytes: number;
+      reasons: string[];
+    }
+  // Per-query App participation toggle. Emitted by main.ts in response to
+  // a `toggle_participation` Command from the Composer. The reducer flips
+  // the bit in `state.participation[name]`. Pure UI state — no harness
+  // side effects; main.ts derives `appFilter` from `state.participation`
+  // at submit time and threads it into runQuery / runResearchPlan.
+  | { type: 'participation:toggled'; name: string }
+  // Installed-AgentApps snapshot for the Settings drawer. Emitted by main.ts
+  // after boot completes AND after every registry enable/disable/config
+  // change. The reducer drops it whole into `state.apps`. Display-only — the
+  // catalog-metadata join (title/iconUrl/entitlements) is best-effort and
+  // falls back to manifest-only fields on any catalog fetch failure.
+  | { type: 'apps:state'; apps: AppDescriptor[] };
+
+export type WorkflowEvent = AgentEvent | StepEvent;

--- a/packages/harness-cli/templates/research/harness/harness.ts
+++ b/packages/harness-cli/templates/research/harness/harness.ts
@@ -1,0 +1,891 @@
+/**
+ * Your harness — the platform contract: a headless generator
+ * `harness(ctx, events, commands)`.
+ *
+ * `ctx` is the resident model; `events` streams your `WorkflowEvent`s to whatever
+ * surface is mounted; `commands` delivers that surface's `Command`s back. This
+ * harness runs the RACE/DRB-tuned pipeline — pre-flight recon → planner →
+ * parallel/chain research pool → synthesis — over the substrate a target's boot
+ * established. It reads `RunnerCtx` (see ./runner.ts) for the edge-shell concerns
+ * it can't own: the reranker, the wind-down / cancel signals, the live config.
+ *
+ * The pipeline itself (`runQuery` / `runResearchPlan` / policies / the 7 tuned
+ * `.eta` prompts) lives in ./pipeline.ts — this file is the command loop + app
+ * boot that drives it. Edit the pipeline to change what your intelligence does;
+ * drop a `prompts/<name>.eta` into the project to override a tuned prompt.
+ *
+ * SNAPSHOT: reasoning.run @ 0.8.0 — a curated separate copy of its pipeline,
+ * conforming to the harness.dev create conventions. Drift from upstream is
+ * expected and accepted.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { spawn, each, call } from "effection";
+import type { Operation, Task, Signal } from "effection";
+import type { SessionContext } from "@lloyal-labs/sdk";
+import {
+  initAgents,
+  WindDown,
+  CancelAgent,
+  reconstructBranch,
+} from "@lloyal-labs/lloyal-agents";
+import type {
+  App,
+  AppFactory,
+  AppRegistry,
+  AppConfigStore,
+} from "@lloyal-labs/lloyal-agents";
+import type { EventBus } from "@lloyal-labs/binding";
+import {
+  createInMemoryConfigStore,
+  createAppRegistry,
+} from "@lloyal-labs/rig";
+import type { PlanResult } from "@lloyal-labs/rig";
+import { createWebApp } from "@lloyal-labs/web-app";
+import { createCorpusApp } from "@lloyal-labs/corpus-app";
+import { RunnerCtx } from "./runner-ctx.js";
+import {
+  runQuery,
+  runResearchPlan,
+  singleTaskPlan,
+  createCoverageCache,
+  CoverageCacheCtx,
+  PromptsCtx,
+  type Effort,
+} from "./pipeline.js";
+import type { WorkflowEvent, Command } from "./protocol.js";
+import type { AppDescriptor } from "./state.js";
+import { RunDirSink } from "./run-dir.js";
+import { resolvePath } from "./path-utils.js";
+
+// The two first-party app factories this harness enables. Before enabling, the
+// boot's `provisionAppModels` reads whatever Services each app declares
+// (corpus/web both declare `services: ['reranker']`), resolves + loads the
+// backing model, and publishes it on `RerankerCtx` — so the harness stays IO-free.
+// Install more with `harness.dev install <app>` and add the factory here.
+export const apps: AppFactory[] = [createCorpusApp, createWebApp];
+
+const WEB_APP = "web";
+const CORPUS_APP = "corpus";
+
+/** Name → factory for the two first-party apps this build ships. Drives the
+ *  `set_app_config` re-enable path (NOT config-write routing, which is
+ *  name-driven by the command payload). Returns undefined for unknown names. */
+const APP_FACTORIES: Record<string, AppFactory> = {
+  [WEB_APP]: createWebApp,
+  [CORPUS_APP]: createCorpusApp,
+};
+function factoryFor(name: string): AppFactory | undefined {
+  return APP_FACTORIES[name];
+}
+
+/** Whether the named app's factory needs stored config to enable. The web app
+ *  runs config-less (keyless search fallback); the corpus app needs a path. */
+function appRequiresConfig(name: string): boolean {
+  return name !== WEB_APP;
+}
+
+/** Resolve path-shaped string values in an app-config object at the UI→harness
+ *  boundary — no per-app name knowledge. A value is a path when its key ends in
+ *  "Path" or the string starts with ~ / . */
+function resolveConfigPaths(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(values)) {
+    if (
+      typeof value === "string" &&
+      value !== "" &&
+      (/path$/i.test(key) || /^[~/.]/.test(value))
+    ) {
+      out[key] = resolvePath(value);
+    } else {
+      out[key] = value;
+    }
+  }
+  return out;
+}
+
+const MAX_TOOL_TURNS = 10;
+
+// ── Planner context ──────────────────────────────────────────────
+
+/** Summarize the registered apps for the planner prompt: the source catalog the
+ *  planner routes against. With ≥2 sources the planner assigns each task's `app`
+ *  to the source that holds it — grounded by the pre-flight coverage probe that
+ *  runQuery folds into the context alongside this catalog. */
+function buildPlannerContext(apps: readonly App[]): string {
+  if (apps.length === 0) return "";
+  const lines: string[] = [
+    "Knowledge sources available for this research. Assign each task's `app` to the source that holds it, using its EXACT name below; the pre-flight `Source coverage` probe (when present) is the primary signal for which source covers what.",
+  ];
+  for (const app of apps) {
+    const protocol = app.manifest.protocol;
+    lines.push("", `### ${protocol.name}`, protocol.useWhen);
+    const toc = app.source.promptData()["toc"];
+    if (typeof toc === "string" && toc) {
+      lines.push("Files and top-level topics available in this source:", toc);
+    }
+  }
+  return lines.join("\n");
+}
+
+// ── Installed-AgentApps surfacing (Settings drawer) ──────────────
+//
+// Manifest-only (the app-catalog fetch was stripped from this template — no
+// hardcoded apps.lloyal.ai URL in a scaffold, and the austere views have no
+// Settings drawer). One descriptor per registry-ENABLED app, built from the
+// app's OWN manifest. Display-only; forwarded to the renderer via `apps:state`.
+// The catalog-metadata join (title/iconUrl/entitlements) reasoning.run does is
+// intentionally absent here.
+
+/** Build view-ready descriptors for every registry-enabled app, from each app's
+ *  own manifest. Display-only — never throws on a missing field. */
+function* buildAppDescriptors(
+  registry: AppRegistry,
+  configStore: AppConfigStore,
+): Operation<AppDescriptor[]> {
+  const descriptors: AppDescriptor[] = [];
+  for (const app of registry.enabled()) {
+    const manifest = app.manifest;
+    const config = (yield* configStore.get(manifest.name)) ?? {};
+    descriptors.push({
+      name: manifest.name,
+      title: manifest.hints?.shortName ?? manifest.protocol.name,
+      description: manifest.hints?.description ?? manifest.protocol.useWhen,
+      iconUrl: undefined,
+      tools: [...manifest.protocol.tools],
+      entitlements: [],
+      configSchema: manifest.configSchema,
+      config,
+      enabled: true,
+    });
+  }
+  return descriptors;
+}
+
+// ── Clarify helpers ──────────────────────────────────────────────
+
+/** Render the planner's clarify questions as an assistant-style markdown message,
+ *  committed to `session.trunk` paired with the user's input so subsequent planner
+ *  forks attend over prior clarify rounds via KV inheritance. */
+function formatClarifyAsAssistantMsg(questions: readonly string[]): string {
+  return [
+    "I need to clarify a few things before researching:",
+    "",
+    ...questions.map((q, i) => `${i + 1}. ${q}`),
+  ].join("\n");
+}
+
+// ── Error helpers ────────────────────────────────────────────────
+
+const errorMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
+/**
+ * A oneShot precondition/abort the harness can't proceed past (missing --query,
+ * no source configured, a clarify it can't answer in non-TTY mode). Thrown rather
+ * than `process.exit`ed so `harness` stays a pure `Operation<void>` — killing the
+ * process is the runner's job. The boot catches it, writes `message`, and exits
+ * `exitCode`; the Effection scope unwinds cleanly (teardowns run).
+ */
+class HarnessExit extends Error {
+  constructor(
+    message: string,
+    readonly exitCode: number,
+  ) {
+    super(message);
+    this.name = "HarnessExit";
+  }
+}
+
+// ── harness — the Layer-3 entrypoint (platform contract) ─────────
+//
+// Runs INSIDE a runtime substrate the boot established (RerankerCtx via the
+// boot's `provisionAppModels`, the agent contexts `initAgents` sets). It reads `RunnerCtx`
+// for the edge-shell concerns it can't own. `events` is the UI `WorkflowEvent`
+// bus; `agentEvents` (from `initAgents`) is the internal agent channel the
+// forwarder relays into `events` + `RunDirSink`. Ends on Session close.
+
+export function* harness(
+  ctx: SessionContext,
+  events: EventBus<WorkflowEvent>,
+  commands: Signal<Command, void>,
+): Operation<void> {
+  const runner = yield* RunnerCtx.expect();
+  const oneShot = runner.mode === "oneshot";
+
+  // ── Session + event forwarding ─────────────────────────────
+  const runDirSink = new RunDirSink();
+
+  const { session, events: agentEvents } = yield* initAgents<WorkflowEvent>(ctx, {
+    traceWriter: runner.traceWriter,
+  });
+
+  // Replay mode: rebuild the spine from the captured checkpoint and install it as
+  // the session trunk BEFORE the apps register their listeners.
+  if (runner.replayCheckpoint) {
+    const replaySpine = yield* reconstructBranch(runner.replayCheckpoint);
+    session.trunk = replaySpine;
+  }
+
+  // Spawned children of this iteration's scope auto-halt on return.
+  yield* spawn(function* () {
+    for (const ev of yield* each(agentEvents)) {
+      runDirSink.handle(ev as WorkflowEvent);
+      events.send(ev as WorkflowEvent);
+      yield* each.next();
+    }
+  });
+
+  // ── App registry ───────────────────────────────────────────
+  // The reranker is already published on RerankerCtx by the boot's
+  // `provisionAppModels` (before this harness runs), so the corpus/web factories
+  // read it on enable. The registry owns each app's detached scope and tears them
+  // down on scope exit. It also sets AppRegistryCtx, which the research pool reads
+  // to render the spine and resolve per-spawn tool scope.
+  yield* WindDown.set(runner.windDown);
+  yield* CancelAgent.set(runner.cancelAgent);
+  const configStore = createInMemoryConfigStore();
+  // Seed the config store generically from the per-app config map — no app-name
+  // knowledge. Each app's factory reads its own entry on enable.
+  for (const [name, cfg] of Object.entries(runner.config().apps)) {
+    yield* configStore.set(name, cfg);
+  }
+  const registry = yield* createAppRegistry({ configStore });
+
+  // Per-boot preflight-coverage memo, spanning every command-loop iteration.
+  yield* CoverageCacheCtx.set(yield* createCoverageCache());
+
+  // The project's prompt-override dir, cwd-relative. Set ONLY when it exists — an
+  // absent `prompts/` keeps the RACE/DRB-tuned baked defaults with no prompt-file
+  // I/O (see resolvePrompt). Override a prompt by dropping `prompts/<name>.eta`.
+  const promptsDir = path.join(process.cwd(), "prompts");
+  if (fs.existsSync(promptsDir)) yield* PromptsCtx.set(promptsDir);
+
+  // Enable the corpus app first so installed()[0] is corpus when present. It only
+  // enables when the user has stored config for it (the factory needs a
+  // corpusPath). A bad path surfaces a toast and leaves the app disabled.
+  const corpusBootCfg = runner.config().apps[CORPUS_APP];
+  if (corpusBootCfg && Object.keys(corpusBootCfg).length > 0) {
+    events.send({ type: "weights:label", label: "Indexing corpus…" });
+    try {
+      const corpusApp = yield* registry.enable(createCorpusApp);
+      const pdToc = corpusApp.source.promptData()["toc"];
+      const pd = { toc: typeof pdToc === "string" ? pdToc : undefined };
+      events.send({
+        type: "corpus:indexed",
+        corpusPath: String(corpusBootCfg.corpusPath ?? ""),
+        fileCount: pd?.toc ? pd.toc.split("\n").filter(Boolean).length : 0,
+        chunkCount: 0,
+      });
+    } catch (err) {
+      events.send({
+        type: "ui:error",
+        message: `Corpus disabled: ${errorMessage(err)}. Use /scan to fix.`,
+      });
+    }
+  }
+  // Web is always available: createWebApp falls back to a keyless provider when no
+  // tavilyKey is configured. Enable it unconditionally.
+  try {
+    yield* registry.enable(createWebApp);
+  } catch (err) {
+    events.send({
+      type: "ui:error",
+      message: `Web search disabled: ${errorMessage(err)}.`,
+    });
+  }
+
+  // Surface the installed AgentApps into the renderer. Re-call after every
+  // registry enable/disable/config change so the drawer stays in sync.
+  function* emitApps(): Operation<void> {
+    const apps = yield* buildAppDescriptors(registry, configStore);
+    yield* agentEvents.send({ type: "apps:state", apps });
+  }
+
+  // Emit once boot completes (web/corpus enabled).
+  yield* emitApps();
+
+  events.send({ type: "weights:done" });
+  events.send({ type: "ui:composer" });
+
+  const harnessOpts = {
+    maxTurns: MAX_TOOL_TURNS,
+    findingsMaxChars: runner.findingsMaxChars,
+    reasoningMode: runner.config().defaults.reasoningMode,
+    effort: runner.config().defaults.effort,
+  };
+
+  function startRunDir(query: string, mode: "flat" | "deep"): void {
+    const outputDir = runner.config().sources.outputDir ?? process.cwd();
+    runDirSink.start({ outputDir, query, mode });
+  }
+
+  // ── JSONL / --query scripted path ──────────────────────────
+  if (oneShot) {
+    if (!runner.initialQuery) {
+      throw new HarnessExit("Non-TTY mode requires --query.", 2);
+    }
+    if (registry.enabled().length === 0) {
+      throw new HarnessExit(
+        "No source configured. Enable an app in harness/harness.ts — the web app runs keyless.",
+        2,
+      );
+    }
+    const wallStartMs = performance.now();
+    const result = yield* runQuery(runner.initialQuery, session, {
+      ...harnessOpts,
+      wallStartMs,
+      onStart: () =>
+        startRunDir(runner.initialQuery!, runner.config().defaults.reasoningMode),
+    });
+    if (result.type === "clarify") {
+      throw new HarnessExit(
+        "Planner asked clarifying questions; non-TTY mode can't answer. Aborting.",
+        2,
+      );
+    }
+    if (result.type === "research_plan") {
+      startRunDir(runner.initialQuery, runner.config().defaults.reasoningMode);
+      yield* runResearchPlan(runner.initialQuery, result.plan, session, {
+        ...harnessOpts,
+        wallStartMs,
+      });
+    }
+    return;
+  }
+
+  // ── Ink TTY command loop ───────────────────────────────────
+
+  // Per-query run effort, set at submit_query and read by every research path.
+  let currentEffort: Effort = runner.config().defaults.effort;
+  let pendingPlan: {
+    plan: PlanResult;
+    query: string;
+    clarifyExchanged: boolean;
+    mode: "flat" | "deep";
+    wallStartMs: number;
+    appFilter: readonly string[];
+  } | null = null;
+
+  // ── Run-in-fiber (Stop escape hatch) ───────────────────────
+  // The heavy operations run in a CHILD fiber so the command loop keeps polling
+  // `each(commands)` while a run is in flight. `stop` halts the held Task.
+  let runTask: Task<void> | null = null;
+
+  function* startRun(
+    body: (clearIfCurrent: () => void) => Operation<void>,
+  ): Operation<void> {
+    if (runTask) yield* haltRun();
+    const task = yield* spawn(() =>
+      body(() => {
+        if (runTask === task) runTask = null;
+      }),
+    );
+    runTask = task;
+  }
+
+  function* haltRun(): Operation<void> {
+    const task = runTask;
+    runTask = null;
+    if (!task) return;
+    try {
+      yield* task.halt();
+    } catch {
+      /* teardown-only error — the run is gone regardless */
+    }
+  }
+
+  // Per-query App participation. Default: every enabled app is included.
+  const participation: Record<string, boolean> = {};
+  const seedParticipation = (): void => {
+    for (const app of registry.enabled()) {
+      if (participation[app.manifest.name] === undefined) {
+        participation[app.manifest.name] = true;
+      }
+    }
+  };
+  const currentAppFilter = (): readonly string[] =>
+    registry
+      .enabled()
+      .filter((a) => participation[a.manifest.name] !== false)
+      .map((a) => a.manifest.name);
+  seedParticipation();
+
+  // Auto-submit --query only on the first iteration.
+  if (runner.isFirstIteration && runner.initialQuery) {
+    const mode = runner.config().defaults.reasoningMode;
+    const wallStartMs = performance.now();
+    const submissionFilter = currentAppFilter();
+    const result = yield* runQuery(runner.initialQuery, session, {
+      ...harnessOpts,
+      reasoningMode: mode,
+      wallStartMs,
+      appFilter: submissionFilter,
+      onStart: () => startRunDir(runner.initialQuery!, mode),
+    });
+    if (result.type === "research_plan") {
+      pendingPlan = {
+        plan: result.plan,
+        query: runner.initialQuery,
+        clarifyExchanged: false,
+        mode,
+        wallStartMs,
+        appFilter: submissionFilter,
+      };
+      yield* agentEvents.send({ type: "ui:plan_review" });
+    } else if (result.type === "clarify") {
+      yield* call(() =>
+        session.commitTurn(
+          runner.initialQuery!,
+          formatClarifyAsAssistantMsg(result.plan.clarifyQuestions),
+        ),
+      );
+      pendingPlan = {
+        plan: result.plan,
+        query: runner.initialQuery,
+        clarifyExchanged: false,
+        mode,
+        wallStartMs,
+        appFilter: submissionFilter,
+      };
+    } else {
+      yield* agentEvents.send({ type: "ui:composer" });
+    }
+  }
+
+  for (const cmd of yield* each(commands)) {
+    try {
+      if (cmd.type === "quit") return;
+
+      if (cmd.type === "stop") {
+        if (runTask) {
+          yield* haltRun();
+          pendingPlan = null;
+          yield* agentEvents.send({ type: "ui:composer" });
+        }
+        continue;
+      }
+
+      if (cmd.type === "wrap_up") {
+        if (runTask) runner.windDown.send();
+        continue;
+      }
+
+      if (cmd.type === "cancel_agent") {
+        if (runTask) runner.cancelAgent.send({ agentId: cmd.agentId });
+        continue;
+      }
+
+      if (cmd.type === "set_model_path") {
+        runner.reloadRuntime({ model: { path: cmd.path } });
+        return;
+      }
+
+      if (cmd.type === "set_reranker_path") {
+        runner.reloadRuntime({ model: { reranker: cmd.path } });
+        return;
+      }
+
+      if (cmd.type === "set_gpu") {
+        runner.reloadRuntime({ model: { gpu: cmd.gpu } });
+        return;
+      }
+
+      if (cmd.type === "toggle_participation") {
+        const current = participation[cmd.name] ?? true;
+        participation[cmd.name] = !current;
+        yield* agentEvents.send({
+          type: "participation:toggled",
+          name: cmd.name,
+        });
+        continue;
+      }
+
+      if (cmd.type === "set_app_config") {
+        const resolvedValues = resolveConfigPaths(cmd.values);
+        const isClear = Object.keys(resolvedValues).length === 0;
+
+        yield* configStore.set(cmd.name, resolvedValues);
+
+        const factory = factoryFor(cmd.name);
+        if (factory) {
+          if (registry.byName(cmd.name)) yield* registry.disable(cmd.name);
+          const needsConfig = appRequiresConfig(cmd.name);
+          if (!isClear || !needsConfig) {
+            try {
+              const app = yield* registry.enable(factory);
+              const pd = (
+                app.source as { promptData?: () => { toc?: string } }
+              ).promptData?.();
+              if (pd?.toc !== undefined) {
+                events.send({
+                  type: "corpus:indexed",
+                  corpusPath: String(resolvedValues.corpusPath ?? ""),
+                  fileCount: pd.toc
+                    ? pd.toc.split("\n").filter(Boolean).length
+                    : 0,
+                  chunkCount: 0,
+                });
+              }
+            } catch (err) {
+              yield* configStore.clear(cmd.name);
+              yield* agentEvents.send({
+                type: "ui:error",
+                message: `Cannot configure ${cmd.name}: ${errorMessage(err)}`,
+              });
+              continue;
+            }
+          } else {
+            yield* configStore.clear(cmd.name);
+          }
+        }
+
+        participation[cmd.name] = true;
+
+        const saved = runner.saveConfig({
+          apps: { [cmd.name]: resolvedValues },
+        });
+        yield* agentEvents.send({
+          type: "config:updated",
+          config: saved.config,
+          origin: saved.origin,
+          savedTo: saved.path,
+          gitignored: saved.gitignored,
+          skipped: saved.skipped,
+        });
+        yield* emitApps();
+      } else if (cmd.type === "set_output_dir") {
+        const resolved = cmd.path ? resolvePath(cmd.path) : "";
+        const saved = runner.saveConfig({
+          sources: { outputDir: resolved },
+        });
+        yield* agentEvents.send({
+          type: "config:updated",
+          config: saved.config,
+          origin: saved.origin,
+          savedTo: saved.path,
+          gitignored: saved.gitignored,
+          skipped: saved.skipped,
+        });
+      } else if (cmd.type === "set_effort") {
+        const saved = runner.saveConfig({
+          defaults: { ...runner.config().defaults, effort: cmd.effort },
+        });
+        yield* agentEvents.send({
+          type: "config:updated",
+          config: saved.config,
+          origin: saved.origin,
+          savedTo: saved.path,
+          gitignored: saved.gitignored,
+          skipped: saved.skipped,
+        });
+      } else if (cmd.type === "submit_query") {
+        if (registry.enabled().length === 0) {
+          yield* agentEvents.send({
+            type: "ui:error",
+            message: "No source configured. Add Tavily key or corpus path.",
+          });
+          continue;
+        }
+        if (currentAppFilter().length === 0) {
+          yield* agentEvents.send({
+            type: "ui:error",
+            message:
+              "All sources excluded. Tab to a chip and press Space to include at least one.",
+          });
+          continue;
+        }
+        const wallStartMs = performance.now();
+        currentEffort = runner.config().defaults.effort;
+        if (runTask) {
+          yield* haltRun();
+          pendingPlan = null;
+        }
+        if (cmd.skipPlanner) {
+          const plan = singleTaskPlan(cmd.query);
+          yield* agentEvents.send({
+            type: "plan:start",
+            query: cmd.query,
+            mode: cmd.mode,
+          });
+          yield* agentEvents.send({
+            type: "query",
+            query: cmd.query,
+            warm: !!session.trunk,
+          });
+          yield* agentEvents.send({
+            type: "plan",
+            intent: plan.intent,
+            tasks: plan.tasks,
+            clarifyQuestions: plan.clarifyQuestions,
+            tokenCount: plan.tokenCount,
+            timeMs: plan.timeMs,
+          });
+          const submissionFilter = currentAppFilter();
+          startRunDir(cmd.query, cmd.mode);
+          yield* startRun(function* (clearIfCurrent) {
+            try {
+              yield* runResearchPlan(cmd.query, plan, session, {
+                ...harnessOpts,
+                reasoningMode: cmd.mode,
+                effort: currentEffort,
+                wallStartMs,
+                appFilter: submissionFilter,
+                isAsk: cmd.skipPlanner,
+              });
+              yield* agentEvents.send({ type: "ui:composer" });
+            } catch (err) {
+              yield* agentEvents.send({
+                type: "ui:error",
+                message: errorMessage(err),
+              });
+            } finally {
+              clearIfCurrent();
+            }
+          });
+          continue;
+        }
+        const submissionFilter = currentAppFilter();
+        const queryText = cmd.query;
+        const queryMode = cmd.mode;
+        yield* startRun(function* (clearIfCurrent) {
+          try {
+            const result = yield* runQuery(queryText, session, {
+              ...harnessOpts,
+              reasoningMode: queryMode,
+              effort: currentEffort,
+              context: buildPlannerContext(registry.enabled()),
+              wallStartMs,
+              appFilter: submissionFilter,
+              onStart: () => startRunDir(queryText, queryMode),
+            });
+            if (result.type === "research_plan") {
+              pendingPlan = {
+                plan: result.plan,
+                query: queryText,
+                clarifyExchanged: false,
+                mode: queryMode,
+                wallStartMs,
+                appFilter: submissionFilter,
+              };
+              yield* agentEvents.send({ type: "ui:plan_review" });
+            } else if (result.type === "clarify") {
+              yield* call(() =>
+                session.commitTurn(
+                  queryText,
+                  formatClarifyAsAssistantMsg(result.plan.clarifyQuestions),
+                ),
+              );
+              pendingPlan = {
+                plan: result.plan,
+                query: queryText,
+                clarifyExchanged: false,
+                mode: queryMode,
+                wallStartMs,
+                appFilter: submissionFilter,
+              };
+            } else {
+              yield* agentEvents.send({ type: "ui:composer" });
+            }
+          } catch (err) {
+            pendingPlan = null;
+            yield* agentEvents.send({
+              type: "ui:error",
+              message: errorMessage(err),
+            });
+          } finally {
+            clearIfCurrent();
+          }
+        });
+      } else if (cmd.type === "submit_clarification" && pendingPlan) {
+        const { query: origQuery, mode, wallStartMs, appFilter } = pendingPlan;
+        const priorPlan = pendingPlan;
+        yield* call(() => session.prefillUser(cmd.answer));
+        yield* startRun(function* (clearIfCurrent) {
+          try {
+            const result = yield* runQuery(origQuery, session, {
+              ...harnessOpts,
+              reasoningMode: mode,
+              effort: currentEffort,
+              context: buildPlannerContext(registry.enabled()),
+              wallStartMs,
+              appFilter,
+              onStart: () => startRunDir(origQuery, mode),
+            });
+            if (result.type === "research_plan") {
+              pendingPlan = {
+                ...priorPlan,
+                plan: result.plan,
+                clarifyExchanged: true,
+              };
+              yield* agentEvents.send({ type: "ui:plan_review" });
+            } else if (result.type === "clarify") {
+              yield* call(() =>
+                session.prefillAssistant(
+                  formatClarifyAsAssistantMsg(result.plan.clarifyQuestions),
+                ),
+              );
+              pendingPlan = {
+                ...priorPlan,
+                plan: result.plan,
+                clarifyExchanged: true,
+              };
+            } else {
+              pendingPlan = null;
+              yield* agentEvents.send({ type: "ui:composer" });
+            }
+          } catch (err) {
+            pendingPlan = null;
+            yield* agentEvents.send({
+              type: "ui:error",
+              message: errorMessage(err),
+            });
+          } finally {
+            clearIfCurrent();
+          }
+        });
+      } else if (cmd.type === "change_mode" && pendingPlan) {
+        const priorPlan = pendingPlan;
+        const nextMode = cmd.mode;
+        yield* startRun(function* (clearIfCurrent) {
+          try {
+            const result = yield* runQuery(priorPlan.query, session, {
+              ...harnessOpts,
+              reasoningMode: nextMode,
+              effort: currentEffort,
+              context: buildPlannerContext(registry.enabled()),
+              wallStartMs: priorPlan.wallStartMs,
+              appFilter: priorPlan.appFilter,
+              onStart: () => startRunDir(priorPlan.query, nextMode),
+            });
+            if (result.type === "research_plan") {
+              pendingPlan = { ...priorPlan, plan: result.plan, mode: nextMode };
+              yield* agentEvents.send({ type: "ui:plan_review" });
+            } else if (result.type === "clarify") {
+              pendingPlan = { ...priorPlan, plan: result.plan, mode: nextMode };
+            } else {
+              pendingPlan = null;
+              yield* agentEvents.send({ type: "ui:composer" });
+            }
+          } catch (err) {
+            pendingPlan = null;
+            yield* agentEvents.send({
+              type: "ui:error",
+              message: errorMessage(err),
+            });
+          } finally {
+            clearIfCurrent();
+          }
+        });
+      } else if (cmd.type === "accept_plan" && pendingPlan) {
+        if (pendingPlan.plan.intent === "clarify") {
+          pendingPlan = null;
+          yield* agentEvents.send({ type: "ui:composer" });
+          continue;
+        }
+        if (registry.enabled().length === 0) {
+          yield* agentEvents.send({
+            type: "ui:error",
+            message: "No source configured. Add Tavily key or corpus path.",
+          });
+          pendingPlan = null;
+          continue;
+        }
+        startRunDir(pendingPlan.query, pendingPlan.mode);
+        const acceptedPlan = pendingPlan;
+        pendingPlan = null;
+        yield* startRun(function* (clearIfCurrent) {
+          try {
+            yield* runResearchPlan(
+              acceptedPlan.query,
+              acceptedPlan.plan,
+              session,
+              {
+                ...harnessOpts,
+                reasoningMode: acceptedPlan.mode,
+                effort: currentEffort,
+                wallStartMs: acceptedPlan.wallStartMs,
+                appFilter: acceptedPlan.appFilter,
+                userSidePending: acceptedPlan.clarifyExchanged,
+              },
+            );
+            yield* agentEvents.send({ type: "ui:composer" });
+          } catch (err) {
+            yield* agentEvents.send({
+              type: "ui:error",
+              message: errorMessage(err),
+            });
+          } finally {
+            clearIfCurrent();
+          }
+        });
+      } else if (cmd.type === "cancel_plan") {
+        pendingPlan = null;
+        yield* agentEvents.send({ type: "ui:composer" });
+      } else if (cmd.type === "edit_plan") {
+        pendingPlan = null;
+        yield* agentEvents.send({ type: "ui:composer", prefill: cmd.query });
+      } else if (cmd.type === "update_task_description" && pendingPlan) {
+        pendingPlan.plan.tasks = pendingPlan.plan.tasks.map((t, i) =>
+          i === cmd.index ? { ...t, description: cmd.description } : t,
+        );
+        yield* agentEvents.send({
+          type: "plan:task_updated",
+          index: cmd.index,
+          description: cmd.description,
+        });
+      } else if (cmd.type === "add_task" && pendingPlan) {
+        const insertAt = Math.max(
+          0,
+          Math.min(pendingPlan.plan.tasks.length, cmd.afterIndex + 1),
+        );
+        pendingPlan.plan.tasks = [
+          ...pendingPlan.plan.tasks.slice(0, insertAt),
+          { description: "" },
+          ...pendingPlan.plan.tasks.slice(insertAt),
+        ];
+        yield* agentEvents.send({
+          type: "plan:task_added",
+          afterIndex: cmd.afterIndex,
+        });
+      } else if (cmd.type === "delete_task" && pendingPlan) {
+        if (pendingPlan.plan.tasks.length > 1) {
+          pendingPlan.plan.tasks = pendingPlan.plan.tasks.filter(
+            (_, i) => i !== cmd.index,
+          );
+          yield* agentEvents.send({
+            type: "plan:task_deleted",
+            index: cmd.index,
+          });
+        }
+      } else if (cmd.type === "move_task" && pendingPlan) {
+        const n = pendingPlan.plan.tasks.length;
+        if (
+          cmd.from !== cmd.to &&
+          cmd.from >= 0 &&
+          cmd.from < n &&
+          cmd.to >= 0 &&
+          cmd.to < n
+        ) {
+          const tasks = [...pendingPlan.plan.tasks];
+          const [moved] = tasks.splice(cmd.from, 1);
+          tasks.splice(cmd.to, 0, moved);
+          pendingPlan.plan.tasks = tasks;
+          yield* agentEvents.send({
+            type: "plan:task_moved",
+            from: cmd.from,
+            to: cmd.to,
+          });
+        }
+      }
+    } catch (err) {
+      pendingPlan = null;
+      yield* agentEvents.send({ type: "ui:error", message: errorMessage(err) });
+    } finally {
+      yield* each.next();
+    }
+  }
+  return;
+}

--- a/packages/harness-cli/templates/research/harness/harness.ts
+++ b/packages/harness-cli/templates/research/harness/harness.ts
@@ -6,8 +6,10 @@
  * surface is mounted; `commands` delivers that surface's `Command`s back. This
  * harness runs the RACE/DRB-tuned pipeline — pre-flight recon → planner →
  * parallel/chain research pool → synthesis — over the substrate a target's boot
- * established. It reads `RunnerCtx` (see ./runner.ts) for the edge-shell concerns
- * it can't own: the reranker, the wind-down / cancel signals, the live config.
+ * established. It reads `RunnerCtx` (see ./runner-ctx.ts) for the edge-shell
+ * concerns it can't own: the wind-down / cancel signals, the live config, the
+ * trace sink. (The reranker is NOT a Runner concern — the boot's
+ * `provisionAppModels` publishes it on `RerankerCtx`.)
  *
  * The pipeline itself (`runQuery` / `runResearchPlan` / policies / the 7 tuned
  * `.eta` prompts) lives in ./pipeline.ts — this file is the command loop + app

--- a/packages/harness-cli/templates/research/harness/path-utils.ts
+++ b/packages/harness-cli/templates/research/harness/path-utils.ts
@@ -1,0 +1,35 @@
+/**
+ * Resolve a user-typed path to an absolute path.
+ *
+ * Three input forms a user might enter (composer field, CLI flag, or
+ * harness.json) handled here:
+ *   - "~" or "~/foo"             → expanded against os.homedir()
+ *   - "/absolute/path"           → unchanged
+ *   - "./relative" or "relative" → resolved against process.cwd()
+ *
+ * Empty input returns ''. Idempotent — calling on an already-absolute
+ * path leaves it absolute. This mirrors what bash/zsh do before passing
+ * args to a program; Node's `path` module deliberately doesn't replicate
+ * shell ergonomics, so the application layer handles it at the boundary.
+ *
+ * Apply at the boundary between user input and persisted/live state:
+ *   - composer commit handlers (set_output_dir, set_app_config path values)
+ *   - loadConfig (defensive — handles stale `~`-bearing harness.json)
+ *
+ * Persisted form should always be absolute; downstream consumers can
+ * treat paths as opaque strings without re-expansion.
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+export function resolvePath(input: string): string {
+  if (!input) return '';
+  const expanded =
+    input === '~'
+      ? os.homedir()
+      : input.startsWith('~/')
+        ? path.join(os.homedir(), input.slice(2))
+        : input;
+  return path.resolve(expanded);
+}

--- a/packages/harness-cli/templates/research/harness/pipeline.ts
+++ b/packages/harness-cli/templates/research/harness/pipeline.ts
@@ -1,0 +1,1254 @@
+/**
+ * Harness — pipeline that turns a user query into an answer.
+ *
+ * Two public Operations:
+ *
+ *   runQuery(query, ...)          — runs the planner, dispatches on intent.
+ *                                    Handles passthrough internally; returns
+ *                                    a research plan for callers to route
+ *                                    (plan-review dialog or direct execution).
+ *
+ *   runResearchPlan(query, plan,..) — runs research → maybe-synth → finalize
+ *                                    for an already-vetted plan. Used by the
+ *                                    accept_plan path (after plan-review) and
+ *                                    by the START path (synthetic 1-task plan
+ *                                    bypassing the planner).
+ *
+ * Two structural gates encode invariants, not user-mode flags:
+ *
+ *   1. session.trunk gates the passthrough fast-path. Without a warm trunk
+ *      there's nothing to fork from; the pipeline falls through to research
+ *      transparently. This is what makes first-query START work without any
+ *      special-case — START produces a research plan, falls into Stage 4.
+ *
+ *   2. plan.tasks.length > 1 gates synth. Synth aggregates findings across
+ *      multiple agents into one argument. With a single agent there's
+ *      nothing to aggregate — that agent's report IS the answer. The synth
+ *      prompts also assume multi-agent framing ("findings from N parallel
+ *      research agents"), so running synth on a single source produces
+ *      awkward output.
+ */
+
+import { call, resource, createContext } from "effection";
+import type { Operation } from "effection";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { EFFORT_PRESETS, type Effort } from "./effort-presets.js";
+import type { Session, SessionContext } from "@lloyal-labs/sdk";
+import {
+  Ctx,
+  Events,
+  AppRegistryCtx,
+  agentPool,
+  useAgent,
+  chain,
+  parallel,
+  renderTemplate,
+  withSpine,
+  DefaultAgentPolicy,
+  ContextPressure,
+} from "@lloyal-labs/lloyal-agents";
+import type { AgentEvent, App, AgentRenderCtx, Agent, DefaultAgentPolicyOpts } from "@lloyal-labs/lloyal-agents";
+import type { StepEvent } from "./protocol.js";
+import type { OpTiming } from "./state.js";
+import {
+  reportTool,
+  ReportTool,
+  PlanTool,
+  renderSpine,
+  renderAgentPreamble,
+} from "@lloyal-labs/rig";
+import type { PlanResult, ResearchTask } from "@lloyal-labs/rig";
+import { taskToContent } from "@lloyal-labs/rig";
+import { weaveSourcesIntoResult } from "./weave-sources.js";
+
+// ── Prompts ─────────────────────────────────────────────────────
+//
+// The .eta sources are inlined into the bundle as string constants by
+// esbuild's `--loader:.eta=text` AT BUILD TIME, so the running bundle
+// reads no prompt files. Every placement bundles this harness — the CLI
+// (dist/bundle.mjs), a host that forks that bin, an in-process
+// model-runtime host — so it is always esbuilt, never executed as raw
+// TS: `eta.d.ts` is a TYPE-only shim (it satisfies tsc but provides no
+// runtime loader). The sources themselves DO ship (src/prompts/*.eta,
+// via the `files` whitelist that also carries the ./protocol/./state
+// source exports) — they're just carried inlined, not read from disk.
+
+import PREFLIGHT_RAW from "../prompts/preflight.eta";
+import PREFLIGHT_RECOVER_RAW from "../prompts/preflight-recover.eta";
+import PLAN_RAW from "../prompts/plan.eta";
+import PLAN_FLAT_RAW from "../prompts/plan-flat.eta";
+import RECOVERY_RAW from "../prompts/recovery.eta";
+import SYNTHESIZE_RAW from "../prompts/synthesize.eta";
+import SYNTHESIZE_FLAT_RAW from "../prompts/synthesize-flat.eta";
+
+function parsePrompt(raw: string): { system: string; user: string } {
+  const trimmed = raw.trim();
+  const sep = trimmed.indexOf("\n---\n");
+  if (sep === -1) return { system: trimmed, user: "" };
+  return {
+    system: trimmed.slice(0, sep).trim(),
+    user: trimmed.slice(sep + 5).trim(),
+  };
+}
+
+/**
+ * The 7 baked prompts, keyed by override name. A project overrides any one by
+ * dropping `prompts/<name>.eta` into its tree (see {@link PromptsCtx} +
+ * {@link resolvePrompt}); an absent override dir uses these RACE/DRB-tuned
+ * defaults with ZERO disk I/O — trace-parity: an empty `prompts/` ≡ today.
+ */
+const BAKED = {
+  preflight: PREFLIGHT_RAW,
+  "preflight-recover": PREFLIGHT_RECOVER_RAW,
+  plan: PLAN_RAW,
+  "plan-flat": PLAN_FLAT_RAW,
+  recovery: RECOVERY_RAW,
+  synthesize: SYNTHESIZE_RAW,
+  "synthesize-flat": SYNTHESIZE_FLAT_RAW,
+} as const satisfies Record<string, string>;
+
+export type PromptName = keyof typeof BAKED;
+
+type Prompt = { system: string; user: string };
+
+/**
+ * The project's prompt-override directory, or null (baked defaults only). Set
+ * once per boot by the runner (`runMain`/`runServedSession`) to the project's
+ * `prompts/` dir — but ONLY when it exists, so the default (no dir) is truly
+ * zero-I/O. Mirrors {@link CoverageCacheCtx}. Default null → `.get()` returns
+ * null when unset → the baked path.
+ */
+export const PromptsCtx = createContext<string | null>("reasoning.promptsDir", null);
+
+const promptMemo = new Map<string, Prompt>();
+
+/**
+ * Resolve a prompt by name: `<promptsDir>/<name>.eta` if present, else the baked
+ * default. Memoized per `(dir,name)` — a present override reads disk at most
+ * once; the baked path never touches disk. `PromptsCtx` unset (the default) ⇒
+ * baked, no I/O.
+ */
+export function* resolvePrompt(name: PromptName): Operation<Prompt> {
+  const dir = (yield* PromptsCtx.get()) ?? null;
+  const key = `${dir ?? ""}\u0000${name}`;
+  const hit = promptMemo.get(key);
+  if (hit) return hit;
+  let raw: string = BAKED[name];
+  if (dir) {
+    const file = join(dir, `${name}.eta`);
+    if (existsSync(file)) raw = readFileSync(file, "utf8");
+  }
+  const parsed = parsePrompt(raw);
+  promptMemo.set(key, parsed);
+  return parsed;
+}
+
+// Run-effort type + presets live in `./effort-presets` (shared, dep-free) so the
+// Settings UI can display the same policy values the harness applies here.
+export type { Effort } from "./effort-presets.js";
+
+/**
+ * The research pool's terminal `report` tool, extended with a grammar-forced
+ * structured `sources: [{title, url}]` field via rig's `ReportTool` schema seam
+ * (`extraProperties`/`extraRequired`). The pool captures only the `result` string;
+ * {@link SourceWeavingPolicy} reads the sibling `sources` off the same call and
+ * weaves them inline at capture (see {@link weaveSourcesIntoResult}). Recon keeps
+ * rig's plain `reportTool` — its coverage output isn't cited.
+ */
+const citedReportTool = new ReportTool({
+  description:
+    "Submit your final research findings with specific evidence, direct quotes, and data points. Cite each claim inline as [title](url) using the exact URL seen in tool results. Fill the sources field with the structured list of every source you used. State what you found AND what you checked but could not find. Do not summarize — preserve detail.",
+  resultDescription:
+    "Detailed findings with direct quotes and data points. Cite each claim inline as [title](url) using the exact URL seen in tool results. Include what was found and what was not found.",
+  extraProperties: {
+    sources: {
+      type: "array",
+      description:
+        "Every source you used: exact title and exact URL as seen in tool results. Empty array only if no URL sources exist.",
+      items: {
+        type: "object",
+        properties: { title: { type: "string" }, url: { type: "string" } },
+        required: ["title", "url"],
+      },
+    },
+  },
+  extraRequired: ["sources"],
+});
+
+/**
+ * Research policy for a run effort + reasoning mode. `high` reproduces the
+ * historical budget exactly. Parallel recovery is a flat-mode + low-effort
+ * concern (a small cohort folded fast); everything else staggers — and the
+ * WindDown drain forces the fold regardless of this default.
+ */
+function createResearchPolicy(
+  effort: Effort,
+  mode: "flat" | "deep",
+  isAsk = false,
+  recoveryPrompt: Prompt,
+): DefaultAgentPolicy {
+  const preset = EFFORT_PRESETS[effort];
+  const opts: DefaultAgentPolicyOpts = {
+    budget: preset.budget,
+    // Ask also salvages an involuntarily-dropped agent (pressure/time before it answers)
+    // instead of skipping it below the 2-tool/100-token floor — its work shouldn't be lost.
+    recovery: isAsk
+      ? { prompt: recoveryPrompt, minToolCalls: 0, minTokens: 0 }
+      : { prompt: recoveryPrompt },
+    terminalToolName: "report",
+    // low AND medium bin-pack recovery in-loop (parallel); high stays staggered
+    // (serial, full-headroom, lossless). Deep is always staggered.
+    recoveryShape:
+      mode === "flat" && effort !== "high" ? "parallel" : "staggered",
+    reportBudget: preset.reportBudget,
+    // Per-effort explore→exploit threshold: low always exploits (strict, on-topic);
+    // medium tightens at 40% KV used; high explores novel facts until 60% used.
+    shouldExplore: preset.shouldExplore,
+  };
+  // Ask (skipPlanner): accept a direct free-text answer from context — 0 tool calls OK.
+  // Non-Ask multi-agent research keeps the tool-gathering guard (a lazy research agent
+  // that answers without evidence is still pushed to research/recovery). Both branches
+  // extend SourceWeavingPolicy so a voluntary report() return is inline-cited at capture.
+  return isAsk ? new DirectAnswerPolicy(opts) : new SourceWeavingPolicy(opts);
+}
+
+/**
+ * Structured-sources citation weave (DRB FACT fix). The `report()` terminal tool
+ * carries a grammar-forced `sources: [{title, url}]` field (see
+ * {@link citedReportTool}); on a voluntary terminal return this override weaves
+ * those sources into the result string — bare source URLs become `[title](url)`
+ * plus an appended `Sources:` block (see {@link weaveSourcesIntoResult}) — BEFORE
+ * the string becomes `agent.result`. That single seam covers both downstream
+ * consumers of a voluntary return: the synthesis findings assembly and the
+ * annexure writer (both read `agent.result` / the `agent:return` event's `result`).
+ *
+ * `onProduced` is the base policy's PUBLIC entry point; the actual capture lives
+ * in its `private _handleTerminalTool`. Rather than reach into a private method,
+ * we post-process its result: `super.onProduced` returns `{type:'return', result}`
+ * with `result` = the plain `result` arg; we re-parse the same tool call for its
+ * sibling `sources` and weave. Non-return actions (nudge/idle/tool_call) and
+ * non-terminal or unparseable calls pass through untouched — matching the base's
+ * own JSON-parse fallback (raw arguments, no weave).
+ *
+ * KNOWN GAP: the RECOVERY capture path (an agent killed by pressure/time and
+ * force-recovered) sets `agent.result` inside `@lloyal-labs/lloyal-agents`'
+ * recovery path, which exposes no policy hook — so recovered agents' findings are
+ * NOT woven from here (the grammar still forces `sources`; they're just dropped at
+ * capture). Voluntary returns (the dominant path) are fully covered.
+ */
+class SourceWeavingPolicy extends DefaultAgentPolicy {
+  override onProduced(
+    ...args: Parameters<DefaultAgentPolicy["onProduced"]>
+  ): ReturnType<DefaultAgentPolicy["onProduced"]> {
+    const action = super.onProduced(...args);
+    if (action.type !== "return") return action;
+    const [, parsed, , config] = args;
+    const tc = parsed.toolCalls[0];
+    if (!tc || tc.name !== config.terminalToolName) return action;
+    let sources: unknown;
+    try {
+      sources = (JSON.parse(tc.arguments) as { sources?: unknown }).sources;
+    } catch {
+      // Base fell back to raw arguments (unparseable) — nothing to weave.
+      return action;
+    }
+    return { ...action, result: weaveSourcesIntoResult(action.result, sources) };
+  }
+}
+
+/**
+ * Direct-answer policy — the agent's free text IS the answer, accepted even with ZERO
+ * tool calls. `DefaultAgentPolicy._handleNoToolCall` gates accepting free text as the
+ * result behind `agent.toolCallCount > 0` — a guard against research agents skipping
+ * evidence-gathering; this bypasses it (the streamed content becomes `agent.result` via
+ * the `free_text_return` action → a voluntary `agent:return`, no drop/recovery).
+ *
+ * Used by **synth** (no tools — the prompt + parent KV ARE the evidence) and by **Ask**
+ * (a single research agent answering directly from the prior report's context, via
+ * `createResearchPolicy(..., isAsk=true)`). Ask can still choose to gather evidence
+ * (tool calls) — this only ensures a direct answer isn't discarded.
+ */
+class DirectAnswerPolicy extends SourceWeavingPolicy {
+  override onProduced(
+    ...args: Parameters<DefaultAgentPolicy["onProduced"]>
+  ): ReturnType<DefaultAgentPolicy["onProduced"]> {
+    const [, parsed] = args;
+    if (!parsed.toolCalls[0] && parsed.content) {
+      return { type: "free_text_return", content: parsed.content };
+    }
+    // Report-tool returns flow through SourceWeavingPolicy's weave; synth (no
+    // terminal tool) and Ask free-text answers are unaffected (no-op weave).
+    return super.onProduced(...args);
+  }
+}
+
+/**
+ * Recon turn budget. A pre-flight probe is shallow — ~2 searches per source
+ * then a report. Enforced HARD via {@link ReconPolicy.shouldExit}: the base
+ * policy only soft-nudges on turns ("report now"), which an over-eager recon
+ * agent ignores, looping to the time hard limit (the recon nudge-loop trace).
+ * Sized at 4 so a time-nudged agent gets one more turn to comply with the
+ * report nudge voluntarily before being force-recovered.
+ */
+const RECON_MAX_TURNS = 4;
+
+/**
+ * Recon policy — research policy with a hard turn cap. Past RECON_MAX_TURNS the
+ * pool kills the agent and `recoverInline` extracts its coverage via the recon
+ * recovery prompt, so a probe always terminates with a coverage line instead of
+ * nudge-looping. A voluntary `report` before the cap still produces a clean
+ * result. `shouldExit` is checked before each turn produces, so this preempts
+ * the base policy's soft turn-limit nudge entirely.
+ */
+class ReconPolicy extends DefaultAgentPolicy {
+  override shouldExit(agent: Agent, pressure: ContextPressure): boolean {
+    if (agent.turns >= RECON_MAX_TURNS) return true;
+    return super.shouldExit(agent, pressure);
+  }
+}
+
+function createReconPolicy(recoverPrompt: Prompt): ReconPolicy {
+  return new ReconPolicy({
+    budget: {
+      context: { softLimit: 2048, hardLimit: 1024 },
+      // Sized for the slowest probe path observed in traces: one corpus
+      // `search` reranks the full chunk index and takes ~30-40s, so 60s
+      // soft / 90s hard was too tight and time-nudged after the first
+      // search. 120s soft / 180s hard gives room for ~2 searches before
+      // nudges + the report turn.
+      time: { softLimit: 120_000, hardLimit: 180_000 },
+    },
+    // Recovery extracts coverage from a force-killed probe. Default
+    // `minToolCalls: 2` skips recovery on agents that only got ONE search
+    // dispatched (the rest got nudged away) — which produced empty coverage
+    // for the slow corpus probe. One probe is enough signal for recon.
+    recovery: { prompt: recoverPrompt, minToolCalls: 1 },
+    terminalToolName: "report",
+  });
+}
+
+// ── Public types ────────────────────────────────────────────────
+
+export type QueryResult =
+  | { type: "done" }
+  | { type: "clarify"; plan: PlanResult }
+  | { type: "research_plan"; plan: PlanResult };
+
+export interface HarnessOpts {
+  maxTurns: number;
+  findingsMaxChars?: number;
+  reasoningMode: "flat" | "deep";
+  /** Run effort preset — pure policy (budget + planner breadth + recovery cap),
+   *  no prompt effect. @see EFFORT_PRESETS. */
+  effort: Effort;
+}
+
+export interface RunQueryOpts extends HarnessOpts {
+  /** Extra context appended to the planner prompt — used to thread
+   *  clarification Q&A back in for re-planning. */
+  context?: string;
+  /** performance.now() at the user's submit. Used as the `wallTimeMs`
+   *  baseline in the `complete` event. */
+  wallStartMs: number;
+  /** Fires after the clarify gate but before passthrough/research starts.
+   *  Used by main.ts to start the run-dir for artifact writes. */
+  onStart?: () => void;
+  /** Per-query app subset, by `manifest.name`. When set, the recon,
+   *  planner, and research stages all operate on `registry.enabled()`
+   *  filtered to this list. When omitted, the full enabled set is used
+   *  (preserves prior behavior). The Composer derives this from
+   *  `state.participation` at submit time. */
+  appFilter?: readonly string[];
+}
+
+export interface RunResearchPlanOpts extends HarnessOpts {
+  wallStartMs: number;
+  /** Per-query app subset, by `manifest.name`. Mirrors `RunQueryOpts.appFilter`
+   *  for the accept_plan path (where the planner already ran with the filter
+   *  and the research pool needs the same subset). When omitted, the full
+   *  enabled set is used. */
+  appFilter?: readonly string[];
+  /** Q1.5: signals whether the caller already prefilled the user-side of the
+   *  next trunk turn via `session.prefillUser` (true) or left it to
+   *  `runResearchPlan` to commit the full pair (false, default). True after a
+   *  clarify round in which `submit_clarification` exposed the user's answer
+   *  to the planner via KV before invoking it; in that case the trunk has a
+   *  dangling user side and the research-findings commit must use
+   *  `session.prefillAssistant` to close the pair rather than `commitTurn`
+   *  (which would re-emit the user side). */
+  userSidePending?: boolean;
+  /** Ask mode (composer `skipPlanner`): a single warm-forked agent that may answer
+   *  DIRECTLY from the prior report's context. Uses `DirectAnswerPolicy` so a free-text
+   *  answer with 0 tool calls is captured (not discarded by the tool-gathering guard).
+   *  Omitted/false ⇒ normal research policy (evidence-gathering enforced). */
+  isAsk?: boolean;
+}
+
+export interface PreflightResult {
+  /** Prose per-entity coverage summary the recon agent reported. Empty when
+   *  the agent produced nothing usable. */
+  coverage: string;
+  tokens: number;
+  toolCalls: number;
+  timeMs: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Content nudge for the structured `report()` sources field, appended to every
+ * research agent's per-task system prompt (see {@link appPreamble}). The grammar
+ * forces the field's SHAPE ({title, url} objects); this nudges its CONTENT toward
+ * real URLs from tool results (not corpus file paths) and inline citations. Kept
+ * as a clearly-separated trailing sentence.
+ */
+const REPORT_CITATION_NUDGE =
+  "\n\nWhen you call report(): cite each claim inline as [title](url) using the exact URL from tool results, and fill the sources field with every {title, url} you used (real URLs from tool results, not file paths).";
+
+/**
+ * Per-spawn preamble for an agent assigned to `app`. `renderAgentPreamble`
+ * prepends the boundary marker and renders the app's `skill.eta`; we merge the
+ * app's own `source.promptData()` (corpus supplies `it.toc`; web supplies
+ * nothing) into the render context, exactly as the old `renderWorkerPrompt`
+ * spread `source.promptData()` into ctx. The structured-sources citation nudge is
+ * appended last so research agents fill report()'s sources field with real URLs.
+ */
+function appPreamble(app: App, ctx: AgentRenderCtx): string {
+  return (
+    renderAgentPreamble(app, ctx as AgentRenderCtx & Record<string, unknown>) +
+    REPORT_CITATION_NUDGE
+  );
+}
+
+/**
+ * Spine = framework catalog + harness-trusted app reference data.
+ *
+ * `renderSpine` stays prose-free by design (cross-app injection defense:
+ * the shared prefix is read by every agent in the pool). Appending app
+ * `promptData` is the HARNESS's trust call — reasoning.run ships
+ * first-party apps only. Rendered once and prefix-shared by every fork,
+ * instead of duplicated into each spawn's suffix (six 4.8k-token
+ * TOC-bearing suffixes overran a 32k context: trace-2026-06-11T06-21).
+ */
+function renderSpineWithReferenceData(apps: readonly App[]): string {
+  const blocks: string[] = [];
+  for (const app of apps) {
+    const toc = app.source.promptData()["toc"];
+    if (typeof toc === "string" && toc.trim()) {
+      blocks.push(
+        `\n\n# ${app.manifest.protocol.name} — available files\n${toc}`,
+      );
+    }
+  }
+  return renderSpine({ apps }) + blocks.join("");
+}
+
+function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function startTimer(): () => number {
+  const start = performance.now();
+  return () => performance.now() - start;
+}
+
+/**
+ * Resolve the effective App set for the current operation. Returns
+ * `registry.enabled()` filtered by `appFilter` (by `manifest.name`) when
+ * the caller passes one; otherwise returns the full enabled set.
+ *
+ * The filter is the per-query App-participation knob: the Composer
+ * derives it from `state.participation` at submit time and threads it
+ * through `RunQueryOpts.appFilter` / `RunResearchPlanOpts.appFilter`.
+ * All in-harness consumers (recon, planner-context, research pool) call
+ * this instead of `registry.enabled()` directly so the filter applies
+ * uniformly.
+ */
+function* effectiveApps(filter?: readonly string[]): Operation<readonly App[]> {
+  const registry = yield* AppRegistryCtx.expect();
+  const all = registry.enabled();
+  if (!filter) return all;
+  const allow = new Set(filter);
+  return all.filter((a) => allow.has(a.manifest.name));
+}
+
+/**
+ * Synthetic single-task research plan. Used by the START path to
+ * bypass the planner — the user's literal query becomes the only
+ * research task. Combined with the synth gate inside runResearchPlan
+ * (skips synth when tasks.length === 1), this collapses START into
+ * "research the literal query, return the agent's report."
+ */
+export function singleTaskPlan(query: string): PlanResult {
+  return {
+    intent: "research",
+    tasks: [{ description: query }],
+    clarifyQuestions: [],
+    tokenCount: 0,
+    timeMs: 0,
+  };
+}
+
+/**
+ * Passthrough — stream a direct answer from session.trunk after appending
+ * the user's query as a fresh user turn. No research pool runs; the
+ * answer comes from the prior Q&A already in trunk's KV.
+ *
+ * Caller ensures session.trunk exists; this throws otherwise.
+ */
+function* runPassthrough(
+  query: string,
+  session: Session,
+): Operation<{ answer: string; tokenCount: number; timeMs: number }> {
+  const trunk = session.trunk;
+  if (!trunk) {
+    throw new Error("runPassthrough: session has no trunk");
+  }
+
+  const ctx: SessionContext = yield* Ctx.expect();
+  const sep = ctx.getTurnSeparator();
+  const { prompt } = ctx.formatChatSync(
+    JSON.stringify([{ role: "user", content: query }]),
+    { addGenerationPrompt: true, enableThinking: false },
+  );
+  const userTurnTokens = [...sep, ...ctx.tokenizeSync(prompt, false)];
+  yield* call(() => trunk.prefill(userTurnTokens));
+
+  const t = performance.now();
+  let tokenCount = 0;
+  const pieces: string[] = [];
+  for (;;) {
+    const { token, text, isStop } = trunk.produceSync();
+    if (isStop) break;
+    yield* call(() => trunk.commit(token));
+    tokenCount++;
+    pieces.push(text);
+  }
+  return { answer: pieces.join(""), tokenCount, timeMs: performance.now() - t };
+}
+
+/**
+ * Pre-flight recon. One probe agent PER enabled app runs in parallel — the
+ * same `agentPool` + `parallel` machinery the research pool uses — each
+ * searching its OWN source for the query's entities and reporting which parts
+ * that source covers. The joined coverage grounds the planner's per-task `app`
+ * routing (RFC: multi-app composition — route by *trying* the apps, not blind
+ * `useWhen`).
+ *
+ * Runs only when ≥2 apps are installed (nothing to route between otherwise).
+ * Each agent is hard-capped at {@link RECON_MAX_TURNS} via {@link ReconPolicy}:
+ * past the cap the pool kills + recovers it (coverage from what it saw) rather
+ * than soft-nudge-looping. Probe calls stream as `agent:*` events, so the UI
+ * shows discovery live. Recon is throwaway — its retrievals aren't reused by
+ * the research agents (they re-search deeper); only the coverage feeds forward.
+ */
+export function* runPreflight(
+  query: string,
+  session: Session,
+  filter?: readonly string[],
+): Operation<PreflightResult> {
+  const events = yield* Events.expect();
+  const send = (ev: StepEvent): Operation<void> =>
+    events.send(ev as unknown as AgentEvent);
+
+  const apps = yield* effectiveApps(filter);
+
+  yield* send({ type: "preflight:start", query, appCount: apps.length });
+  const timer = startTimer();
+
+  const reconTools = [...apps.flatMap((a) => [...a.tools]), reportTool];
+  const spinePrompt = renderSpineWithReferenceData(apps);
+  const currentDate = today();
+
+  const { coverage, tokens, toolCalls } = yield* withSpine<{
+    coverage: string;
+    tokens: number;
+    toolCalls: number;
+  }>(
+    {
+      parent: session.trunk ?? undefined,
+      systemPrompt: spinePrompt,
+      tools: reconTools,
+    },
+    function* (reconSpine) {
+      const preflight = yield* resolvePrompt("preflight");
+      const reconRecover = yield* resolvePrompt("preflight-recover");
+      const probe = yield* agentPool({
+        tools: reconTools,
+        parent: reconSpine,
+        terminal: reportTool,
+        maxTurns: RECON_MAX_TURNS,
+        pruneOnReturn: true,
+        policy: createReconPolicy(reconRecover),
+        enableThinking: true,
+        orchestrate: parallel(
+          apps.map((app, i) => ({
+            content: renderTemplate(preflight.user, {
+              query,
+              date: currentDate,
+              app: {
+                name: app.manifest.protocol.name,
+                useWhen: app.manifest.protocol.useWhen,
+                tools: app.manifest.protocol.tools,
+                // Surface the source's content advert so the recon agent
+                // can recognize what each source actually contains BEFORE
+                // probing — fixes TICK-005 (corpus probe agent reading
+                // HDK chunks as "Lloyal platform stuff" because it didn't
+                // know the corpus IS the HDK docs). Duck-typed because
+                // not every source implements promptData (web doesn't).
+                // Graduates to Source.describe() framework affordance in
+                // TICK-018; for now reasoning.run pulls it directly.
+                contents:
+                  (app.source as { promptData?: () => { toc?: string } })
+                    .promptData?.()?.toc ?? null,
+              },
+            }),
+            systemPrompt: preflight.system,
+            assignedApp: app.manifest.name,
+            seed: 2000 + i,
+          })),
+        ),
+      });
+
+      // Join each source's coverage under its protocol name so the planner can
+      // see which source holds what. Agents align with `apps` by spawn order.
+      const lines = probe.agents
+        .map((a, i) => {
+          const name = apps[i]?.manifest.protocol.name ?? `source ${i + 1}`;
+          const body = a.result?.trim();
+          return body ? `### ${name}\n${body}` : null;
+        })
+        .filter((l): l is string => l !== null);
+
+      return {
+        coverage: lines.join("\n\n"),
+        tokens: probe.totalTokens,
+        toolCalls: probe.totalToolCalls,
+      };
+    },
+  );
+
+  const result: PreflightResult = { coverage, tokens, toolCalls, timeMs: timer() };
+  yield* send({
+    type: "preflight:done",
+    coverage,
+    tokens: result.tokens,
+    toolCalls: result.toolCalls,
+    timeMs: result.timeMs,
+  });
+  return result;
+}
+
+/**
+ * Memoizes preflight coverage for the lifetime of the boot session.
+ *
+ * Coverage is a pure function of `(query, enabledApps)`; the enabled-app
+ * set is constant within a boot scope (a `/model` or `/reranker` change
+ * unwinds that scope and rebuilds the cache), so `query` alone is a sufficient
+ * key. This is what lets a clarify-answer or change_mode re-invoke
+ * `runQuery(sameQuery)` without re-running the ~170 s recon probe — the second
+ * call hits the memo. See TICK-004 (and TICK-014, subsumed).
+ */
+export interface CoverageCache {
+  getOrCompute(
+    query: string,
+    compute: () => Operation<PreflightResult>,
+  ): Operation<PreflightResult>;
+}
+
+/**
+ * Construct a per-boot coverage cache. Created once at the command-loop scope
+ * via `CoverageCacheCtx.set` and cleared on scope teardown.
+ */
+export function createCoverageCache(): Operation<CoverageCache> {
+  return resource(function* (provide) {
+    const memo = new Map<string, PreflightResult>();
+    try {
+      yield* provide({
+        *getOrCompute(query, compute) {
+          const hit = memo.get(query);
+          if (hit) return hit; // reuse — `compute` (which emits preflight:* events) never fires
+          const fresh = yield* compute();
+          memo.set(query, fresh);
+          return fresh;
+        },
+      });
+    } finally {
+      memo.clear();
+    }
+  });
+}
+
+export const CoverageCacheCtx = createContext<CoverageCache>(
+  "reasoning.coverageCache",
+);
+
+/**
+ * Resolve preflight coverage for `query`, computing it at most once per
+ * boot session. The ≥2-app gate lives here (a single source has nothing to
+ * route between, so coverage is empty and no probe runs). The caller folds
+ * the returned prose into the planner context.
+ */
+export function* useCoverage(
+  query: string,
+  session: Session,
+  filter?: readonly string[],
+): Operation<PreflightResult> {
+  const apps = yield* effectiveApps(filter);
+  if (apps.length < 2) {
+    return { coverage: "", tokens: 0, toolCalls: 0, timeMs: 0 };
+  }
+  const cache = yield* CoverageCacheCtx.expect();
+  // Compose the cache key from query + sorted filter so distinct
+  // participation subsets get distinct cached coverage. Same query +
+  // same subset across clarify rounds still hits the cache.
+  const key = filter
+    ? `${query}|${[...filter].sort().join(",")}`
+    : query;
+  return yield* cache.getOrCompute(key, () => runPreflight(query, session, filter));
+}
+
+/**
+ * Run the planner LLM. Emits a `query` event and a `plan` event.
+ * Returns the raw PlanResult so callers can route based on intent.
+ */
+export function* runPlanner(
+  query: string,
+  session: Session,
+  opts: { reasoningMode: "flat" | "deep"; effort: Effort; context?: string; appFilter?: readonly string[] },
+): Operation<PlanResult> {
+  const events = yield* Events.expect();
+  const send = (ev: StepEvent): Operation<void> =>
+    events.send(ev as unknown as AgentEvent);
+
+  yield* send({ type: "query", query, warm: !!session.trunk });
+
+  const currentDate = today();
+  const planPrompt = yield* resolvePrompt(opts.reasoningMode === "flat" ? "plan-flat" : "plan");
+  // Grounded planner routing (RFC: multi-app composition). With ≥2 apps the
+  // pre-flight recon agent has already probed each source and folded a coverage
+  // summary into `opts.context`; passing `availableApps` re-adds the per-task
+  // `app` enum to the plan grammar so the planner assigns each task to the
+  // source the coverage shows holds it — evidence-grounded, not blind `useWhen`.
+  // `appForTask` in runResearchPlan consumes `task.app`. With <2 apps there is
+  // nothing to route between, so the field is dropped and tasks fall back to the
+  // primary app + open reads (authGuard).
+  const apps = yield* effectiveApps(opts.appFilter);
+  const planTool = new PlanTool({
+    prompt: planPrompt,
+    session,
+    // Caps the tasks-array `maxItems` (grammar-enforced) and the `it.count`
+    // rendered into the planner prompt. 6 is the upper bound that survives
+    // the 8-agent shared-spine overflow seen in
+    // trace-2026-06-01T07-46-17-924 (8 corpus-heavy tasks → all agents
+    // softcut/settle-reject, no recovery, empty synth).
+    maxTasks: EFFORT_PRESETS[opts.effort].maxTasks,
+    availableApps: apps.length >= 2 ? apps : undefined,
+  });
+  const planContext = opts.context
+    ? `Today's date: ${currentDate}\n\n${opts.context}`
+    : `Today's date: ${currentDate}`;
+  const plan = (yield* planTool.execute({
+    query,
+    context: planContext,
+  })) as PlanResult;
+
+  yield* send({
+    type: "plan",
+    intent: plan.intent,
+    tasks: plan.tasks,
+    clarifyQuestions: plan.clarifyQuestions,
+    tokenCount: plan.tokenCount,
+    timeMs: plan.timeMs,
+  });
+
+  return plan;
+}
+
+// ── Pipeline ────────────────────────────────────────────────────
+
+/**
+ * Top of pipeline: run planner, dispatch on intent.
+ *
+ *   - intent='clarify'      → return; caller drives the clarify dialog
+ *   - intent='passthrough'  → run passthrough inline (if trunk exists),
+ *                             return done. If no trunk, fall through to
+ *                             research_plan with a single-task synthetic
+ *                             plan since passthrough requires a warm
+ *                             session.
+ *   - intent='research'     → return the plan; caller decides whether to
+ *                             show plan-review or run it directly.
+ *
+ * For START (skip planner): main.ts builds a singleTaskPlan(query) and
+ * calls runResearchPlan directly — never enters this function.
+ */
+export function* runQuery(
+  query: string,
+  session: Session,
+  opts: RunQueryOpts,
+): Operation<QueryResult> {
+  const events = yield* Events.expect();
+  const send = (ev: StepEvent): Operation<void> =>
+    events.send(ev as unknown as AgentEvent);
+
+  // Defensive guard: empty `appFilter` is a programming error — the
+  // Composer's submit handler blocks zero-source submission with a
+  // toast, so reaching here with [] means the auto-submit `--query`
+  // path or a future caller forgot the same check. Fail loudly.
+  if (opts.appFilter && opts.appFilter.length === 0) {
+    throw new Error(
+      "runQuery: appFilter is an empty array — at least one source must be included.",
+    );
+  }
+
+  // Pre-flight recon (RFC: multi-app composition). Probe each source for the
+  // query's entities BEFORE planning and fold the coverage summary into the
+  // planner context — that's what makes the planner's per-task `app` routing
+  // grounded rather than blind. `useCoverage` memoizes per `(query, appFilter)`
+  // for the boot session, so a clarify-answer / change_mode re-invocation of
+  // `runQuery` with the same filter reuses the probe instead of re-running
+  // it; it also applies the ≥2-app gate internally (a single effective source
+  // has nothing to route between → empty coverage).
+  const preflight = yield* useCoverage(query, session, opts.appFilter);
+  let plannerContext = opts.context;
+  if (preflight.coverage) {
+    const coverageSection =
+      "Source coverage (from a pre-flight probe of each source for this query — " +
+      "use it as the primary signal when assigning each task's `app`):\n" +
+      preflight.coverage;
+    plannerContext = [opts.context, coverageSection]
+      .filter(Boolean)
+      .join("\n\n");
+  }
+
+  yield* send({
+    type: "plan:start",
+    query,
+    mode: opts.reasoningMode,
+  });
+
+  const plan = yield* runPlanner(query, session, {
+    reasoningMode: opts.reasoningMode,
+    effort: opts.effort,
+    context: plannerContext,
+    appFilter: opts.appFilter,
+  });
+
+  if (plan.intent === "clarify") {
+    return { type: "clarify", plan };
+  }
+
+  // Passthrough fast-path. Gated on trunk existence: passthrough forks
+  // from the warm spine, so a cold session can't take it. Without trunk
+  // we degrade to running the query as a single-task research plan,
+  // which transparently gives the user an answer either way.
+  if (plan.intent === "passthrough") {
+    if (!session.trunk) {
+      const fallbackPlan = singleTaskPlan(query);
+      opts.onStart?.();
+      yield* runResearchPlan(query, fallbackPlan, session, { ...opts });
+      return { type: "done" };
+    }
+    opts.onStart?.();
+    const pt = yield* runPassthrough(query, session);
+    yield* send({ type: "answer", text: pt.answer });
+    yield* finalizePassthrough(plan, pt, opts.wallStartMs);
+    return { type: "done" };
+  }
+
+  return { type: "research_plan", plan };
+}
+
+/**
+ * Run a research plan to completion: research pool → (synth iff fan-in)
+ * → answer + stats + complete + commitTurn.
+ *
+ * Used for both:
+ *   - accept_plan path: planner-built plan, possibly edited via the
+ *     plan-review dialog
+ *   - START path: synthetic singleTaskPlan(query) bypassing the planner
+ *
+ * Synth gate (single conditional, encodes invariant): synth aggregates
+ * findings across multiple agents into one argument. tasks.length === 1
+ * has nothing to aggregate — the agent's report IS the answer.
+ */
+export function* runResearchPlan(
+  query: string,
+  plan: PlanResult,
+  session: Session,
+  opts: RunResearchPlanOpts,
+): Operation<void> {
+  if (plan.intent !== "research") {
+    throw new Error(
+      `runResearchPlan: expected plan.intent=research, got ${plan.intent}`,
+    );
+  }
+
+  const events = yield* Events.expect();
+  const send = (ev: StepEvent): Operation<void> =>
+    events.send(ev as unknown as AgentEvent);
+
+  const tasks = plan.tasks;
+  const currentDate = today();
+
+  yield* send({
+    type: "research:start",
+    agentCount: tasks.length,
+    mode: opts.reasoningMode,
+  });
+  const researchTimer = startTimer();
+
+  // App protocol: the registry (set on AppRegistryCtx by createAppRegistry at
+  // boot) is the source of truth. Apps are born already-bound to the reranker
+  // (no source.bind step). The spine carries every app's catalog metadata AND
+  // every app's tools (`researchTools` below), so each agent can read across
+  // ALL apps — routing dissolves at execution time (RFC §3.2 M2 authGuard:
+  // read tools are open; only `protected` tools are grant-gated, and these
+  // apps have none). `task.app` is now a soft routing hint, not a tool lock:
+  // it selects which app's preamble (skill.eta) the agent gets and drives the
+  // per-task UI chip; the model is free to pivot to another app's read tools
+  // mid-task. App-agnostic tasks fall back to the primary.
+  const apps = yield* effectiveApps(opts.appFilter);
+  const primaryApp = apps[0];
+  const byProtocol = new Map(apps.map((a) => [a.manifest.protocol.name, a]));
+  const appForTask = (task: ResearchTask): App =>
+    (task.app ? byProtocol.get(task.app) : undefined) ?? primaryApp;
+  // The scorer is reranker-backed and the reranker is shared across all apps
+  // (RerankerCtx), so one pool-level scorer is equivalent regardless of which
+  // app a given agent is assigned.
+  const primaryScorer = primaryApp.source.createScorer(query);
+  // citedReportTool replaces rig's reportTool for the research pool: same 'report'
+  // terminal name + no-op semantics, but its schema adds the required `sources`
+  // field (grammar-forced). Recon keeps rig's reportTool (its coverage output isn't
+  // cited). The pool builds the terminal grammar from `terminal:` below, so the
+  // registry entry and the `terminal:` arg MUST be the same tool.
+  const researchTools = [...apps.flatMap((a) => [...a.tools]), citedReportTool];
+  const spinePrompt = renderSpineWithReferenceData(apps);
+
+  let synthTimeMs = 0;
+  let researchTimeMs = 0;
+
+  const {
+    answer,
+    totalTokens: researchTotalTokens,
+    totalToolCalls: researchTotalToolCalls,
+    synthTokens: synthTotalTokens,
+  } = yield* withSpine<{
+    answer: string;
+    totalTokens: number;
+    totalToolCalls: number;
+    synthTokens: number;
+  }>(
+    {
+      parent: session.trunk ?? undefined,
+      systemPrompt: spinePrompt,
+      tools: researchTools,
+    },
+    function* (querySpine) {
+      if (opts.reasoningMode === "flat") {
+        yield* send({ type: "fanout:tasks", tasks });
+      }
+
+      const recoveryPrompt = yield* resolvePrompt("recovery");
+      const research = yield* agentPool({
+        tools: researchTools,
+        parent: querySpine,
+        terminal: citedReportTool,
+        maxTurns: opts.maxTurns,
+        pruneOnReturn: true,
+        policy: createResearchPolicy(opts.effort, opts.reasoningMode, opts.isAsk, recoveryPrompt),
+        scorer: primaryScorer,
+        enableThinking: true,
+        orchestrate:
+          opts.reasoningMode === "flat"
+            ? parallel(
+                tasks.map((task: ResearchTask, i: number) => {
+                  const app = appForTask(task);
+                  return {
+                    content: taskToContent(task),
+                    systemPrompt: appPreamble(app, {
+                      maxTurns: opts.maxTurns,
+                      agentCount: tasks.length,
+                      siblingTasks: tasks
+                        .filter((_, j) => j !== i)
+                        .map((t) => t.description),
+                      date: currentDate,
+                      taskIndex: 0,
+                    }),
+                    assignedApp: app.manifest.name,
+                    seed: 1000 + i,
+                  };
+                }),
+              )
+            : chain(tasks, (task: ResearchTask, i: number) => {
+                const app = appForTask(task);
+                return {
+                  task: {
+                    content: taskToContent(task),
+                    systemPrompt: appPreamble(app, {
+                      maxTurns: opts.maxTurns,
+                      agentCount: 1,
+                      siblingTasks: [],
+                      date: currentDate,
+                      taskIndex: i,
+                    }),
+                    assignedApp: app.manifest.name,
+                  },
+                  userContent: `Research task: ${task.description}`,
+                  beforeSpawn: function* () {
+                    yield* send({
+                      type: "spine:task",
+                      taskIndex: i,
+                      taskCount: tasks.length,
+                      description: task.description,
+                    });
+                    yield* send({
+                      type: "spine:source",
+                      taskIndex: i,
+                      source: app.source.name,
+                    });
+                  },
+                  afterExtend: function* (delta: number, position: number) {
+                    yield* send({
+                      type: "spine:task:done",
+                      taskIndex: i,
+                      stageFindings: delta,
+                      accumulated: position,
+                    });
+                  },
+                };
+              }),
+      });
+
+      // Emit research:done HERE — before synth starts — so the flat-mode
+      // panel's finalize happens while the cursor is still directly below
+      // the panel.
+      researchTimeMs = researchTimer();
+      yield* send({
+        type: "research:done",
+        totalTokens: research.totalTokens,
+        totalToolCalls: research.totalToolCalls,
+        timeMs: researchTimeMs,
+      });
+
+      // Synth gate. Synth aggregates fan-in across multiple sources;
+      // single-task runs have nothing to aggregate — the agent's
+      // report IS the answer. The synth prompts also assume multi-agent
+      // framing, so running them on a single source produces awkward
+      // output. Skipping saves ~120s of LLM time on START runs.
+      if (tasks.length === 1) {
+        return {
+          answer: research.agents[0]?.result?.trim() ?? "",
+          totalTokens: research.totalTokens,
+          totalToolCalls: research.totalToolCalls,
+          synthTokens: 0,
+        };
+      }
+
+      // All-empty gate: every agent was cut before producing findings
+      // (capacity failure, mass tool outage). Synthesizing from nothing
+      // yields a confident hallucination sourced from model priors —
+      // 16k chars of it in trace-2026-06-11T06-21. Say so honestly instead.
+      if (research.agents.every((a) => !a.result?.trim())) {
+        return {
+          answer:
+            "Research produced no findings — every agent was cut before completing its task (see trace for drop reasons). No synthesis was attempted.",
+          totalTokens: research.totalTokens,
+          totalToolCalls: research.totalToolCalls,
+          synthTokens: 0,
+        };
+      }
+
+      yield* send({ type: "synthesize:start" });
+      const synthT = startTimer();
+
+      const synthPrompt = yield* resolvePrompt(
+        opts.reasoningMode === "flat" ? "synthesize-flat" : "synthesize",
+      );
+      const findings =
+        opts.reasoningMode === "flat"
+          ? research.agents
+              .map((a, i) => {
+                const desc = tasks[i]?.description ?? `task ${i + 1}`;
+                // Consumer-side guard: a dangling <tool_call> fragment in a
+                // finding is an in-context demonstration that primes the
+                // (tool-less) synth agent to emit tool calls. The framework
+                // sanitizes at result capture; this catches anything that
+                // slips through a future capture path.
+                const body =
+                  a.result
+                    ?.replace(/<tool_call>(?:(?!<\/tool_call>)[\s\S])*$/, "")
+                    .trim() || "(no findings)";
+                return `### Agent ${i + 1}: ${desc}\n\n${body}`;
+              })
+              .join("\n\n")
+          : undefined;
+      const synthCtx = {
+        query,
+        findings,
+        agentCount: tasks.length,
+      };
+
+      const synth = yield* useAgent({
+        systemPrompt: renderTemplate(synthPrompt.system, synthCtx),
+        task: renderTemplate(synthPrompt.user, synthCtx),
+        parent: querySpine,
+        policy: new DirectAnswerPolicy(),
+        maxTurns: opts.maxTurns,
+      });
+
+      synthTimeMs = synthT();
+      yield* send({
+        type: "synthesize:done",
+        agentId: synth.id,
+        ppl: synth.branch.disposed ? 0 : synth.branch.perplexity,
+        tokenCount: synth.tokenCount,
+        toolCallCount: synth.toolCallCount,
+        timeMs: synthTimeMs,
+      });
+
+      return {
+        answer: synth.result || "",
+        totalTokens: research.totalTokens,
+        totalToolCalls: research.totalToolCalls,
+        synthTokens: synth.tokenCount,
+      };
+    },
+  );
+
+  yield* send({ type: "answer", text: answer });
+  if (answer) {
+    if (opts.userSidePending) {
+      // Clarify path: user-side already on trunk via prefillUser; close the
+      // dangling pair by appending the assistant side only.
+      yield* call(() => session.prefillAssistant(answer));
+    } else {
+      // No-clarify path (START or first-shot accept_plan): bootstrap or
+      // append the full (query, answer) pair atomically.
+      yield* call(() => session.commitTurn(query, answer));
+    }
+  }
+
+  yield* finalizeResearch({
+    plan,
+    researchTokens: researchTotalTokens,
+    researchToolCalls: researchTotalToolCalls,
+    researchTimeMs,
+    synthTokens: synthTotalTokens,
+    synthTimeMs,
+    wallStartMs: opts.wallStartMs,
+    send,
+  });
+}
+
+// ── Finalize helpers ────────────────────────────────────────────
+
+function* finalizePassthrough(
+  plan: PlanResult,
+  pt: { tokenCount: number; timeMs: number },
+  wallStartMs: number,
+): Operation<void> {
+  const events = yield* Events.expect();
+  const send = (ev: StepEvent): Operation<void> =>
+    events.send(ev as unknown as AgentEvent);
+
+  const ctx: SessionContext = yield* Ctx.expect();
+  const p = ctx._storeKvPressure();
+  const ctxTotal = p.nCtx || 1;
+
+  const timings: OpTiming[] = [
+    {
+      label: "Plan",
+      tokens: plan.tokenCount,
+      detail: plan.intent,
+      timeMs: plan.timeMs,
+    },
+    {
+      label: "Passthrough",
+      tokens: pt.tokenCount,
+      detail: "trunk stream",
+      timeMs: pt.timeMs,
+    },
+  ];
+  yield* send({
+    type: "stats",
+    timings,
+    ctxPct: Math.round((100 * p.cellsUsed) / ctxTotal),
+    ctxPos: p.cellsUsed,
+    ctxTotal,
+  });
+  yield* send({
+    type: "complete",
+    data: {
+      intent: plan.intent,
+      planTokens: plan.tokenCount,
+      passthroughTokens: pt.tokenCount,
+      wallTimeMs: Math.round(performance.now() - wallStartMs),
+      planMs: Math.round(plan.timeMs),
+      passthroughMs: Math.round(pt.timeMs),
+    },
+  });
+  // Trunk already contains the streamed user+assistant pair via
+  // produceSync+commit; no session.commitTurn needed.
+}
+
+function* finalizeResearch(args: {
+  plan: PlanResult;
+  researchTokens: number;
+  researchToolCalls: number;
+  researchTimeMs: number;
+  synthTokens: number;
+  synthTimeMs: number;
+  wallStartMs: number;
+  send: (ev: StepEvent) => Operation<void>;
+}): Operation<void> {
+  const ctx: SessionContext = yield* Ctx.expect();
+  const p = ctx._storeKvPressure();
+  const ctxTotal = p.nCtx || 1;
+
+  const timings: OpTiming[] = [
+    {
+      label: "Plan",
+      tokens: args.plan.tokenCount,
+      detail: args.plan.intent,
+      timeMs: args.plan.timeMs,
+    },
+    {
+      label: "Research",
+      tokens: args.researchTokens,
+      detail: `${args.researchToolCalls} tools`,
+      timeMs: args.researchTimeMs,
+    },
+    {
+      label: "Synthesize",
+      tokens: args.synthTokens,
+      detail: args.synthTokens > 0 ? "spine fork" : "skipped (single task)",
+      timeMs: args.synthTimeMs,
+    },
+  ];
+
+  yield* args.send({
+    type: "stats",
+    timings,
+    ctxPct: Math.round((100 * p.cellsUsed) / ctxTotal),
+    ctxPos: p.cellsUsed,
+    ctxTotal,
+  });
+
+  yield* args.send({
+    type: "complete",
+    data: {
+      intent: args.plan.intent,
+      planTokens: args.plan.tokenCount,
+      agentTokens: args.researchTokens,
+      synthTokens: args.synthTokens,
+      totalToolCalls: args.researchToolCalls,
+      agentCount: args.plan.tasks.length,
+      wallTimeMs: Math.round(performance.now() - args.wallStartMs),
+      planMs: Math.round(args.plan.timeMs),
+      researchMs: Math.round(args.researchTimeMs),
+      synthMs: Math.round(args.synthTimeMs),
+    },
+  });
+}

--- a/packages/harness-cli/templates/research/harness/primitives.ts
+++ b/packages/harness-cli/templates/research/harness/primitives.ts
@@ -1,0 +1,44 @@
+let _jsonlMode = false;
+let _verboseMode = false;
+
+export function setJsonlMode(on: boolean): void { _jsonlMode = on; }
+export function setVerboseMode(on: boolean): void { _verboseMode = on; }
+export function isJsonlMode(): boolean { return _jsonlMode; }
+export function isVerboseMode(): boolean { return _verboseMode; }
+
+export const isTTY = !!process.stdout.isTTY;
+
+export const c = isTTY ? {
+  bold: '\x1b[1m', dim: '\x1b[2m', reset: '\x1b[0m',
+  green: '\x1b[32m', cyan: '\x1b[36m', yellow: '\x1b[33m', red: '\x1b[31m',
+} : { bold: '', dim: '', reset: '', green: '', cyan: '', yellow: '', red: '' };
+
+let _statusText = '';
+
+export function status(text: string): void {
+  if (_jsonlMode || !isTTY) return;
+  _statusText = text;
+  process.stdout.write('\r\x1b[K' + text);
+}
+
+export function statusClear(): void {
+  if (!_statusText) return;
+  _statusText = '';
+  process.stdout.write('\r\x1b[K');
+}
+
+export const log = (...a: unknown[]): void => {
+  if (_jsonlMode) return;
+  statusClear();
+  console.log(...a);
+};
+
+export function emit(event: string, data: Record<string, unknown>): void {
+  if (_jsonlMode) console.log(JSON.stringify({ event, ...data }));
+}
+
+export const fmtSize = (bytes: number): string => bytes > 1e9
+  ? (bytes / 1e9).toFixed(1) + ' GB'
+  : (bytes / 1e6).toFixed(0) + ' MB';
+
+export const pad = (s: unknown, n: number): string => String(s).padStart(n);

--- a/packages/harness-cli/templates/research/harness/protocol.ts
+++ b/packages/harness-cli/templates/research/harness/protocol.ts
@@ -7,9 +7,10 @@
  * imports these to speak the protocol without depending on the UI.
  *
  * TYPES ONLY — this surface must stay `node:`-free so a browser/renderer surface
- * can import it for the plan/event types. The config *loaders*
- * (`loadConfig`/`saveConfig`) deliberately stay runner-side in `./tui-ink/config`
- * — they touch `node:fs`, and only the in-package runner (`runMain`) calls them.
+ * can import it for the plan/event types. The config *schema* it re-exports lives
+ * in `./config-types.ts` (also node-free); the runner that resolves + holds that
+ * config (`makeEdgeRunner` / `makeServedRunner` in `./served-runtime.ts`) is
+ * node-side and set on `RunnerCtx` by a target's boot.
  */
 export type { StepEvent, WorkflowEvent } from "./events.js";
 export type { Command } from "./commands.js";

--- a/packages/harness-cli/templates/research/harness/protocol.ts
+++ b/packages/harness-cli/templates/research/harness/protocol.ts
@@ -1,0 +1,25 @@
+/**
+ * reasoning.run/protocol — the harness's wire vocabulary.
+ *
+ * Its `WorkflowEvent` union (down) + `Command` union (up) — the two halves of
+ * the headless interface `harness(ctx, events, commands)` speaks — plus the
+ * config *schema* a runner resolves and hands the harness. A host or surface
+ * imports these to speak the protocol without depending on the UI.
+ *
+ * TYPES ONLY — this surface must stay `node:`-free so a browser/renderer surface
+ * can import it for the plan/event types. The config *loaders*
+ * (`loadConfig`/`saveConfig`) deliberately stay runner-side in `./tui-ink/config`
+ * — they touch `node:fs`, and only the in-package runner (`runMain`) calls them.
+ */
+export type { StepEvent, WorkflowEvent } from "./events.js";
+export type { Command } from "./commands.js";
+export type {
+  Config,
+  ConfigSources,
+  ConfigDefaults,
+  ConfigModel,
+  ConfigOrigin,
+  LoadedConfig,
+  CliOverrides,
+  SaveResult,
+} from "./config-types.js";

--- a/packages/harness-cli/templates/research/harness/reducer.ts
+++ b/packages/harness-cli/templates/research/harness/reducer.ts
@@ -1,0 +1,1166 @@
+/**
+ * Pure event → AppState reducer.
+ *
+ * Owns: phase transitions, per-agent state machine (<think> boundary
+ * detection), timeline item accrual (think / tool_call / tool_result /
+ * report), synth buffer.
+ *
+ * Emits no side effects. Feed it a trace of StepEvent + AgentEvent; it
+ * returns the view-ready state.
+ */
+
+import type { AppState, AgentRuntime, TimelineItem, SourceMeta } from './state-core.js';
+import { initialState } from './state-core.js';
+import type { WorkflowEvent } from './events.js';
+import type { Config } from './config-types.js';
+import { shortPath } from './short-path.js';
+
+/** Seed/refresh `participation` from current config. The reducer holds NO
+ *  per-app knowledge: apps default to included via the `!== false`
+ *  convention (any app absent from the map renders as included), so there's
+ *  nothing to seed here on a plain config load. The included-by-default set
+ *  is the registry-enabled apps surfaced via `apps:state`; per-app intent is
+ *  driven explicitly through `participation:toggled` (chip toggle) and
+ *  `set_app_config` (configuring → main.ts sets the bit + re-emits state).
+ *  Returns `prev` unchanged — kept as a function so config events have a
+ *  single, named place to hook future participation policy. */
+function seedParticipation(
+  prev: Record<string, boolean>,
+  _cfg: Config,
+): Record<string, boolean> {
+  return prev;
+}
+
+const THINK_CLOSE = '</think>';
+
+/** First meaningful line of a think-block body, cleaned up for a title. */
+function extractTitle(body: string): string {
+  const text = body
+    .replace(/^\s*\n/, '')
+    .replace(/\*\*/g, '')
+    .replace(/^#+\s*/, '')
+    .trim();
+  if (!text) return 'Thinking…';
+  const firstLine = text.split('\n')[0].trim();
+  const clipped = firstLine.length > 72 ? firstLine.slice(0, 72).trimEnd() + '…' : firstLine;
+  return clipped;
+}
+
+function hostOf(url: string): string {
+  try {
+    const u = new URL(url);
+    return u.hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+/** Best-effort argsSummary for tool_call rendering. One-liners per tool. */
+function formatArgSummary(tool: string, rawArgs: string): string {
+  let parsed: Record<string, unknown>;
+  try { parsed = JSON.parse(rawArgs); } catch { parsed = {}; }
+  const q = typeof parsed.query === 'string' ? parsed.query
+    : typeof parsed.pattern === 'string' ? parsed.pattern
+    : typeof parsed.url === 'string' ? parsed.url
+    : typeof parsed.filename === 'string' ? parsed.filename
+    : '';
+  return q ? `"${q.length > 48 ? q.slice(0, 48) + '…' : q}"` : '';
+}
+
+/** Best-effort per-tool summary used by the column's ToolResult line. The
+ *  `sources` field carries per-page citation metadata for the Sources ledger —
+ *  extracted consumer-side from the tool's free-form result (the App Protocol
+ *  prescribes no result schema). web_search/fetch_page already return
+ *  url+title+snippet; image/icon (og:image + favicon) populate once the web app
+ *  ≥1.2.0 emits them. */
+function summarizeResult(tool: string, raw: string): {
+  summary: string;
+  hosts: string[];
+  resultCount: number | null;
+  preview: string | null;
+  sources?: SourceMeta[];
+} {
+  // Try JSON parse first — structured tools (web_search, search, grep, plan).
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (tool === 'web_search' && Array.isArray(parsed)) {
+      const items = parsed as {
+        url?: string;
+        title?: string;
+        snippet?: string;
+        image?: string;
+        icon?: string;
+      }[];
+      const hosts = Array.from(
+        new Set(items.map((i) => (i.url ? hostOf(i.url) : '')).filter(Boolean)),
+      ).slice(0, 3);
+      // Per-page citations (url+title+snippet are already returned; image/icon
+      // arrive with web ≥1.2.0). Cap to keep the envelope small.
+      const sources: SourceMeta[] = items
+        .filter((i) => i.url || i.title)
+        .slice(0, 8)
+        .map((i) => ({
+          url: i.url,
+          title: i.title,
+          snippet: i.snippet,
+          image: i.image,
+          icon: i.icon,
+          host: i.url ? hostOf(i.url) : undefined,
+        }));
+      return {
+        summary: `${items.length} results`,
+        hosts,
+        resultCount: items.length,
+        preview: items[0]?.title ?? null,
+        sources: sources.length ? sources : undefined,
+      };
+    }
+    // Corpus semantic search → { hits: [{ file, heading, score }], … }. Each hit
+    // is a local source (a file/section); emit per-hit metadata into `sources`
+    // so the ledger surfaces corpus sources exactly like web pages. The ledger
+    // is App-Protocol-agnostic — it keys off `sources[]`, not the app/tool name.
+    if (
+      tool === 'search' &&
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      Array.isArray((parsed as { hits?: unknown }).hits)
+    ) {
+      const hits = (parsed as { hits: { file?: string; heading?: string }[] }).hits;
+      const sources: SourceMeta[] = hits
+        .slice(0, 8)
+        .map((h) => ({ title: h.heading || h.file, host: h.file }))
+        .filter((s) => s.title || s.host);
+      return {
+        summary: `${hits.length} results`,
+        hosts: [],
+        resultCount: hits.length,
+        preview: hits[0]?.heading ?? hits[0]?.file ?? null,
+        sources: sources.length ? sources : undefined,
+      };
+    }
+    // Corpus grep → { totalMatches, matches: [{ file, line, text }] }. One local
+    // source per matching file, the matched line as the snippet.
+    if (tool === 'grep' && typeof parsed === 'object' && parsed !== null) {
+      const r = parsed as {
+        totalMatches?: number;
+        matches?: { file?: string; line?: number; text?: string }[];
+      };
+      const matches = r.matches ?? [];
+      const sources: SourceMeta[] = matches
+        .slice(0, 8)
+        .map((m) => ({
+          title: m.file,
+          host: m.line != null ? `line ${m.line}` : undefined,
+          snippet: m.text,
+        }))
+        .filter((s) => s.title);
+      return {
+        summary: `${r.totalMatches ?? 0} matches`,
+        hosts: [],
+        resultCount: r.totalMatches ?? null,
+        preview: matches[0]?.file ?? null,
+        sources: sources.length ? sources : undefined,
+      };
+    }
+    // Corpus read_file → { file, content, lines } (or { file, note }). The agent
+    // opened this file: one local source, marked via the fetch-tool name so the
+    // ledger tiers it as "featured" (read closely) rather than merely surveyed.
+    if (tool === 'read_file' && typeof parsed === 'object' && parsed !== null) {
+      const r = parsed as { file?: string; error?: string };
+      if (r.error) return { summary: r.error, hosts: [], resultCount: null, preview: null };
+      const sources: SourceMeta[] = r.file ? [{ title: r.file }] : [];
+      return {
+        summary: `${raw.length}b`,
+        hosts: [],
+        resultCount: null,
+        preview: r.file ?? null,
+        sources: sources.length ? sources : undefined,
+      };
+    }
+    if (
+      (tool === 'fetch_page' || tool === 'web_fetch') &&
+      typeof parsed === 'object' &&
+      parsed !== null
+    ) {
+      const r = parsed as {
+        url?: string;
+        title?: string;
+        error?: string;
+        excerpt?: string;
+        image?: string;
+        icon?: string;
+      };
+      if (r.error) return { summary: r.error, hosts: [], resultCount: null, preview: null };
+      const hosts = r.url ? [hostOf(r.url)] : [];
+      // A fetched page is one rich citation: title + excerpt as the snippet,
+      // plus og:image + favicon once the web app emits them (web ≥1.2.0).
+      const sources: SourceMeta[] | undefined =
+        r.url || r.title
+          ? [
+              {
+                url: r.url,
+                title: r.title,
+                snippet: r.excerpt,
+                image: r.image,
+                icon: r.icon,
+                host: r.url ? hostOf(r.url) : undefined,
+              },
+            ]
+          : undefined;
+      return {
+        summary: `${raw.length}b`,
+        hosts,
+        resultCount: null,
+        preview: r.title ?? null,
+        sources,
+      };
+    }
+  } catch {
+    /* fall through to URL-scan fallback */
+  }
+
+  // Fallback: scrape hosts from raw URLs in the result payload.
+  const urls = Array.from(raw.matchAll(/https?:\/\/[^\s\])>"]+/g)).map((m) => m[0]);
+  if (urls.length > 0) {
+    const hosts = Array.from(new Set(urls.map(hostOf))).slice(0, 3);
+    return {
+      summary: `${urls.length} links`,
+      hosts,
+      resultCount: urls.length,
+      preview: null,
+    };
+  }
+
+  return { summary: `${raw.length}b`, hosts: [], resultCount: null, preview: null };
+}
+
+// ── Immutable-update helpers ────────────────────────────────────
+
+function replaceAgent(
+  state: AppState,
+  id: number,
+  patch: (a: AgentRuntime) => AgentRuntime,
+): AppState {
+  const existing = state.agents.get(id);
+  if (!existing) return state;
+  const agents = new Map(state.agents);
+  agents.set(id, patch(existing));
+  return { ...state, agents };
+}
+
+function createAgent(state: AppState, id: number, patch: Partial<AgentRuntime> = {}): AppState {
+  if (state.agents.has(id)) return state;
+  const base: AgentRuntime = {
+    id,
+    label: `A${state.nextLabelIdx}`,
+    phase: 'idle',
+    startedAt: Date.now(),
+    endedAt: null,
+    tokenCount: 0,
+    toolCallCount: 0,
+    taskIndex: null,
+    taskDescription: null,
+    dependencyHint: null,
+    currentThinkId: null,
+    pendingToolCallId: null,
+    retry: null,
+    contentBuffer: '',
+    recovering: false,
+    failReason: null,
+    timeline: [],
+    ...patch,
+  };
+  const agents = new Map(state.agents);
+  agents.set(id, base);
+  return { ...state, agents, nextLabelIdx: state.nextLabelIdx + 1 };
+}
+
+function pushTimeline(agent: AgentRuntime, item: TimelineItem): AgentRuntime {
+  return { ...agent, timeline: [...agent.timeline, item] };
+}
+
+function updateTimeline(
+  agent: AgentRuntime,
+  id: number,
+  update: (item: TimelineItem) => TimelineItem,
+): AgentRuntime {
+  return {
+    ...agent,
+    timeline: agent.timeline.map((it) => (it.id === id ? update(it) : it)),
+  };
+}
+
+/** Open a new live think block on this agent. */
+function openThink(state: AppState, agentId: number): AppState {
+  const id = state.nextTimelineId;
+  const next = replaceAgent(state, agentId, (a) =>
+    pushTimeline({ ...a, currentThinkId: id, phase: 'thinking' }, {
+      kind: 'think',
+      id,
+      title: 'Thinking…',
+      body: '',
+      live: true,
+      openedAt: Date.now(),
+      closedAt: null,
+    }),
+  );
+  return { ...next, nextTimelineId: state.nextTimelineId + 1 };
+}
+
+/** Close the agent's currently-live think block with finalBody. */
+function closeThink(state: AppState, agentId: number, finalBody: string): AppState {
+  const agent = state.agents.get(agentId);
+  if (!agent || agent.currentThinkId === null) return state;
+  const thinkId = agent.currentThinkId;
+  const title = extractTitle(finalBody);
+  return replaceAgent(state, agentId, (a) =>
+    updateTimeline({ ...a, currentThinkId: null, phase: 'content' }, thinkId, (it) =>
+      it.kind === 'think'
+        ? { ...it, body: finalBody, title, live: false, closedAt: Date.now() }
+        : it,
+    ),
+  );
+}
+
+// ── reducer entry ────────────────────────────────────────────────
+
+export function reduce(state: AppState, ev: WorkflowEvent): AppState {
+  switch (ev.type) {
+    case 'query':
+      // Preserve session-level fields across queries. Notably `mode` — a
+      // `query` event fires at the start of every `runPlanner` call
+      // (including re-plans on T toggle), and wiping mode would make the
+      // PlanReview picker snap back to the default every time.
+      return {
+        ...initialState,
+        config: state.config,
+        configOrigin: state.configOrigin,
+        uiPhase: state.uiPhase,
+        mode: state.mode,
+        nextToastId: state.nextToastId,
+        toast: state.toast,
+        scrollback: state.scrollback,
+        participation: state.participation,
+        apps: state.apps,
+        query: ev.query,
+        warm: ev.warm,
+        phase: 'plan',
+        startedAt: Date.now(),
+      };
+
+    case 'plan':
+      return {
+        ...state,
+        uiPhase: ev.intent === 'clarify' ? 'clarifying' : state.uiPhase,
+        phase: ev.intent === 'research' ? 'plan' : 'done',
+        plan: {
+          intent: ev.intent,
+          tasks: ev.tasks,
+          clarifyQuestions: ev.clarifyQuestions,
+          tokenCount: ev.tokenCount,
+          timeMs: ev.timeMs,
+        },
+        clarifyContext: ev.intent === 'clarify'
+          ? { originalQuery: state.query, questions: ev.clarifyQuestions }
+          : null,
+      };
+
+    case 'plan:task_updated': {
+      if (!state.plan) return state;
+      if (ev.index < 0 || ev.index >= state.plan.tasks.length) return state;
+      const tasks = state.plan.tasks.map((t, i) =>
+        i === ev.index ? { ...t, description: ev.description } : t,
+      );
+      return { ...state, plan: { ...state.plan, tasks } };
+    }
+
+    case 'plan:task_added': {
+      if (!state.plan) return state;
+      // afterIndex: -1 prepends; otherwise insert at afterIndex + 1.
+      const insertAt = Math.max(0, Math.min(state.plan.tasks.length, ev.afterIndex + 1));
+      const tasks = [
+        ...state.plan.tasks.slice(0, insertAt),
+        { description: '' },
+        ...state.plan.tasks.slice(insertAt),
+      ];
+      return { ...state, plan: { ...state.plan, tasks } };
+    }
+
+    case 'plan:task_deleted': {
+      if (!state.plan) return state;
+      // Don't allow deleting the only task — keeps the plan-review valid.
+      if (state.plan.tasks.length <= 1) return state;
+      if (ev.index < 0 || ev.index >= state.plan.tasks.length) return state;
+      const tasks = state.plan.tasks.filter((_, i) => i !== ev.index);
+      return { ...state, plan: { ...state.plan, tasks } };
+    }
+
+    case 'plan:task_moved': {
+      if (!state.plan) return state;
+      const n = state.plan.tasks.length;
+      if (ev.from === ev.to) return state;
+      if (ev.from < 0 || ev.from >= n) return state;
+      if (ev.to < 0 || ev.to >= n) return state;
+      const tasks = [...state.plan.tasks];
+      const [moved] = tasks.splice(ev.from, 1);
+      tasks.splice(ev.to, 0, moved);
+      return { ...state, plan: { ...state.plan, tasks } };
+    }
+
+    case 'research:start':
+      // Resume the pipeline timer — it was paused on ui:plan_review while
+      // the user reviewed the plan. Accumulator holds the planning-phase
+      // time; now we add research/synth on top.
+      return {
+        ...state,
+        uiPhase: 'research',
+        phase: 'research',
+        mode: ev.mode === 'flat' ? 'flat' : 'deep',
+        // Authoritative fork count — the harness derives it from plan.tasks.length
+        // BEFORE the pool spawns. Stored so "Forked N agents" is right even when
+        // the renderer's plan.tasks is empty/late (the old `?? plan.tasks.length`
+        // path rendered "Forked 0" while agents really forked).
+        researchAgentCount: ev.agentCount,
+        pipelineResumedAt: Date.now(),
+      };
+
+    case 'research:done':
+      return { ...state, phase: 'synth' };
+
+    case 'fanout:tasks':
+      return state;
+
+    case 'spine:task':
+      return {
+        ...state,
+        pendingTaskIndex: ev.taskIndex,
+        pendingTaskDescription: ev.description,
+      };
+
+    case 'spine:source':
+    case 'spine:task:done':
+      return state;
+
+    case 'synthesize:start':
+      return {
+        ...state,
+        phase: 'synth',
+        synth: { open: true, buffer: '', done: false, stats: null },
+      };
+
+    case 'synthesize:done': {
+      const body = state.synth.buffer.trim();
+      const scrollback = body
+        ? [
+            ...state.scrollback,
+            {
+              key: `synth-${state.scrollback.length}-${Date.now()}`,
+              kind: 'synth' as const,
+              body,
+            },
+          ]
+        : state.scrollback;
+      return {
+        ...state,
+        scrollback,
+        synth: {
+          ...state.synth,
+          open: false,
+          done: true,
+          stats: {
+            tokens: ev.tokenCount,
+            toolCalls: ev.toolCallCount,
+            ppl: ev.ppl,
+            timeMs: ev.timeMs,
+          },
+        },
+      };
+    }
+
+    case 'answer':
+      return { ...state, answer: ev.text };
+
+    case 'stats':
+      return {
+        ...state,
+        timings: ev.timings,
+        pressure: {
+          pct: ev.ctxPct,
+          cellsUsed: ev.ctxPos,
+          nCtx: ev.ctxTotal,
+        },
+      };
+
+    case 'complete': {
+      // Pipeline finished — bank the last active slice into the accumulator
+      // and pause. The footer reads this frozen value until the next query
+      // submit resets it.
+      const accrued = state.pipelineResumedAt
+        ? state.pipelineElapsedMs + (Date.now() - state.pipelineResumedAt)
+        : state.pipelineElapsedMs;
+      return {
+        ...state,
+        phase: 'done',
+        uiPhase: 'done',
+        pipelineElapsedMs: accrued,
+        pipelineResumedAt: null,
+      };
+    }
+
+    // ── UI + config events ───────────────────────────────────
+
+    case 'config:loaded':
+      // Just seed config — don't transition uiPhase. Boot flow is:
+      //   boot → (download:start? → downloading) → weights:start → loading
+      //   → ui:composer → composer
+      // If we auto-flipped to 'composer' here, the composer would flash
+      // briefly before the first boot-phase event arrived.
+      // Also seed participation: web is always enabled (keyless fallback);
+      // corpus is enabled iff a path is set. Both default to included.
+      return {
+        ...state,
+        config: ev.config,
+        configOrigin: ev.origin,
+        participation: seedParticipation(state.participation, ev.config),
+      };
+
+    case 'config:updated': {
+      const toastId = state.nextToastId + 1;
+      const message = ev.skipped.length > 0
+        ? `saved → ${shortPath(ev.savedTo)} (skipped: ${ev.skipped.join(', ')} — env active)`
+        : ev.gitignored
+          ? `saved → ${shortPath(ev.savedTo)} (added to .gitignore)`
+          : `saved → ${shortPath(ev.savedTo)}`;
+      // Reconfigure = strong signal of intent to use. Auto-include the
+      // newly-(re)configured apps; drop participation entries for apps
+      // whose config was just cleared.
+      return {
+        ...state,
+        config: ev.config,
+        configOrigin: ev.origin,
+        participation: seedParticipation(state.participation, ev.config),
+        toast: {
+          id: toastId,
+          message,
+          tone: ev.skipped.length > 0 ? 'warn' : 'success',
+        },
+        nextToastId: toastId,
+      };
+    }
+
+    case 'participation:toggled': {
+      const current = state.participation[ev.name] ?? true;
+      const next = !current;
+      // Clear the "All sources excluded" error toast on any include — toggling
+      // a source back on is the natural resolution. Drop on exclude too: the
+      // toast was a submit-time complaint about the previous filter, so any
+      // change to the filter invalidates it.
+      return {
+        ...state,
+        participation: { ...state.participation, [ev.name]: next },
+        toast: null,
+      };
+    }
+
+    case 'apps:state':
+      // Whole-replace the installed-AgentApps snapshot. Display-only — drives
+      // the Settings drawer. Emitted on boot completion + every registry
+      // enable/disable/config change.
+      return { ...state, apps: ev.apps };
+
+    case 'preflight:start': {
+      // Pre-flight recon runs BEFORE the planner, so it's the first event of a
+      // multi-app query. Reset to a clean run (like the `query` event does) and
+      // enter the discovering phase; the recon agent's stream renders live via
+      // the same Column machinery the research view uses. The planner's later
+      // `query` event resets again before research, so recon agents are
+      // transient — they vanish at the discovering → planning transition.
+      const freshSubmission =
+        state.uiPhase === 'composer' ||
+        state.uiPhase === 'done' ||
+        state.uiPhase === 'boot';
+      return {
+        ...initialState,
+        config: state.config,
+        configOrigin: state.configOrigin,
+        mode: state.mode,
+        nextToastId: state.nextToastId,
+        toast: state.toast,
+        scrollback: state.scrollback,
+        corpusStatus: state.corpusStatus,
+        participation: state.participation,
+        apps: state.apps,
+        query: ev.query,
+        uiPhase: 'discovering',
+        phase: 'recon',
+        startedAt: Date.now(),
+        pipelineElapsedMs: freshSubmission ? 0 : state.pipelineElapsedMs,
+        pipelineResumedAt: Date.now(),
+      };
+    }
+
+    case 'preflight:done':
+      // Bracket-only — plan:start flips uiPhase to 'planning' next. The probe
+      // detail lives in the recon agent's live stream, not here.
+      return state;
+
+    case 'plan:start': {
+      // Fresh submission (from composer / done) → reset the pipeline timer
+      // to zero. Re-plan from plan_review → keep the accumulator so the
+      // displayed elapsed continues past the dwell.
+      const freshSubmission =
+        state.uiPhase === 'composer' ||
+        state.uiPhase === 'done' ||
+        state.uiPhase === 'boot';
+      const base = freshSubmission
+        ? { pipelineElapsedMs: 0, startedAt: Date.now() }
+        : {};
+      return {
+        ...state,
+        ...base,
+        uiPhase: 'planning',
+        phase: 'plan',
+        plan: null,
+        query: ev.query,
+        mode: ev.mode === 'flat' ? 'flat' : 'deep',
+        pipelineResumedAt: Date.now(),
+      };
+    }
+
+    case 'ui:composer': {
+      // Cancelled / finished — pause the timer if it was running. Preserve
+      // the accumulator so the composer can show "last run took Xs" if we
+      // ever want it.
+      const accrued = state.pipelineResumedAt
+        ? state.pipelineElapsedMs + (Date.now() - state.pipelineResumedAt)
+        : state.pipelineElapsedMs;
+      return {
+        ...state,
+        uiPhase: 'composer',
+        composerPrefill: ev.prefill ?? '',
+        clarifyContext: null,
+        pipelineElapsedMs: accrued,
+        pipelineResumedAt: null,
+      };
+    }
+
+    case 'ui:plan_review': {
+      // Pause the pipeline timer — user is dwelling on the plan, not the
+      // machine doing work. Bank the running slice, clear the resume
+      // timestamp. research:start / next plan:start will resume it.
+      const accrued = state.pipelineResumedAt
+        ? state.pipelineElapsedMs + (Date.now() - state.pipelineResumedAt)
+        : state.pipelineElapsedMs;
+      return {
+        ...state,
+        uiPhase: 'plan_review',
+        pipelineElapsedMs: accrued,
+        pipelineResumedAt: null,
+      };
+    }
+
+    case 'ui:error': {
+      const toastId = state.nextToastId + 1;
+      return {
+        ...state,
+        uiPhase: 'composer',
+        toast: { id: toastId, message: ev.message, tone: 'error' },
+        nextToastId: toastId,
+      };
+    }
+
+    // ── Boot phases ────────────────────────────────────────────
+
+    case 'backendpack:offer':
+      return {
+        ...state,
+        uiPhase: 'backend_pack_offer',
+        backendPackOffer: {
+          gpuName: ev.gpuName,
+          sizeBytes: ev.sizeBytes,
+          needsRuntime: ev.needsRuntime,
+          runtimeSizeBytes: ev.runtimeSizeBytes,
+          reasons: ev.reasons,
+        },
+      };
+
+    case 'download:plan':
+      // Plan is the ONLY event that grows state.downloads. Replaces the
+      // array entirely with one entry per planned download. start /
+      // progress / complete only mutate existing entries — they never
+      // append. This makes duplicate-by-id structurally impossible.
+      return {
+        ...state,
+        uiPhase: 'downloading',
+        backendPackOffer: null,
+        downloads: ev.entries.map((e) => ({
+          id: e.id,
+          label: e.label,
+          got: 0,
+          total: e.sizeBytes,
+          done: false,
+          started: false,
+        })),
+      };
+
+    case 'download:start':
+      // Mark the planned entry started. If no plan precedes (legacy /
+      // unexpected path), drop the event rather than risk a duplicate
+      // entry. uiPhase still flips to 'downloading' so the spinner
+      // renders.
+      return {
+        ...state,
+        uiPhase: 'downloading',
+        downloads: state.downloads.map((d) =>
+          d.id === ev.id ? { ...d, started: true } : d,
+        ),
+      };
+
+    case 'download:progress':
+      return {
+        ...state,
+        downloads: state.downloads.map((d) =>
+          d.id === ev.id
+            ? { ...d, started: true, got: ev.got, total: ev.total, url: ev.url ?? d.url }
+            : d,
+        ),
+      };
+
+    case 'download:complete':
+      return {
+        ...state,
+        downloads: state.downloads.map((d) =>
+          d.id === ev.id ? { ...d, got: d.total || d.got, done: true } : d,
+        ),
+      };
+
+    case 'weights:start':
+      // Also exits 'backend_pack_offer' on the decline path (no download
+      // plan fires — boot proceeds straight to the load phase).
+      return { ...state, uiPhase: 'loading', loadingLabel: ev.label, backendPackOffer: null };
+
+    case 'weights:label':
+      return { ...state, loadingLabel: ev.label };
+
+    case 'weights:done':
+      return { ...state, loadingLabel: null };
+
+    case 'corpus:indexed':
+      return {
+        ...state,
+        corpusStatus: { fileCount: ev.fileCount, chunkCount: ev.chunkCount },
+      };
+
+    case 'boot:error':
+      return {
+        ...state,
+        uiPhase: 'boot_error',
+        bootError: { kind: ev.kind, message: ev.message },
+      };
+
+    // ── Agent events ───────────────────────────────────────────
+
+    case 'agent:spawn': {
+      // Pre-flight recon agent: stream it through the same timeline machinery
+      // as research (taskIndex 0 so the produce/tool handlers engage), but
+      // track it in reconAgentIds so the research column never picks it up and
+      // agent:return never freezes it into research scrollback.
+      if (state.phase === 'recon') {
+        const next = createAgent(state, ev.agentId, {
+          phase: 'thinking',
+          taskIndex: 0,
+          taskDescription: 'Probing sources',
+        });
+        return openThink(
+          { ...next, reconAgentIds: [...next.reconAgentIds, ev.agentId] },
+          ev.agentId,
+        );
+      }
+
+      // Non-research phase: track the agent but don't open a timeline.
+      if (state.phase !== 'research') {
+        return createAgent(state, ev.agentId, { phase: 'idle', taskIndex: null });
+      }
+
+      // Research phase: bind taskIndex + description, open the first think block.
+      let taskIndex: number;
+      let description: string | null;
+      let nextPendingIdx: number | null = state.pendingTaskIndex;
+      let nextPendingDesc: string | null = state.pendingTaskDescription;
+      if (state.mode === 'deep') {
+        taskIndex = nextPendingIdx ?? state.researchSpawnCount;
+        description = nextPendingDesc
+          ?? state.plan?.tasks[taskIndex]?.description
+          ?? null;
+        nextPendingIdx = null;
+        nextPendingDesc = null;
+      } else {
+        taskIndex = state.researchSpawnCount;
+        description = state.plan?.tasks[taskIndex]?.description ?? null;
+      }
+
+      const dependencyHint =
+        state.mode === 'deep' && taskIndex > 0
+          ? `builds on Task ${taskIndex}`
+          : null;
+
+      let next = createAgent(state, ev.agentId, {
+        phase: 'thinking',
+        taskIndex,
+        taskDescription: description,
+        dependencyHint,
+      });
+      next = {
+        ...next,
+        researchAgentIds: [...next.researchAgentIds, ev.agentId],
+        researchSpawnCount: state.researchSpawnCount + 1,
+        pendingTaskIndex: nextPendingIdx,
+        pendingTaskDescription: nextPendingDesc,
+      };
+      return openThink(next, ev.agentId);
+    }
+
+    case 'agent:produce': {
+      // Synth phase: accumulate into synth buffer.
+      if (state.phase === 'synth' && state.synth.open) {
+        return { ...state, synth: { ...state.synth, buffer: state.synth.buffer + ev.text } };
+      }
+      // Muted phases. 'recon' streams through the same path as 'research'
+      // (its agent has taskIndex 0), so it's allowed past the gate.
+      if (state.phase !== 'research' && state.phase !== 'recon') return state;
+
+      const agent = state.agents.get(ev.agentId);
+      if (!agent || agent.taskIndex === null) return state;
+
+      let working = state;
+      let acting = agent;
+
+      // Content-phase tokens (post-</think>, pre-tool_call) — the model is
+      // writing tool-call JSON. For the terminal `report` tool, the report
+      // body lives inside that JSON. Stream into contentBuffer so it's
+      // visible; cleared on tool_call / report when the structured event
+      // lands.
+      if (acting.phase === 'content') {
+        return replaceAgent(working, acting.id, (a) => ({
+          ...a,
+          tokenCount: ev.tokenCount,
+          contentBuffer: a.contentBuffer + ev.text,
+        }));
+      }
+
+      // Recovery stream (post agent:done): `recoverInline` force-extracts the
+      // report under an EAGER report grammar with no `<think>`/`</think>`.
+      // Route it into contentBuffer (→ "Writing report") instead of opening a
+      // think block, so a forced report isn't mislabeled as the agent
+      // "Thinking". Cleared on agent:return/recovered. See docs/upstream-issues.md.
+      if (acting.recovering) {
+        return replaceAgent(working, acting.id, (a) => ({
+          ...a,
+          tokenCount: ev.tokenCount,
+          contentBuffer: a.contentBuffer + ev.text,
+        }));
+      }
+
+      // Re-enter thinking after tool_result / recovery / initial idle.
+      if (acting.phase !== 'thinking' || acting.currentThinkId === null) {
+        if (acting.phase === 'tool' || acting.phase === 'idle') {
+          working = openThink(working, acting.id);
+          acting = working.agents.get(acting.id)!;
+        } else {
+          // done — drop.
+          return replaceAgent(working, acting.id, (a) => ({ ...a, tokenCount: ev.tokenCount }));
+        }
+      }
+
+      const thinkId = acting.currentThinkId!;
+      const item = acting.timeline.find((it) => it.id === thinkId);
+      if (!item || item.kind !== 'think') return working;
+
+      const combined = item.body + ev.text;
+      const markerIdx = combined.indexOf(THINK_CLOSE);
+
+      if (markerIdx === -1) {
+        return replaceAgent(working, acting.id, (a) =>
+          updateTimeline({ ...a, tokenCount: ev.tokenCount }, thinkId, (it) =>
+            it.kind === 'think' ? { ...it, body: combined } : it,
+          ),
+        );
+      }
+
+      // Close on </think>. Anything AFTER </think> in this same produce event
+      // is content-phase prose — seed the contentBuffer with it so no tokens
+      // are lost at the boundary.
+      const finalBody = combined.slice(0, markerIdx);
+      const tail = combined.slice(markerIdx + THINK_CLOSE.length);
+      const closed = closeThink(working, acting.id, finalBody);
+      return replaceAgent(closed, acting.id, (a) => ({
+        ...a,
+        tokenCount: ev.tokenCount,
+        contentBuffer: tail,
+      }));
+    }
+
+    case 'agent:tool_call': {
+      const agent = state.agents.get(ev.agentId);
+      if (!agent) return state;
+
+      // Force-close any live think block first.
+      let working = state;
+      if (agent.currentThinkId !== null) {
+        const thinkItem = agent.timeline.find((it) => it.id === agent.currentThinkId);
+        const finalBody = thinkItem && thinkItem.kind === 'think' ? thinkItem.body : '';
+        working = closeThink(working, ev.agentId, finalBody);
+      }
+
+      // Skip timeline entry for non-research agents (synth may also emit tool_calls).
+      if (working.agents.get(ev.agentId)?.taskIndex == null) {
+        return replaceAgent(working, ev.agentId, (a) => ({
+          ...a,
+          phase: 'tool',
+          toolCallCount: a.toolCallCount + 1,
+        }));
+      }
+
+      // Terminal `report` tool: this fires at the stop token, but the report
+      // already streamed live as a "Writing report" row (the model's report
+      // body flowed into `contentBuffer` during the content phase — see the
+      // marker extractor in Work.tsx). Pushing a generic tool_call row here
+      // would render a misleading "Reading" timeline entry; instead just
+      // advance phase/counts and clear the streamed buffer. `agent:return`
+      // finalizes the report into a structured `report` item next.
+      // Detection: the agent was mid-report stream iff its `contentBuffer`
+      // (raw post-</think> tokens, not yet cleared) already holds the report
+      // open marker. Belt-and-suspenders on the terminal tool name, which in
+      // reasoning.run's own UI is always `report`.
+      const acting = working.agents.get(ev.agentId);
+      const wasReporting =
+        ev.tool === 'report' ||
+        (acting?.contentBuffer.includes('<parameter=result>') ?? false);
+      if (wasReporting) {
+        return replaceAgent(working, ev.agentId, (a) => ({
+          ...a,
+          phase: 'tool',
+          toolCallCount: a.toolCallCount + 1,
+          contentBuffer: '',
+        }));
+      }
+
+      const id = working.nextTimelineId;
+      const next = replaceAgent(working, ev.agentId, (a) =>
+        pushTimeline(
+          {
+            ...a,
+            phase: 'tool',
+            toolCallCount: a.toolCallCount + 1,
+            pendingToolCallId: id,
+            contentBuffer: '',
+          },
+          {
+            kind: 'tool_call',
+            id,
+            tool: ev.tool,
+            argsSummary: formatArgSummary(ev.tool, ev.args),
+          },
+        ),
+      );
+      return { ...next, nextTimelineId: working.nextTimelineId + 1 };
+    }
+
+    case 'agent:tool_retry': {
+      const agent = state.agents.get(ev.agentId);
+      if (!agent) return state;
+      return replaceAgent(state, ev.agentId, (a) => ({
+        ...a,
+        retry: { tool: ev.tool, retryAt: Date.now() + ev.retryAfterMs, attempt: ev.attempt },
+      }));
+    }
+
+    case 'agent:tool_result': {
+      const agent = state.agents.get(ev.agentId);
+      if (!agent) return state;
+
+      if (agent.taskIndex == null) {
+        return replaceAgent(state, ev.agentId, (a) => ({ ...a, phase: 'idle', retry: null }));
+      }
+
+      const summary = summarizeResult(ev.tool, ev.result);
+      const id = state.nextTimelineId;
+      const hostsUnique = Array.from(new Set(summary.hosts));
+      const next = replaceAgent(state, ev.agentId, (a) =>
+        pushTimeline(
+          { ...a, phase: 'idle', pendingToolCallId: null, retry: null },
+          {
+            kind: 'tool_result',
+            id,
+            tool: ev.tool,
+            callId: agent.pendingToolCallId,
+            byteLength: ev.result.length,
+            preview: summary.preview,
+            hosts: hostsUnique,
+            resultCount: summary.resultCount,
+            sources: summary.sources,
+          },
+        ),
+      );
+      return {
+        ...next,
+        nextTimelineId: state.nextTimelineId + 1,
+        sourceCount: state.sourceCount + hostsUnique.length,
+      };
+    }
+
+    case 'agent:tool_progress':
+      return state;
+
+    case 'agent:return':
+    case 'agent:recovered': {
+      const agent = state.agents.get(ev.agentId);
+      if (!agent) return state;
+
+      // Force-close any live think (recovery path may bypass </think>).
+      let working = state;
+      if (agent.currentThinkId !== null) {
+        const thinkItem = agent.timeline.find((it) => it.id === agent.currentThinkId);
+        const finalBody = thinkItem && thinkItem.kind === 'think' ? thinkItem.body : '';
+        working = closeThink(working, ev.agentId, finalBody);
+      }
+
+      if (working.agents.get(ev.agentId)?.taskIndex == null) {
+        return replaceAgent(working, ev.agentId, (a) => ({
+          ...a,
+          phase: 'done',
+          endedAt: Date.now(),
+          contentBuffer: '',
+          recovering: false,
+        }));
+      }
+
+      const id = working.nextTimelineId;
+      const next = replaceAgent(working, ev.agentId, (a) =>
+        pushTimeline(
+          { ...a, phase: 'done', endedAt: Date.now(), contentBuffer: '', recovering: false },
+          {
+            kind: 'report',
+            id,
+            body: ev.result,
+            tokenCount: a.tokenCount,
+          },
+        ),
+      );
+
+      // Push the finished panel into scrollback as a Static item, and drop
+      // it from researchAgentIds so Narrative stops rendering it live. This
+      // keeps the dynamic tree small (only currently-streaming agents stay
+      // in Narrative), avoiding the clearTerminal-on-overflow scrollback
+      // wipe at later phase transitions. The frozen panel survives in
+      // terminal scrollback for the rest of the session.
+      const finalAgent = next.agents.get(ev.agentId);
+      const isResearch = next.researchAgentIds.includes(ev.agentId);
+      const scrollback = isResearch && finalAgent
+        ? [
+            ...next.scrollback,
+            {
+              key: `agent-${ev.agentId}-${next.scrollback.length}`,
+              kind: 'agent' as const,
+              agent: finalAgent,
+            },
+          ]
+        : next.scrollback;
+      const researchAgentIds = isResearch
+        ? next.researchAgentIds.filter((id) => id !== ev.agentId)
+        : next.researchAgentIds;
+
+      return {
+        ...next,
+        nextTimelineId: working.nextTimelineId + 1,
+        scrollback,
+        researchAgentIds,
+      };
+    }
+
+    case 'agent:failed': {
+      // Forced recovery FAILED (no result — e.g. KV exhausted mid-report decode →
+      // `llama_decode failed`). The agent already showed "Writing report"
+      // (agent:done set `recovering`); without this it spins forever. Mark it
+      // terminally `failed` → cross glyph + frozen timer. There is no report.
+      const agent = state.agents.get(ev.agentId);
+      if (!agent || agent.phase === 'done' || agent.phase === 'failed') return state;
+      let working = state;
+      if (agent.currentThinkId !== null) {
+        const thinkItem = agent.timeline.find((it) => it.id === agent.currentThinkId);
+        const finalBody = thinkItem && thinkItem.kind === 'think' ? thinkItem.body : '';
+        working = closeThink(working, ev.agentId, finalBody);
+      }
+      const next = replaceAgent(working, ev.agentId, (a) => ({
+        ...a,
+        phase: 'failed',
+        endedAt: Date.now(),
+        contentBuffer: '',
+        recovering: false,
+        failReason: ev.reason,
+      }));
+      // Move it out of the live tree into scrollback (like a finished agent) so
+      // Narrative stops rendering it live — but with no `report` item.
+      const finalAgent = next.agents.get(ev.agentId);
+      const isResearch = next.researchAgentIds.includes(ev.agentId);
+      const scrollback = isResearch && finalAgent
+        ? [
+            ...next.scrollback,
+            {
+              key: `agent-${ev.agentId}-${next.scrollback.length}`,
+              kind: 'agent' as const,
+              agent: finalAgent,
+            },
+          ]
+        : next.scrollback;
+      const researchAgentIds = isResearch
+        ? next.researchAgentIds.filter((id) => id !== ev.agentId)
+        : next.researchAgentIds;
+      return { ...next, scrollback, researchAgentIds };
+    }
+
+    case 'agent:done': {
+      // Do NOT mark the agent `done` here. In the stall-break path,
+      // agent:done fires BEFORE recoverInline streams recovery tokens via
+      // agent:produce → agent:recovered. Freezing to `done` would drop those
+      // tokens. Force-close any live think and step back to `idle`, marking
+      // the agent `recovering` so the produce handler routes the forced
+      // report into contentBuffer (→ "Writing report") rather than a think
+      // block. Only agent:return / agent:recovered mark `done`.
+      //
+      // Clear the stale contentBuffer too: if the agent was in `content` phase
+      // when killed (mid tool-call JSON), the partial buffer never resolves to
+      // a tool_call; recovery refills it with the actual forced report.
+      const agent = state.agents.get(ev.agentId);
+      if (!agent || agent.phase === 'done') return state;
+      let working = state;
+      if (agent.currentThinkId !== null) {
+        const thinkItem = agent.timeline.find((it) => it.id === agent.currentThinkId);
+        const finalBody = thinkItem && thinkItem.kind === 'think' ? thinkItem.body : '';
+        working = closeThink(working, ev.agentId, finalBody);
+      }
+      return replaceAgent(working, ev.agentId, (a) => ({
+        ...a,
+        phase: 'idle',
+        // Drop any partial content buffer: if the agent is being force-recovered
+        // it never closed the terminal call, so recovery prose (refilled into
+        // contentBuffer while `recovering`) drives the "Writing report" row now.
+        contentBuffer: '',
+        recovering: true,
+      }));
+    }
+
+    case 'agent:tick':
+      return {
+        ...state,
+        pressure: {
+          pct: ev.nCtx > 0 ? Math.round((100 * ev.cellsUsed) / ev.nCtx) : 0,
+          cellsUsed: ev.cellsUsed,
+          nCtx: ev.nCtx,
+        },
+      };
+
+    default:
+      return state;
+  }
+}

--- a/packages/harness-cli/templates/research/harness/run-dir.ts
+++ b/packages/harness-cli/templates/research/harness/run-dir.ts
@@ -1,0 +1,143 @@
+/**
+ * Per-query artifact sink.
+ *
+ * Subscribes to the WorkflowEvent stream forwarded by main.ts's drain
+ * and writes:
+ *   <output-dir>/<ISO-timestamp>/
+ *     report.md          — synth/passthrough answer with metadata + annexure index
+ *     annexure-N.md      — one per research agent's `report` tool result
+ *
+ * Trace.jsonl is NOT this sink's concern. Trace is session-scoped: opened
+ * once at boot in main.ts, captures every query (including warm follow-
+ * ups), closed at process exit.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { WorkflowEvent } from './events.js';
+
+export class RunDirSink {
+  private currentDir: string | null = null;
+  private inResearch = false;
+  private spawnOrdinal = 0;
+  private agentToOrdinal = new Map<number, number>();
+  private taskByOrdinal = new Map<number, string>();
+  private lastAnswer: string | null = null;
+  private query: string | null = null;
+  private mode: 'flat' | 'deep' | null = null;
+  private startedAt: number | null = null;
+  private synthStats: { tokens: number; ppl: number; timeMs: number } | null = null;
+
+  /** Begin a new query's run-dir. Returns the absolute path so callers can
+   *  emit a `ui:run_dir` event for the composer to display. */
+  start(opts: { outputDir: string; query: string; mode: 'flat' | 'deep' }): string {
+    const ts = new Date().toISOString().replace(/[:.]/g, '-').replace('Z', '');
+    this.currentDir = path.resolve(opts.outputDir, ts);
+    fs.mkdirSync(this.currentDir, { recursive: true });
+    this.inResearch = false;
+    this.spawnOrdinal = 0;
+    this.agentToOrdinal.clear();
+    this.taskByOrdinal.clear();
+    this.lastAnswer = null;
+    this.query = opts.query;
+    this.mode = opts.mode;
+    this.startedAt = Date.now();
+    this.synthStats = null;
+    return this.currentDir;
+  }
+
+  handle(ev: WorkflowEvent): void {
+    if (!this.currentDir) return;
+    switch (ev.type) {
+      case 'research:start':
+        this.inResearch = true;
+        break;
+      case 'research:done':
+        this.inResearch = false;
+        break;
+      case 'fanout:tasks':
+        ev.tasks.forEach((t, i) => this.taskByOrdinal.set(i + 1, t.description));
+        break;
+      case 'spine:task':
+        this.taskByOrdinal.set(ev.taskIndex + 1, ev.description);
+        break;
+      case 'agent:spawn':
+        if (this.inResearch && !this.agentToOrdinal.has(ev.agentId)) {
+          this.spawnOrdinal += 1;
+          this.agentToOrdinal.set(ev.agentId, this.spawnOrdinal);
+        }
+        break;
+      case 'agent:return':
+      case 'agent:recovered': {
+        const ord = this.agentToOrdinal.get(ev.agentId);
+        if (ord !== undefined) this.writeAnnexure(ord, ev.result);
+        break;
+      }
+      case 'answer':
+        this.lastAnswer = ev.text;
+        break;
+      case 'synthesize:done':
+        this.synthStats = {
+          tokens: ev.tokenCount,
+          ppl: ev.ppl,
+          timeMs: ev.timeMs,
+        };
+        break;
+      case 'complete':
+        this.finish();
+        break;
+      case 'ui:error':
+        // Failed mid-run — annexures already written, no report.md.
+        // Trace is session-scoped so partial events are already persisted.
+        this.reset();
+        break;
+    }
+  }
+
+  private writeAnnexure(n: number, body: string): void {
+    if (!this.currentDir) return;
+    const desc = this.taskByOrdinal.get(n) ?? '';
+    const header = `# Annexure ${n}\n\n${desc ? `**Task:** ${desc}\n\n` : ''}---\n\n`;
+    fs.writeFileSync(
+      path.join(this.currentDir, `annexure-${n}.md`),
+      header + body.trimEnd() + '\n',
+      'utf8',
+    );
+  }
+
+  private finish(): void {
+    if (this.currentDir && this.lastAnswer && this.query) {
+      const totalMs = this.startedAt ? Date.now() - this.startedAt : 0;
+      const ords = [...this.agentToOrdinal.values()].sort((a, b) => a - b);
+      const refs = ords
+        .map((n) => {
+          const desc = this.taskByOrdinal.get(n);
+          return `- [Annexure ${n}](./annexure-${n}.md)${desc ? ` — ${desc}` : ''}`;
+        })
+        .join('\n');
+      const stats = this.synthStats
+        ? ` · ${this.synthStats.tokens} synth tokens · ppl ${this.synthStats.ppl.toFixed(2)}`
+        : '';
+      const meta = `> ${new Date().toISOString()} · ${this.mode}${stats} · ${(totalMs / 1000).toFixed(1)}s`;
+      const annexureSection = refs
+        ? `\n---\n\n## Annexures\n\n${refs}\n`
+        : '';
+      const body = `# ${this.query}\n\n${meta}\n\n${this.lastAnswer.trim()}\n${annexureSection}`;
+      fs.writeFileSync(path.join(this.currentDir, 'report.md'), body, 'utf8');
+    }
+    this.reset();
+  }
+
+  private reset(): void {
+    this.currentDir = null;
+    this.inResearch = false;
+    this.spawnOrdinal = 0;
+    this.agentToOrdinal.clear();
+    this.taskByOrdinal.clear();
+    this.lastAnswer = null;
+    this.query = null;
+    this.mode = null;
+    this.startedAt = null;
+    this.synthStats = null;
+  }
+}

--- a/packages/harness-cli/templates/research/harness/runner-ctx.ts
+++ b/packages/harness-cli/templates/research/harness/runner-ctx.ts
@@ -1,0 +1,61 @@
+/**
+ * The runner ↔ harness seam — this harness's OWN edge substrate.
+ *
+ * `harness(ctx, events, commands)` reads `RunnerCtx` for the edge-shell concerns
+ * it cannot own: the persistent wind-down / cancel signals, the live resolved
+ * config, config persistence, and the model-reload restart request. A target's
+ * boot sets `RunnerCtx` before calling `harness`.
+ *
+ *   - cli   → {@link makeEdgeRunner}   (in-memory config, no-op reload, one boot)
+ *   - web   → {@link makeServedRunner} (per-session, tenant-isolated)
+ *
+ * (The reranker is NOT a Runner concern: the boot's `provisionAppModels` reads
+ * the enabled apps' `services` and publishes the reranker on `RerankerCtx` in the
+ * harness's scope — the same context `registry.enable` reads. So a harness that
+ * outgrows this template gets the SAME platform contract: a reranker-less Runner +
+ * `provisionAppModels` for services.)
+ *
+ * NOT a platform contract — `@lloyal-labs/host` speaks `ServedHarness`, never
+ * `Runner`. This is the reference harness's private substrate, reproduced so the
+ * template builds the pipeline itself.
+ */
+import { createContext } from "effection";
+import type { Signal } from "effection";
+import type { TraceWriter, BranchCheckpoint } from "@lloyal-labs/lloyal-agents";
+import type { Config, ConfigOrigin, SaveResult } from "./config-types.js";
+
+export interface Runner {
+  /** The live, resolved config (CLI > env > file > default). */
+  config(): Config;
+  /** Provenance of each resolved config field (for `config:updated` echoes). */
+  origin(): ConfigOrigin;
+  /** Persist a config patch to the config layer + reload; returns the new
+   *  resolved state. Edge-only in practice — never sent over the served wire. */
+  saveConfig(
+    patch: Partial<Config>,
+  ): SaveResult & { config: Config; origin: ConfigOrigin };
+  /** Persist a model/reranker/gpu change and request a runtime restart: the runner
+   *  tears down the current `SessionContext` + rebuilds, then re-instantiates
+   *  `harness` on the new context. The harness returns after calling this. No-op on
+   *  a served/edge runner (the model is a fixed residency for the run). */
+  reloadRuntime(patch: Partial<Config>): void;
+  /** Persistent graceful-wind-down signal (one per process, survives restarts). */
+  windDown: Signal<void, void>;
+  /** Persistent per-agent cancel signal (one per process, survives restarts). */
+  cancelAgent: Signal<{ agentId: number }, void>;
+  /** Observability sink threaded into `initAgents`. */
+  traceWriter: TraceWriter;
+  /** Replay-mode spine checkpoint (edge `--replay-trace`); null normally + served. */
+  replayCheckpoint: BranchCheckpoint | null;
+  /** `--findings-budget` cap (edge flag); undefined = default. */
+  findingsMaxChars: number | undefined;
+  /** 'oneshot' = non-TTY `--query`/JSONL (run once, no plan-review gate);
+   *  'interactive' = Ink or the fork-IPC / wss bridge (the command loop). */
+  mode: "interactive" | "oneshot";
+  /** The `--query` to auto-submit (interactive, first iteration) or run (oneshot). */
+  initialQuery: string | undefined;
+  /** True only on the runner's first boot iteration — gates the `--query` auto-submit. */
+  isFirstIteration: boolean;
+}
+
+export const RunnerCtx = createContext<Runner>("research.harness.runner");

--- a/packages/harness-cli/templates/research/harness/served-runtime.ts
+++ b/packages/harness-cli/templates/research/harness/served-runtime.ts
@@ -29,8 +29,8 @@ import type { Config, ConfigOrigin } from "./config-types.js";
  * via `process.env.LLOYAL_GPU` (rig's `createReranker` exposes no loadOptions
  * passthrough). A configured backend is an EXPLICIT deploy request → fail loud on
  * an unavailable variant (`LLOYAL_NO_FALLBACK`, never overriding a user-set one)
- * instead of silently loading on CPU. With no gpu configured (Metal), any
- * inherited `LLOYAL_GPU` is CLEARED — config stays the sole source of truth.
+ * instead of silently loading on CPU. With no gpu configured, any inherited
+ * `LLOYAL_GPU` is CLEARED — config stays the sole source of truth.
  */
 export function applyServedGpuEnv(cfg: Config): void {
   const gpu = cfg.model.gpu;

--- a/packages/harness-cli/templates/research/harness/served-runtime.ts
+++ b/packages/harness-cli/templates/research/harness/served-runtime.ts
@@ -126,7 +126,7 @@ export function makeServedRunner(cfg: Config): Runner {
         origin: EPHEMERAL_ORIGIN,
       };
     },
-    reloadRuntime() {
+    reloadRuntime(_patch: Partial<Config>) {
       // No-op — the model is a fixed host residency; it can't rebuild per Session.
     },
     windDown,
@@ -168,7 +168,7 @@ export function makeEdgeRunner(cfg: Config): Runner {
         origin: EPHEMERAL_ORIGIN,
       };
     },
-    reloadRuntime() {
+    reloadRuntime(_patch: Partial<Config>) {
       // No-op — the CLI boot owns the SessionContext lifetime; a /model or /gpu
       // change can't rebuild it mid-run. The harness `return`s right after
       // calling this, ending the current run cleanly.

--- a/packages/harness-cli/templates/research/harness/served-runtime.ts
+++ b/packages/harness-cli/templates/research/harness/served-runtime.ts
@@ -1,0 +1,197 @@
+/**
+ * The harness's edge/served compute substrate — the harness-FREE half.
+ *
+ * The per-session `SessionContext` factory + the `Runner` factories (edge + served),
+ * split from the `Runner` *interface* ({@link ./runner-ctx}) and from the
+ * harness-RUNNING `runServedSession` ({@link ./served-session}) so these factories
+ * import neither the `harness` nor its `.eta` prompts — a web driver imports this
+ * file (only `createServedContext`/`createServedChannels`) without pulling esbuild.
+ *
+ * Copied from reasoning.run's `served-runtime.ts`. A served host materialises one
+ * `SessionContext` per admitted Session over one resident model; lloyal.node's
+ * ModelRegistry weak-caches the model by path, so the Nth session shares the
+ * resident weights + only allocates a fresh KV context. The reranker is NOT built
+ * here — `provisionAppModels` (in `runServedSession` / the cli boot) loads it and
+ * publishes it on `RerankerCtx`, so no factory here touches it.
+ */
+import { createSignal } from "effection";
+import type { Signal } from "effection";
+import { createContext as createNativeContext } from "@lloyal-labs/lloyal.node";
+import type { SessionContext } from "@lloyal-labs/sdk";
+import { NullTraceWriter } from "@lloyal-labs/lloyal-agents";
+import { createBus, type EventBus } from "@lloyal-labs/binding";
+import type { Runner } from "./runner-ctx.js";
+import type { WorkflowEvent, Command } from "./protocol.js";
+import type { Config, ConfigOrigin } from "./config-types.js";
+
+/**
+ * Steer the native backend for BOTH the resident model context AND the reranker
+ * via `process.env.LLOYAL_GPU` (rig's `createReranker` exposes no loadOptions
+ * passthrough). A configured backend is an EXPLICIT deploy request → fail loud on
+ * an unavailable variant (`LLOYAL_NO_FALLBACK`, never overriding a user-set one)
+ * instead of silently loading on CPU. With no gpu configured (Metal), any
+ * inherited `LLOYAL_GPU` is CLEARED — config stays the sole source of truth.
+ */
+export function applyServedGpuEnv(cfg: Config): void {
+  const gpu = cfg.model.gpu;
+  if (gpu) {
+    process.env.LLOYAL_GPU = gpu;
+    if (process.env.LLOYAL_NO_FALLBACK === undefined) {
+      process.env.LLOYAL_NO_FALLBACK = "1";
+    }
+  } else if (process.env.LLOYAL_GPU !== undefined) {
+    delete process.env.LLOYAL_GPU;
+  }
+}
+
+/**
+ * Build one `SessionContext` over the resident model. Called once per admitted
+ * Session (in the host's `materialise`); lloyal.node's ModelRegistry weak-caches
+ * the model by path, so the Nth call shares the resident weights and only
+ * allocates a fresh KV context.
+ */
+export function createServedContext(cfg: Config): Promise<SessionContext> {
+  const modelPath = cfg.model.path;
+  if (!modelPath) {
+    throw new Error(
+      "createServedContext: cfg.model.path is required (the host's resident model)",
+    );
+  }
+  applyServedGpuEnv(cfg);
+  return createNativeContext(
+    {
+      modelPath,
+      nCtx: cfg.model.nCtx ?? 32768,
+      nSeqMax: 24,
+      typeK: "q4_0",
+      typeV: "q4_0",
+    },
+    cfg.model.gpu ? { gpuVariant: cfg.model.gpu } : undefined,
+  );
+}
+
+// A runner config isn't sourced from CLI/env/file — it's in-memory/deploy state.
+// Every field reads as `default` for the composer's provenance hints.
+const EPHEMERAL_ORIGIN: ConfigOrigin = {
+  reasoningMode: "default",
+  modelPath: "default",
+  reranker: "default",
+  nCtx: "default",
+  gpu: "default",
+  outputDir: "default",
+};
+
+/** Deep-merge a `saveConfig` patch into a config — the same nested-object merge
+ *  the file loader used, but purely in-memory. */
+function mergeConfig(base: Config, patch: Partial<Config>): Config {
+  const sources = { ...base.sources, ...(patch.sources ?? {}) };
+  const model = { ...base.model, ...(patch.model ?? {}) };
+  if (sources.outputDir === "") delete sources.outputDir;
+  return {
+    ...base,
+    ...patch,
+    version: 1,
+    sources,
+    apps: { ...base.apps, ...(patch.apps ?? {}) },
+    defaults: { ...base.defaults, ...(patch.defaults ?? {}) },
+    model,
+  };
+}
+
+/**
+ * Build the served `Runner` for ONE Session. Everything here is per-session: its
+ * OWN config clone (in-memory `saveConfig`), fresh wind-down / cancel signals, and
+ * a null trace sink — so no runner state and no user data crosses between tenants.
+ * The reranker is NOT a Runner concern: `runServedSession`'s `provisionAppModels`
+ * publishes a per-session reranker on `RerankerCtx` in the harness's scope.
+ * `reloadRuntime` is a no-op: the model is a fixed host residency, so a /model or
+ * /gpu change can't rebuild it — the harness's unconditional `return` after calling
+ * it simply ends that Session.
+ */
+export function makeServedRunner(cfg: Config): Runner {
+  let sessionConfig = structuredClone(cfg);
+  const windDown = createSignal<void, void>();
+  const cancelAgent = createSignal<{ agentId: number }, void>();
+  const traceWriter = new NullTraceWriter();
+  return {
+    config: () => sessionConfig,
+    origin: () => EPHEMERAL_ORIGIN,
+    saveConfig(patch) {
+      sessionConfig = mergeConfig(sessionConfig, patch);
+      return {
+        path: "<served>",
+        gitignored: false,
+        skipped: [],
+        config: sessionConfig,
+        origin: EPHEMERAL_ORIGIN,
+      };
+    },
+    reloadRuntime() {
+      // No-op — the model is a fixed host residency; it can't rebuild per Session.
+    },
+    windDown,
+    cancelAgent,
+    traceWriter,
+    replayCheckpoint: null,
+    findingsMaxChars: undefined,
+    mode: "interactive",
+    initialQuery: undefined,
+    isFirstIteration: true,
+  };
+}
+
+/**
+ * Build the CLI edge `Runner` — this template's edge substrate. An in-memory,
+ * ephemeral mirror of {@link makeServedRunner}: `saveConfig` mutates a private
+ * clone (so /output-dir, /effort survive within a session but not across
+ * restarts — a cold path, fine for an austere CLI), `reloadRuntime` is a no-op
+ * (the boot owns the `SessionContext` lifetime; a config change that would
+ * rebuild it just ends the run), a NullTraceWriter, no replay, `interactive`
+ * mode. The reranker is NOT here: the boot's `provisionAppModels` publishes it on
+ * `RerankerCtx` before `harness` runs, exactly as reasoning.run's edge boot does.
+ */
+export function makeEdgeRunner(cfg: Config): Runner {
+  let sessionConfig = structuredClone(cfg);
+  const windDown = createSignal<void, void>();
+  const cancelAgent = createSignal<{ agentId: number }, void>();
+  const traceWriter = new NullTraceWriter();
+  return {
+    config: () => sessionConfig,
+    origin: () => EPHEMERAL_ORIGIN,
+    saveConfig(patch) {
+      sessionConfig = mergeConfig(sessionConfig, patch);
+      return {
+        path: "<in-memory>",
+        gitignored: false,
+        skipped: [],
+        config: sessionConfig,
+        origin: EPHEMERAL_ORIGIN,
+      };
+    },
+    reloadRuntime() {
+      // No-op — the CLI boot owns the SessionContext lifetime; a /model or /gpu
+      // change can't rebuild it mid-run. The harness `return`s right after
+      // calling this, ending the current run cleanly.
+    },
+    windDown,
+    cancelAgent,
+    traceWriter,
+    replayCheckpoint: null,
+    findingsMaxChars: undefined,
+    mode: "interactive",
+    initialQuery: undefined,
+    isFirstIteration: true,
+  };
+}
+
+/** Build a fresh per-session event bus + command signal. A web driver pairs this
+ *  with {@link createServedContext} to satisfy the host's `materialise`. */
+export function createServedChannels(): {
+  uiChannel: EventBus<WorkflowEvent>;
+  commands: Signal<Command, void>;
+} {
+  return {
+    uiChannel: createBus<WorkflowEvent>(),
+    commands: createSignal<Command, void>(),
+  };
+}

--- a/packages/harness-cli/templates/research/harness/served-session.ts
+++ b/packages/harness-cli/templates/research/harness/served-session.ts
@@ -1,0 +1,57 @@
+/**
+ * Served (B-host) placement — the harness-RUNNING half. Isolated from the
+ * factories in `./served-runtime` because it imports the `harness` (and thus its
+ * `.eta` prompts): anything importing this file must be esbuilt with
+ * `--loader:.eta=text`, never run as raw `tsx`. The web target's `serve.ts`
+ * injects this as the host's `run`.
+ *
+ * SNAPSHOT: reasoning.run @ main (src/served-session.ts).
+ */
+import type { Operation, Signal } from "effection";
+import type { SessionContext } from "@lloyal-labs/sdk";
+import type { EventBus } from "@lloyal-labs/binding";
+import { provisionAppModels } from "@lloyal-labs/rig/node";
+import { harness, apps } from "./harness.js";
+import { RunnerCtx } from "./runner-ctx.js";
+import { applyServedGpuEnv, makeServedRunner } from "./served-runtime.js";
+import type { WorkflowEvent, Command } from "./protocol.js";
+import type { Config } from "./config-types.js";
+
+/**
+ * Run ONE served Session end to end: provision its per-session reranker + app
+ * services (its OWN reranker KV context over the shared resident weights, so
+ * tenant documents never cross the reranker context), build the served `Runner`,
+ * publish it on `RunnerCtx`, and run the UNCHANGED `harness(...)` over this
+ * Session. `provisionAppModels` reads the corpus/web apps' static
+ * `services: ['reranker']`, loads the reranker, and publishes it on `RerankerCtx`
+ * in THIS scope — the scope `harness()` runs in, so `registry.enable` injects it.
+ * The host `spawn`s this as the per-session child; its scope owns BOTH the
+ * reranker resource (disposes on teardown) and the `RunnerCtx` binding, so N
+ * sessions share no runner state and no native reranker context.
+ *
+ * `cfg.model.reranker` is `serve.ts`'s resolved (digest-verified) reranker path →
+ * a `{path}` spec rig uses as-is (no re-fetch). `applyServedGpuEnv(cfg)` runs
+ * FIRST so the reranker load below (rig has no loadOptions passthrough) rides the
+ * same `LLOYAL_GPU` as the resident context.
+ *
+ * The last three params ARE the `harness(ctx, events, commands)` signature — the
+ * driver forwards the `{context, uiChannel, commands}` it materialised for the host.
+ */
+export function* runServedSession(
+  cfg: Config,
+  ctx: SessionContext,
+  events: EventBus<WorkflowEvent>,
+  commands: Signal<Command, void>,
+): Operation<void> {
+  applyServedGpuEnv(cfg);
+  yield* provisionAppModels({
+    apps,
+    projectRoot: process.cwd(),
+    reranker: cfg.model.reranker ? { path: cfg.model.reranker } : undefined,
+    // 10 leases (2 for trunk + queryBranch, 8 effective scoring leaves); nCtx
+    // 16384 (rig defaults 4096) sizes the reranker for longer rerank inputs.
+    rerankerLoad: { nSeqMax: 10, nCtx: 16384 },
+  });
+  yield* RunnerCtx.set(makeServedRunner(cfg));
+  yield* harness(ctx, events, commands);
+}

--- a/packages/harness-cli/templates/research/harness/short-path.ts
+++ b/packages/harness-cli/templates/research/harness/short-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Collapse a home-prefixed absolute path to `~/...` for display.
+ *
+ * Browser-safe by design — NO `node:os`/`node:path`, so it can sit in the
+ * `reduce` graph that `reasoning.run/state` re-exports (a renderer imports
+ * that surface). Reads $HOME/$USERPROFILE from a guarded `process.env` where a
+ * `process` global exists (Node), and returns the path unchanged in a browser
+ * or for any path outside home. Its inverse — `resolvePath` (`~` expansion for
+ * config
+ * input, genuinely `node:`) — stays in `./path-utils`, the runner-side module.
+ */
+export function shortPath(p: string): string {
+  if (!p) return p;
+  const env = (
+    globalThis as { process?: { env?: Record<string, string | undefined> } }
+  ).process?.env;
+  const home = env?.HOME ?? env?.USERPROFILE;
+  if (
+    home &&
+    (p === home || p.startsWith(home + "/") || p.startsWith(home + "\\"))
+  ) {
+    return "~" + p.slice(home.length);
+  }
+  return p;
+}

--- a/packages/harness-cli/templates/research/harness/state-core.ts
+++ b/packages/harness-cli/templates/research/harness/state-core.ts
@@ -1,0 +1,430 @@
+/**
+ * Ink TUI — AppState shape.
+ *
+ * Populated by reducer.ts from StepEvent + AgentEvent. Components render
+ * from this state and nothing else; no ambient ANSI, no side-effect logging.
+ *
+ * Layout model: each research agent owns a vertical `timeline` of items
+ * (think blocks, tool calls, tool results, reports). Flat mode renders those
+ * timelines as side-by-side columns; chain mode stacks them vertically.
+ */
+
+import type { Config, ConfigOrigin } from './config-types.js';
+
+export type Phase = 'idle' | 'recon' | 'query' | 'plan' | 'research' | 'synth' | 'done';
+
+/** Drives which top-level view the App renders. Distinct from `phase` —
+ *  `phase` tracks the workflow progress; `uiPhase` tracks what the user
+ *  currently interacts with. */
+export type UiPhase =
+  | 'boot'           // before config:loaded
+  | 'downloading'    // model cache miss — spinner + per-file progress bars
+  | 'loading'        // createContext / createReranker running; single spinner
+  | 'composer'       // query input, source/mode editing
+  | 'discovering'    // pre-flight recon agent probing sources; streams live
+  | 'planning'       // planner running, spinner
+  | 'plan_review'    // plan dialog visible, accept/edit/change-mode
+  | 'clarifying'     // planner asked questions; composer takes the answer
+  | 'research'       // column layout streaming
+  | 'done'           // research complete, results visible, composer below
+  | 'boot_error'     // download/load failed; recovery via /model or /quit
+  | 'backend_pack_offer'; // CUDA pack available — Download / Not now dialog
+
+/** User-facing reasoning mode. 'deep' == chain-shaped orchestration
+ *  (sequential tasks that build on each other); 'flat' == parallel-shaped
+ *  orchestration (orthogonal tasks running concurrently). One encoding
+ *  everywhere — no 'chain' alias. */
+export type Mode = 'flat' | 'deep';
+
+/** One cited source, extracted CONSUMER-side from a tool result (the App
+ *  Protocol prescribes no result schema). Web tools populate url/title/snippet
+ *  today; image (og:image) + icon (favicon) arrive once the web app ≥1.2.0
+ *  emits them. App-agnostic — corpus/other apps fill whatever subset applies. */
+export interface SourceMeta {
+  url?: string;
+  title?: string;
+  snippet?: string;
+  /** og:image URL (or a local cache ref once the engine inlines it). */
+  image?: string;
+  /** favicon URL. */
+  icon?: string;
+  /** Display host, derived from url when present. */
+  host?: string;
+}
+
+/** Per-agent chronological stream item. Column.tsx renders one component
+ *  per kind. `live: true` on a think item means its body is currently
+ *  streaming tokens and should render with a `▎` cursor. */
+export type TimelineItem =
+  | {
+      kind: 'think';
+      id: number;
+      title: string;
+      body: string;
+      live: boolean;
+      openedAt: number;
+      closedAt: number | null;
+    }
+  | {
+      kind: 'tool_call';
+      id: number;
+      tool: string;
+      argsSummary: string;
+    }
+  | {
+      kind: 'tool_result';
+      id: number;
+      tool: string;
+      /** Optional back-reference to the tool_call id this result pairs with.
+       *  Column renderer indents results under their matching call. */
+      callId: number | null;
+      byteLength: number;
+      preview: string | null;
+      hosts: string[];
+      resultCount: number | null;
+      /** Per-source citation metadata extracted from the tool's (free-form)
+       *  result — the App Protocol prescribes no result schema, so this is a
+       *  CONSUMER-side convention parsed in summarizeResult from known tool
+       *  shapes (web_search/fetch_page already return url+title+snippet;
+       *  fetch_page additionally emits og:image + favicon once web ≥1.2.0).
+       *  Drives the per-page rows in the Sources ledger. Empty/undefined for
+       *  tools that surface no per-source data (grep, corpus search). */
+      sources?: SourceMeta[];
+    }
+  | {
+      kind: 'report';
+      id: number;
+      body: string;
+      tokenCount: number;
+    };
+
+export interface AgentRuntime {
+  id: number;
+  label: string;                          // "A0", "A1", …
+  phase: 'idle' | 'thinking' | 'content' | 'tool' | 'done' | 'failed';
+  tokenCount: number;
+  toolCallCount: number;
+  /** Wall-clock spawn time (ms) — start of this task's elapsed timer. */
+  startedAt: number;
+  /** Wall-clock completion time (ms), set when the agent reaches `done`
+   *  (agent:return / agent:recovered). Null while running. Elapsed =
+   *  (endedAt ?? now) − startedAt. */
+  endedAt: number | null;
+  /** Research task index this agent was spawned for. Null for synth. */
+  taskIndex: number | null;
+  /** Short task description, used in the column header when present. */
+  taskDescription: string | null;
+  /** Chain-mode dependency hint ("builds on Task 1"), shown in header. */
+  dependencyHint: string | null;
+  /** Id of the currently-live think item in `timeline`, or null. */
+  currentThinkId: number | null;
+  /** Id of the most recent tool_call, paired with its tool_result when one lands. */
+  pendingToolCallId: number | null;
+  /** Live park-and-retry state for the pending tool call (rate-limited
+   *  provider; pool re-executes after the delay). Set on agent:tool_retry,
+   *  cleared when the eventual tool_result lands. Renders as
+   *  "rate-limited — retrying in ~Ns" so a waiting agent never reads as
+   *  hung. */
+  retry: { tool: string; retryAt: number; attempt: number } | null;
+  /** Live post-</think> token buffer. Tokens stream into this between
+   *  closing a think block and the next agent:tool_call / agent:report
+   *  (the model is writing tool-call JSON — the terminal `report` tool's body
+   *  lives inside that JSON, between `<parameter=result>` and `</parameter>`,
+   *  raw and unescaped). Renderers extract the live report body straight from
+   *  this buffer via `extractStreamingReport` below (consumed by Column.tsx's
+   *  ContentStream and the desktop renderer's Work.tsx) — same
+   *  marker-delimited technique the think block uses with `</think>`. Cleared
+   *  on tool_call / report (those fire structured items instead). */
+  contentBuffer: string;
+  /** True while the agent is being force-recovered: `agent:done` fired (the
+   *  agent stalled without a voluntary report) and `recoverInline` is streaming
+   *  a forced report under an EAGER report grammar (no `<think>`/`</think>`).
+   *  Routes those `agent:produce` tokens into `contentBuffer` (→ "Writing
+   *  report") instead of a think block, so a recovered report isn't mislabeled
+   *  as the agent "Thinking". Set on `agent:done`, cleared on
+   *  `agent:return`/`agent:recovered`. See docs/upstream-issues.md. */
+  recovering: boolean;
+  /** Set when the agent's forced recovery FAILED (e.g. KV exhausted mid-report
+   *  decode → `llama_decode failed`): no result was produced. Drives the terminal
+   *  failure glyph (a cross) + frozen timer instead of an eternal "Writing report"
+   *  spinner. Set on `agent:failed`; null otherwise. */
+  failReason: string | null;
+  /** Per-agent chronological stream. */
+  timeline: TimelineItem[];
+}
+
+/** Live report markdown from a raw Hermes terminal-tool buffer:
+ *  `…<parameter=result>\n<markdown>\n</parameter>…`. Raw <parameter> values are
+ *  unescaped, so no decoding — same idea as streaming a think block until </think>.
+ *  Returns the body (to the close marker, or buffer tail if not arrived), or null.
+ *  Null until the open marker arrives — that gating is what keeps non-terminal
+ *  tool-call args (search queries, URLs) from flashing as report prose. Callers
+ *  branch on `recovering` first: a forced recovery streams raw prose with no
+ *  envelope, so the buffer is used verbatim there. */
+export function extractStreamingReport(buffer: string): string | null {
+  const OPEN = '<parameter=result>';
+  const i = buffer.indexOf(OPEN);
+  if (i === -1) return null;
+  let body = buffer.slice(i + OPEN.length);
+  const c = body.indexOf('</parameter>');
+  if (c !== -1) body = body.slice(0, c);
+  return body.replace(/^\n/, '');
+}
+
+/** Append-only items rendered via Ink's `<Static>` so they get written to
+ *  terminal scrollback once and never re-render.
+ *
+ *  Two kinds:
+ *    - 'synth' — synth answer body (markdown), pushed at `synthesize:done`.
+ *    - 'agent' — a finished research agent's panel snapshot, pushed at
+ *      `agent:report`. The agent is also dropped from `researchAgentIds`
+ *      at that point so Narrative stops rendering it live.
+ *
+ *  Why this matters: anything in the dynamic tree that isn't actively
+ *  streaming triggers Ink's clearTerminal-on-overflow when the dynamic
+ *  tree exceeds viewport, wiping scrollback. Pushing completed content
+ *  to Static keeps the dynamic tree small and preserves scrollback. */
+export type ScrollbackItem =
+  | {
+      key: string;
+      kind: 'synth';
+      /** Streamed body content (markdown). */
+      body: string;
+    }
+  | {
+      key: string;
+      kind: 'agent';
+      /** Snapshot of the agent's runtime state at agent:report time.
+       *  Reducer state is immutable so this reference is stable —
+       *  subsequent reductions create new AgentRuntime objects rather
+       *  than mutating this one. */
+      agent: AgentRuntime;
+    };
+
+export interface Pressure {
+  pct: number;
+  cellsUsed: number;
+  nCtx: number;
+}
+
+export interface SynthState {
+  open: boolean;
+  buffer: string;
+  done: boolean;
+  stats: { tokens: number; toolCalls: number; ppl: number; timeMs: number } | null;
+}
+
+export interface OpTiming {
+  label: string;
+  tokens: number;
+  detail: string;
+  timeMs: number;
+}
+
+export interface DownloadStatus {
+  id: string;
+  label: string;
+  got: number;
+  total: number;
+  done: boolean;
+  /** True once `download:start` has fired for this entry. Distinguishes
+   *  queued (planned but not begun) from active (bytes flowing). */
+  started: boolean;
+  /** Most recent URL the streamer is pulling from. Updates if a fallback
+   *  kicks in (e.g., HF fails → R2 takes over mid-download). */
+  url?: string;
+}
+
+export interface Toast {
+  message: string;
+  tone: 'info' | 'success' | 'warn' | 'error';
+  /** Monotonic id so the view can animate/dismiss on change. */
+  id: number;
+}
+
+/** A signed entitlement disclosed by an app's catalog metadata. The `key`
+ *  maps to a privacy-label-style pill (network → Internet, etc.); `label`
+ *  is the human-readable name carried alongside it. */
+export interface AppEntitlement {
+  key: string;
+  label: string;
+}
+
+/** A view-ready descriptor for one installed (registry-enabled) AgentApp.
+ *  Joins the app's local manifest with its signed catalog metadata
+ *  (title/iconUrl/entitlements from apps.lloyal.ai) so the Settings drawer
+ *  can render the app card, its tools, its config schema, and its current
+ *  stored config. Built engine-side by main.ts and forwarded via the
+ *  `apps:state` event; the reducer drops it whole into `AppState.apps`. */
+export interface AppDescriptor {
+  /** manifest.name (e.g. "web") — routing key + config-store key. */
+  name: string;
+  /** catalog metadata.title ?? manifest.hints?.shortName ?? protocol.name */
+  title: string;
+  /** manifest.hints?.description ?? protocol.useWhen */
+  description: string;
+  /** catalog metadata.iconUrl (apps.lloyal.ai asset) — else undefined → glyph. */
+  iconUrl?: string;
+  /** manifest.protocol.tools — the protocol's tool-name list. */
+  tools: string[];
+  /** catalog metadata.entitlements — capability keys
+   *  (network|data-egress|local-files|credentials). */
+  entitlements: string[];
+  /** manifest.configSchema (JSON Schema) — fields render read-only this increment. */
+  configSchema?: unknown;
+  /** Current stored config from configStore.get(name). */
+  config: Record<string, unknown>;
+  /** Registry participation/enabled state. */
+  enabled: boolean;
+}
+
+export interface AppState {
+  query: string;
+  warm: boolean;
+  /** Top-level view state — drives App.tsx branching. */
+  uiPhase: UiPhase;
+  /** Payload for uiPhase 'backend_pack_offer'; null outside that phase. */
+  backendPackOffer: {
+    gpuName: string;
+    sizeBytes: number;
+    needsRuntime: boolean;
+    runtimeSizeBytes: number;
+    reasons: string[];
+  } | null;
+  /** Workflow phase — drives footer label, narrative visibility, etc. */
+  phase: Phase;
+  mode: Mode | null;
+  plan: {
+    intent: string;
+    tasks: { description: string; app?: string }[];
+    clarifyQuestions: string[];
+    tokenCount: number;
+    timeMs: number;
+  } | null;
+  agents: Map<number, AgentRuntime>;
+  /** Research agents in spawn order — drives the column layout. */
+  researchAgentIds: number[];
+  /** Pre-flight recon agents in spawn order — drives the Discovering view.
+   *  Kept separate from researchAgentIds so the two never cross-render; both
+   *  reuse the same Column timeline machinery. Cleared when the planner's
+   *  `query` event resets state for the run. */
+  reconAgentIds: number[];
+  /** Aggregate source count across all agents' tool_results (deduplicated
+   *  by host within a result). Rendered in the footer. */
+  sourceCount: number;
+  synth: SynthState;
+  answer: string | null;
+  pressure: Pressure | null;
+  timings: OpTiming[];
+  startedAt: number;
+  /** Accumulated milliseconds of pipeline-active time across the current
+   *  query's lifecycle (planning + research + synth). Excludes plan-review
+   *  dwell and composer idle. */
+  pipelineElapsedMs: number;
+  /** Timestamp (ms) of when the pipeline-active phase last resumed. Null
+   *  while paused (plan_review, composer, done). Live elapsed = paused
+   *  accumulator + (now - resume) while non-null. */
+  pipelineResumedAt: number | null;
+  /** Monotonic counters used by the reducer to assign stable ids. */
+  nextTimelineId: number;
+  nextLabelIdx: number;
+  /** Set by spine:task in chain mode; consumed by the next research agent:spawn. */
+  pendingTaskIndex: number | null;
+  /** Set by spine:task; descriptor copied onto the next spawned agent. */
+  pendingTaskDescription: string | null;
+  /** Count of research-phase spawns seen (flat mode uses this to assign taskIndex). */
+  researchSpawnCount: number;
+  /** Authoritative fork count from `research:start` (= plan.tasks.length at the
+   *  harness). The "Forked N agents" label prefers this over the live agent set
+   *  or plan.tasks, which can be empty/late on the renderer side. 0 until research starts. */
+  researchAgentCount: number;
+  /** Merged config from CLI > env > file > default. Null until config:loaded. */
+  config: Config | null;
+  /** Per-field origin — used to flag secrets as `(env)` in the composer. */
+  configOrigin: ConfigOrigin | null;
+  /** Most recent transient toast (e.g. "saved → harness.json"). */
+  toast: Toast | null;
+  /** Prefill for the composer when arriving from `edit_plan`. */
+  composerPrefill: string;
+  /** Set when the planner asks clarifying questions. Drives the clarifying
+   *  UI (questions stay visible above the composer while the user types
+   *  the answer) and carries the original query so main.ts can re-run the
+   *  planner with the Q&A as context. */
+  clarifyContext: {
+    originalQuery: string;
+    questions: string[];
+  } | null;
+  /** Active downloads (model cache misses). Rendered under BootStatus
+   *  while uiPhase === 'downloading'. Ordered by start time. */
+  downloads: DownloadStatus[];
+  /** Current "Loading weights…" / "Loading reranker…" label while
+   *  uiPhase === 'loading'. Null while the phase is inactive. */
+  loadingLabel: string | null;
+  nextToastId: number;
+  /** Append-only Static items (synth bodies). Persisted across queries so
+   *  prior answers stay in scrollback after a follow-up query starts. */
+  scrollback: ScrollbackItem[];
+  /** Corpus indexing summary — displayed in the Composer's Corpus chip
+   *  so the user can see how many files are in scope. Null until the
+   *  first `corpus:indexed` event lands; refreshes on path changes. */
+  corpusStatus: { fileCount: number; chunkCount: number } | null;
+  /** Set when boot fails (model/reranker download or load error). Renders
+   *  the error block + recovery prompt; the user can `/model <path>` or
+   *  `/reranker <path>` to retry with a local .gguf, or `/quit`. `kind`
+   *  determines which CTA is highlighted. Null once boot has progressed
+   *  past the failure or the recovery succeeded. */
+  bootError: { kind: 'llm' | 'reranker' | 'backend-pack'; message: string } | null;
+  /** Per-app participation in the next query, keyed by `manifest.name`.
+   *  `true` = included; `false` = configured-but-excluded (user opted out
+   *  for this session); missing key = treat as included by default. The
+   *  filter is applied at submit time in main.ts; `runQuery`'s
+   *  `appFilter` opt carries the included-names array. Reset to `true`
+   *  on reconfigure (`set_app_config`) — a config
+   *  change is a strong signal of intent to use the app. */
+  participation: Record<string, boolean>;
+  /** Installed AgentApps surfaced into the renderer — one descriptor per
+   *  registry-enabled app, joined with its signed catalog metadata. Drives
+   *  the Settings drawer. Re-emitted whole on boot completion and after
+   *  every registry enable/disable/config change. */
+  apps: AppDescriptor[];
+}
+
+export const initialState: AppState = {
+  query: '',
+  warm: false,
+  uiPhase: 'boot',
+  backendPackOffer: null,
+  phase: 'idle',
+  mode: null,
+  plan: null,
+  agents: new Map(),
+  researchAgentIds: [],
+  reconAgentIds: [],
+  sourceCount: 0,
+  synth: { open: false, buffer: '', done: false, stats: null },
+  answer: null,
+  pressure: null,
+  timings: [],
+  startedAt: Date.now(),
+  pipelineElapsedMs: 0,
+  pipelineResumedAt: null,
+  nextTimelineId: 0,
+  nextLabelIdx: 0,
+  pendingTaskIndex: null,
+  pendingTaskDescription: null,
+  researchSpawnCount: 0,
+  researchAgentCount: 0,
+  config: null,
+  configOrigin: null,
+  toast: null,
+  composerPrefill: '',
+  clarifyContext: null,
+  downloads: [],
+  loadingLabel: null,
+  nextToastId: 0,
+  scrollback: [],
+  corpusStatus: null,
+  bootError: null,
+  participation: {},
+  apps: [],
+};

--- a/packages/harness-cli/templates/research/harness/state.ts
+++ b/packages/harness-cli/templates/research/harness/state.ts
@@ -1,0 +1,13 @@
+/**
+ * How a view *accumulates* your events into renderable state — the
+ * renderer-neutral state surface.
+ *
+ * The pure `reduce` + `AppState` (and the state vocabulary) with NO Ink/React
+ * dependency, so every target view — the terminal (Ink), and later the desktop
+ * and web (React) — imports this ONE `reduce`. Only the small raw
+ * `WorkflowEvent` crosses a target boundary; the growing transcript never does,
+ * so the fold happens in the *sink*. The harness stays a pure emitter; each
+ * renderer stays a pure sink. Node-free so every runtime can import it.
+ */
+export { reduce } from "./reducer.js";
+export * from "./state-core.js";

--- a/packages/harness-cli/templates/research/harness/weave-sources.ts
+++ b/packages/harness-cli/templates/research/harness/weave-sources.ts
@@ -1,0 +1,87 @@
+/**
+ * DRB citation weave — deterministic post-processing that turns a research
+ * agent's `report()` result into already-inline-cited text.
+ *
+ * Background: DeepResearch-Bench's FACT metric scores 0 when a report carries
+ * no inline `[title](url)` citations at its claims (an end-of-document Sources
+ * list does not count). At 4B scale the synthesizer mirrors the citation FORMAT
+ * of its input rather than obeying an abstract "cite inline" mandate — so the
+ * durable fix is to seed the format in the findings themselves. The `report()`
+ * terminal tool carries a grammar-forced `sources: [{title, url}]` field (built
+ * via rig's `ReportTool({ extraProperties, extraRequired })` schema seam); this
+ * helper weaves that structured array into the findings string at result
+ * capture, so synthesis input + annexures are already inline-cited.
+ *
+ * Semantics: for each {title, url} — replace every BARE occurrence of the exact
+ * url with `[title](url)`, SKIPPING urls already inside a markdown link (preceded
+ * by `](`) or inside parens (preceded by `(`), and STOPPING at a url boundary so
+ * a shorter source url that is a prefix of a longer url in the body is not
+ * corrupted; then append a trailing `Sources:` list. Sources are de-duplicated by
+ * url and processed LONGEST-url-first so a shorter prefix url (`https://x.com`)
+ * can't corrupt a longer occurrence (`https://x.com/page`). Pure + defensive: a
+ * non-string result or an empty/absent/non-array `sources` returns `result`
+ * unchanged. No new fields and no type changes on the capture seam — the result
+ * stays a plain string.
+ */
+
+/** Structured source as emitted in the `report()` tool's `sources` field. */
+export interface WeaveSource {
+  title: string;
+  url: string;
+}
+
+// A source url must not wrap when the very next character continues a url — else
+// a declared root like `https://a.io` would corrupt a longer body url such as
+// `https://a.io/guide` into `[A](https://a.io)/guide`, and a query string
+// (`.../data?year=2024`) would be severed from its link. Two lookaheads:
+//   1. the next char is NOT a direct url-continuation char, AND
+//   2. the next char is not a `.` that itself continues the url — i.e. a `.`
+//      followed by a word char or `/` (a file extension like `.pdf`, a longer
+//      domain like `.co.uk`, a subdomain). A `.` at end-of-string or before
+//      whitespace/punctuation is a sentence terminator, so a sentence-final
+//      `https://a.io.` still wraps (period left outside the link).
+const URL_BOUNDARY = "(?![\\w/?#=&~%+@:-])(?!\\.[\\w/])";
+
+export function weaveSourcesIntoResult(result: string, sources: unknown): string;
+export function weaveSourcesIntoResult(result: unknown, sources: unknown): unknown;
+export function weaveSourcesIntoResult(result: unknown, sources: unknown): unknown {
+  if (typeof result !== "string" || !Array.isArray(sources) || sources.length === 0) {
+    return result;
+  }
+
+  const seen = new Set<string>();
+  const clean: WeaveSource[] = [];
+  for (const s of sources as unknown[]) {
+    if (!s || typeof s !== "object") continue;
+    const rec = s as { url?: unknown; title?: unknown };
+    if (typeof rec.url !== "string" || typeof rec.title !== "string") continue;
+    const url = rec.url.trim();
+    const title = rec.title.trim();
+    if (!url || !title || seen.has(url)) continue;
+    seen.add(url);
+    clean.push({ url, title });
+  }
+
+  // Longest url first — a shorter prefix url must not corrupt a longer occurrence.
+  clean.sort((a, b) => b.url.length - a.url.length);
+
+  let out = result;
+  const lines: string[] = [];
+  for (const { url, title } of clean) {
+    // Escape `[`/`]` in the title so a bracketed page title (e.g. "Foo [2024]")
+    // can't break the `[title](url)` markdown link syntax.
+    const safeTitle = title.replace(/[[\]]/g, "\\$&");
+    const esc = url.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    // Capture a preceding `](` (already a link target) or `(` (parens) so those
+    // occurrences are left untouched; a bare occurrence has no prefix → wrap it.
+    // The trailing boundary stops a wrap part-way through a longer url.
+    const re = new RegExp("(\\]\\(|\\()?" + esc + URL_BOUNDARY, "g");
+    out = out.replace(re, (m, pre) => (pre ? m : `[${safeTitle}](${url})`));
+    lines.push(`- [${safeTitle}](${url})`);
+  }
+
+  if (lines.length > 0) {
+    out = out + "\n\nSources:\n" + lines.join("\n");
+  }
+  return out;
+}

--- a/packages/harness-cli/templates/research/package.json
+++ b/packages/harness-cli/templates/research/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "__NAME__",
+  "version": "0.1.0",
+  "private": true,
+  "description": "A grounded multi-agent research harness scaffolded by `harness.dev`. SNAPSHOT: reasoning.run @ 0.8.0.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "__NAME__": "bin/run.js"
+  },
+  "files": [
+    "bin/",
+    "dist/",
+    "harness.yml",
+    "prompts/",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "esbuild targets/cli/index.ts --bundle --platform=node --format=esm --packages=external --loader:.eta=text --outfile=dist/targets/cli/index.mjs",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.web.json && tsc -p tsconfig.electron.json",
+    "prestart": "npm run build",
+    "start": "node bin/run.js",
+    "dev:desktop": "npm run build && electron-vite dev",
+    "build:desktop": "npm run build && electron-vite build",
+    "serve": "esbuild targets/web/serve.ts --bundle --platform=node --format=esm --packages=external --loader:.eta=text --outfile=dist/targets/web/serve.mjs && node bin/serve.js",
+    "dev:web": "vite --config targets/web/vite.web.config.ts",
+    "build:web": "vite build --config targets/web/vite.web.config.ts"
+  },
+  "dependencies": {
+    "@inkjs/ui": "^2.0.0",
+    "@lloyal-labs/binding": "^0.1.0",
+    "@lloyal-labs/corpus-app": "https://apps.lloyal.ai/v1/bundles/lloyal__corpus-1.3.0.tgz",
+    "@lloyal-labs/host": "^0.1.0",
+    "@lloyal-labs/lloyal-agents": "^3.4.0",
+    "@lloyal-labs/lloyal.node": "^3.1.0",
+    "@lloyal-labs/rig": "^3.7.0",
+    "@lloyal-labs/sdk": "^3.0.3",
+    "@lloyal-labs/web-app": "https://apps.lloyal.ai/v1/bundles/lloyal__web-1.3.0.tgz",
+    "effection": "^4.0.2",
+    "eta": "^4.5.1",
+    "ink": "^5.0.1",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "ws": "^8.18.0",
+    "yaml": "^2.9.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "@types/ws": "^8.5.13",
+    "@vitejs/plugin-react": "^5.0.0",
+    "electron": "^42.0.0",
+    "electron-vite": "^5.0.0",
+    "esbuild": "^0.28.0",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3",
+    "vite": "^7.0.0"
+  }
+}

--- a/packages/harness-cli/templates/research/prompts/plan-flat.eta
+++ b/packages/harness-cli/templates/research/prompts/plan-flat.eta
@@ -1,0 +1,88 @@
+You're a research planner. You analyze a user query and pick ONE of three dispositions, producing a JSON plan. Output JSON only.
+---
+The query: "<%= it.query %>"
+
+Your output must commit to a single `intent`:
+
+**intent: "clarify"** — the query is genuinely ambiguous and you cannot proceed without user input. Return 1-3 specific `clarifyQuestions` that would unblock you. Do not use this for "more detail would be nice" — only for genuine ambiguity that makes research infeasible.
+
+**intent: "passthrough"** — the query is a follow-up answerable from the conversation history already visible in your context (prior assistant turns with their findings). No new research is needed; the harness will stream a direct answer from the existing context. Use this for questions like "what did you mean by X?", "summarize the second section", "compare A and B from your earlier findings". DO NOT use passthrough when the user has introduced new entities or shifted topic in a way that requires fresh research.
+
+**intent: "research"** — the query needs a full research pipeline. Emit 1-<%= it.count %> research `tasks` as a flat, parallel plan.
+
+For research intent, the rules for the `tasks` array:
+
+1. **Tasks are orthogonal.** Each task covers a distinct facet of the query and can be researched independently. Agents run concurrently and do NOT see each other's findings — no task can depend on another task's output.
+
+2. **Descriptions are self-contained and independently researchable.** No cross-task references — phrases like "for the entities surfaced by task 1", "building on task 2's findings", or "among the projects identified in task 2" are FORBIDDEN. Every task must stand alone and be executable on its own without waiting for siblings.
+
+3. **Collectively exhaustive.** The union of tasks should cover the meaningful facets of the query. Think "what are the distinct lenses through which this query decomposes?" — not "what's the first step, then the second step?"
+
+4. **Vocabulary-loaded per-task.** Since there's no prior-task to lean on, each task must load its own technical vocabulary directly in its description. Name the modalities, frameworks, or entities the task should investigate — don't punt vocabulary discovery to a sibling.
+
+5. **Right-sized.** Each task answerable in 3-5 search/fetch cycles. Not "Research X" (too broad) and not "Find the exact phrase Y" (too narrow).
+
+6. **Route each task to its source (when sources are listed).** If the context below lists knowledge sources, set each task's `app` to the source that holds it, using the source's EXACT name. Ground this in the `Source coverage` probe results when present (they show which source actually has each entity) — fall back to each source's stated purpose otherwise. If two facets clearly belong to different sources, that's a good orthogonal split. Keep the description itself about WHAT to find — don't write "search the web for…" or "in the corpus". (When no sources are listed, omit `app` and just describe the facet.)
+
+GOOD research plan for "How do modern cancer immunotherapies achieve durable remission?":
+
+```json
+{
+  "intent": "research",
+  "tasks": [
+    { "description": "Survey checkpoint inhibitors (anti-PD-1, anti-PD-L1, anti-CTLA-4) — mechanisms, response rates, and long-term remission data in peer-reviewed oncology trials. Include durability metrics: objective response rate, progression-free survival, overall survival at 2-5 years." },
+    { "description": "Survey CAR-T cell therapies — mechanisms (CD19, BCMA targeting), manufacturing approaches, response rates in hematologic malignancies (ALL, DLBCL, multiple myeloma), and solid-tumor trial outcomes. Include durability metrics and conditioning-regimen impact." },
+    { "description": "Survey bispecific antibodies and T-cell engagers in oncology — named examples (blinatumomab, mosunetuzumab, teclistamab), mechanisms, clinical response durability, and trade-offs vs CAR-T." },
+    { "description": "Survey oncolytic viruses and cancer vaccines as immunotherapy modalities — named examples (talimogene laherparepvec, neoantigen vaccines), mechanisms, response rates, and durability in clinical trials." }
+  ]
+}
+```
+
+Notice that each task names its own scope and vocabulary directly. None reference another task. Each could run on its own agent and produce a standalone report. The harness fans in the four reports for synthesis. (Per-task `app` routing is omitted from this example — see rule 6 and the live `Source coverage` reports for routing decisions on your actual catalog.)
+
+GOOD passthrough for a follow-up after the above research completed: "What did you mean by cytokine release syndrome in the trade-offs section?":
+
+```json
+{ "intent": "passthrough" }
+```
+
+(No tasks, no clarifyQuestions — the harness will stream an answer from the prior assistant turn that's already in context.)
+
+GOOD clarify for an ambiguous query "What's the best model?":
+
+```json
+{
+  "intent": "clarify",
+  "clarifyQuestions": [
+    "Best at what task — language modeling, speech synthesis, image generation, or something else?",
+    "What constraints matter — local inference, cost, accuracy, latency?",
+    "Over what time horizon — currently available models or upcoming research?"
+  ]
+}
+```
+
+BAD — passthrough when new research is warranted. If the follow-up introduces a new entity or topic not covered by the prior research, use research intent, not passthrough.
+
+BAD — dependency chain, NOT orthogonal (for research intent):
+
+```json
+{
+  "intent": "research",
+  "tasks": [
+    { "description": "Survey the landscape of cancer immunotherapies and identify the named modalities that appear in recent reviews." },
+    { "description": "For the modalities surfaced by task 1, find specific remission-durability metrics." },
+    { "description": "For the modalities with the best long-term remission rates from task 2, investigate the specific mechanisms that drive durability." }
+  ]
+}
+```
+
+These depend on each other — task 2 can't start until task 1 has surfaced modalities, and task 3 needs task 2's metrics. In parallel execution, task 2 and 3 run concurrently with task 1 and CANNOT see its findings. Do NOT produce plans in this shape. If the query genuinely needs a dependency chain, the user should run in chain mode.
+
+BAD — individual task issues (for research intent):
+- "Research cancer immunotherapy." (too broad, no vocabulary)
+- "Find the exact 5-year overall survival number for pembrolizumab in NSCLC." (too narrow, single fact)
+- "Investigate the best modalities found by other tasks." (cross-task reference — forbidden in parallel)
+<% if (it.context) { -%>
+
+<%= it.context %>
+<% } -%>

--- a/packages/harness-cli/templates/research/prompts/plan.eta
+++ b/packages/harness-cli/templates/research/prompts/plan.eta
@@ -1,0 +1,89 @@
+You're a research planner. You analyze a user query and pick ONE of three dispositions, producing a JSON plan. Output JSON only.
+---
+The query: "<%= it.query %>"
+
+Your output must commit to a single `intent`:
+
+**intent: "clarify"** — the query is genuinely ambiguous and you cannot proceed without user input. Return 1-3 specific `clarifyQuestions` that would unblock you. Do not use this for "more detail would be nice" — only for genuine ambiguity that makes research infeasible.
+
+**intent: "passthrough"** — the query is a follow-up answerable from the conversation history already visible in your context (prior assistant turns with their findings). No new research is needed; the harness will stream a direct answer from the existing context. Use this for questions like "what did you mean by X?", "summarize the second section", "compare A and B from your earlier findings". DO NOT use passthrough when the user has introduced new entities or shifted topic in a way that requires fresh research.
+
+**intent: "research"** — the query needs a full research pipeline. Emit 1-`<%= it.count %>` research `tasks` as a chain-shaped plan.
+
+For research intent, the rules for the `tasks` array:
+
+1. **Task 1 is always landscape discovery.** It surveys the broad category the query belongs to and establishes vocabulary — the named projects, models, papers, or frameworks that later tasks will investigate. Task 1 should NOT try to answer any specific part of the query directly. Its only job is to identify entities and authoritative sources.
+
+2. **Tasks 2+ each build on what prior tasks will have surfaced.** Every task after task 1 must be written so it can't be fully answered without prior findings. Use phrases like "for the entities surfaced by task 1", "among the projects identified in task 2", or "deepen the benchmarks from task 2" in the description — these force a real dependency chain rather than independent slices.
+
+3. **Descriptions are self-contained at planning time.** Each description must be understandable on its own, written before any research has happened. For tasks 2+, pronoun-like references to prior tasks are resolved at runtime via the spine and count as self-contained. What's NOT allowed is inventing specific names: "investigate Moshi's architecture" presupposes you already found Moshi, which you haven't at planning time. Instead write: "investigate the architecture of the top end-to-end speech-to-speech models surfaced by task 1".
+
+4. **Right-sized.** Each task answerable in 3-5 search/fetch cycles. Not "Research X" (too broad) and not "Find the exact phrase Y" (too narrow).
+
+5. **Vocabulary-loaded.** Use the technical terms practitioners in that field would search for.
+
+6. **Route each task to its source (when sources are listed).** If the context below lists knowledge sources, set each task's `app` to the source that holds it, using the source's EXACT name. Ground this in the `Source coverage` probe results when present (they show which source actually has each entity) — fall back to each source's stated purpose otherwise. If a facet genuinely needs distinct, valuable content from two sources, split it into one task per source. Keep the description itself about WHAT to find — don't repeat the source name in prose. (When no sources are listed, omit `app` and just describe the facet.)
+
+GOOD research chain for "How do modern cancer immunotherapies achieve durable remission?":
+
+```json
+{
+  "intent": "research",
+  "tasks": [
+    { "description": "Survey the landscape of cancer immunotherapies — the named modalities (checkpoint inhibitors, CAR-T cell therapies, bispecific antibodies, oncolytic viruses, cancer vaccines) — that appear in recent clinical reviews, oncology guidelines, and peer-reviewed surveys." },
+    { "description": "For the modalities surfaced by task 1, find specific remission-durability metrics: objective response rate, progression-free survival, and overall survival at 2-5 years, reported in peer-reviewed clinical trials. Prefer sources with concrete numbers over qualitative claims." },
+    { "description": "For the modalities with the best long-term remission rates from task 2, investigate the specific mechanisms and regimens that drive durability: target antigen selection, conditioning protocols, combination strategies, T-cell engineering." },
+    { "description": "Survey the toxicity and access trade-offs for the modalities identified in task 1 — how each balances cytokine release syndrome, manufacturing complexity, and treatment cost against the durability benefits." }
+  ]
+}
+```
+
+Notice that tasks 2-4 each reference what earlier tasks will have surfaced. None of them can be answered in isolation. This is a real dependency chain — the KV spine carries useful signal between every task. (Per-task `app` routing is omitted from this example — see rule 6 and the live `Source coverage` reports for routing decisions on your actual catalog.)
+
+GOOD passthrough for a follow-up after the above research completed: "What did you mean by cytokine release syndrome in the trade-offs section?":
+
+```json
+{ "intent": "passthrough" }
+```
+
+(No tasks, no clarifyQuestions — the harness will stream an answer from the prior assistant turn that's already in context.)
+
+GOOD clarify for an ambiguous query "What's the best model?":
+
+```json
+{
+  "intent": "clarify",
+  "clarifyQuestions": [
+    "Best at what task — language modeling, speech synthesis, image generation, or something else?",
+    "What constraints matter — local inference, cost, accuracy, latency?",
+    "Over what time horizon — currently available models or upcoming research?"
+  ]
+}
+```
+
+BAD — passthrough when new research is warranted. If the follow-up introduces a new entity or topic not covered by the prior research, use research intent, not passthrough.
+
+BAD — orthogonal slices, NOT a chain (for research intent):
+
+```json
+{
+  "intent": "research",
+  "tasks": [
+    { "description": "Research checkpoint inhibitors" },
+    { "description": "Research CAR-T cell therapies" },
+    { "description": "Research bispecific antibodies" },
+    { "description": "Research oncolytic viruses" }
+  ]
+}
+```
+
+These are independent — each could run in isolation, none builds on any other, and the spine carries no useful signal between them. Do NOT produce plans in this shape even when the query naturally decomposes into parallel sub-aspects.
+
+BAD — individual task issues (for research intent):
+- "Research cancer immunotherapy." (too broad, no vocabulary)
+- "Find the exact 5-year overall survival number for pembrolizumab in NSCLC." (too narrow, single fact)
+- "Investigate the durability of pembrolizumab, tisagenlecleucel, and talimogene laherparepvec." (invents specific names before task 1 has surfaced them — use "surfaced by task 1" pronoun reference instead)
+<% if (it.context) { -%>
+
+<%= it.context %>
+<% } -%>

--- a/packages/harness-cli/templates/research/prompts/preflight-recover.eta
+++ b/packages/harness-cli/templates/research/prompts/preflight-recover.eta
@@ -1,0 +1,7 @@
+You are mapping source coverage and your probe was cut short — deliver the coverage now from the searches you already ran.
+
+Call `report` stating which parts of the query THIS source genuinely covers and which it does not — judged by whether the results you saw were actually on-topic, not by how many there were. Be honest; "covers nothing relevant here" is a valid, useful answer.
+
+About <%= it.budget %> words, 1-3 lines.
+---
+Report the coverage now.

--- a/packages/harness-cli/templates/research/prompts/preflight.eta
+++ b/packages/harness-cli/templates/research/prompts/preflight.eta
@@ -1,0 +1,21 @@
+You are a pre-flight reconnaissance agent. You probe ONE knowledge source and report what it actually covers for the user's query. Your report advises the planner about this source's strengths so it can route research tasks accordingly.
+
+Read the Contents advert below before searching. It tells you what this source actually contains. Treat topics named in the advert as covered. Treat acronyms in the query as referring to whatever the advert expands them to.
+
+Probe with the source's search tool: one short, entity-focused query per key entity in the query (~2 searches is enough for a shallow probe). Then call `report`.
+
+Judge by RELEVANCE, not count. Hits aren't proof of coverage — the search can return its closest matches even when nothing is truly relevant. Only count hits that are genuinely about the entity.
+
+`report` exactly once: 2-4 lines naming what this source covers, with one piece of concrete evidence per covered entity (a file you read, a specific page, a snippet you saw). Report only what you found; don't list what you didn't.
+---
+Source to probe: **<%= it.app.name %>** — <%= it.app.useWhen %>
+Search tool(s): <%= it.app.tools.join(", ") %>
+<% if (it.app.contents) { %>
+Contents:
+<%= it.app.contents %>
+<% } else { %>
+Contents: (this source has no static contents advert — judge entirely from probe results)
+<% } %>
+The query: "<%= it.query %>"
+
+Probe this source for the query's key entities, then report what you found.

--- a/packages/harness-cli/templates/research/prompts/recovery.eta
+++ b/packages/harness-cli/templates/research/prompts/recovery.eta
@@ -1,0 +1,10 @@
+You are a research reporter. The agent has been terminated due to budget constraints and must deliver findings now.
+
+Call the report tool with the most important findings from the research above. Prioritize in this order:
+1. Direct quotes and specific evidence that answer the task
+2. Key conclusions with source URLs / line references
+3. Supporting context (only if budget allows)
+
+IMPORTANT: You have approximately <%= it.budget %> words for your report. Be concise — if you exceed the budget your report will be cut off.
+---
+Report your findings.

--- a/packages/harness-cli/templates/research/prompts/synthesize-flat.eta
+++ b/packages/harness-cli/templates/research/prompts/synthesize-flat.eta
@@ -1,0 +1,117 @@
+You are writing an analytical research report that answers the user's question below.
+
+The findings below come from N research agents that ran in parallel. Each agent covered a distinct facet of the question independently — they did not see each other's work. Your job is to synthesize their fan-in into a single coherent argument.
+
+Your report is an ARGUMENT, not a catalog. The difference matters:
+- A catalog organizes findings by topic (hardware, quantization, TTS, LLMs) and lists what each agent found. Readers can rearrange the sections without changing the report.
+- An argument organizes findings by argumentative function (thesis, supporting evidence, complicating evidence, resolution, prescription). Each section exists to move the argument forward. Rearranging the sections breaks the logic.
+
+Produce an argument.
+
+══════════════════════════════════════════════════════════════════════
+RULE 0 — GROUNDING (overrides all other considerations)
+══════════════════════════════════════════════════════════════════════
+
+Every factual claim must be traceable to the findings below. "Factual claim" means: an entity (model, framework, library, paper, company, repository), a quantitative claim (benchmark number, VRAM, latency, size, percentage), a direct quote, a URL, or a concrete technical assertion (a technique, algorithm, or tradeoff that was evaluated).
+
+Do NOT introduce:
+- Models, frameworks, libraries, or papers the research did not name
+- Benchmark numbers the research did not measure or cite
+- Code examples or implementation snippets not shown in the research
+- Techniques, algorithms, or tuning strategies the research did not discuss
+- Architectural patterns, comparisons, or tradeoffs the research did not raise
+
+If the findings are silent on something important to the user's question, name that gap explicitly in your Limitations section rather than filling it from prior knowledge.
+
+Cite only URLs that appear verbatim in the findings below. Copy the URL exactly — never shorten, guess, or reconstruct it. Place every citation INLINE — in `[short source title](url)` form, right at the claim it supports — never collected only in a list at the end. Worked example (illustrative form; cite a REAL url from the findings): `The tool was released in March 2024 ([Release Notes](https://example.com/notes)).` If a claim's source URL is not in the findings, state the claim without a citation or cut it.
+
+══════════════════════════════════════════════════════════════════════
+RULE 1 — THESIS
+══════════════════════════════════════════════════════════════════════
+
+Commit to ONE thesis. State it in the opening paragraph. Every section that follows must advance that thesis.
+
+The thesis is a POSITION on the user's question, derived from the findings. Examples of the shape:
+- "Sub-100ms with native emotional nuance is not achievable with today's open-source stack — you must choose two of three."
+- "Local voice agents have solved latency; the frontier has shifted to empathy modeling."
+- "The market fragmentation reflects a deeper architectural split between cascading pipelines and end-to-end S2S models, and the right choice depends on N specific constraints."
+
+The thesis is NOT:
+- A restatement of the question
+- A list of findings ("we found that A, B, and C")
+- A hedge ("it depends on your needs")
+- Three competing framings left unresolved
+
+If the findings point to multiple competing theses, PICK ONE based on which is most strongly supported by the evidence across agents, state it explicitly, and treat the others as complicating evidence to resolve within the report.
+
+══════════════════════════════════════════════════════════════════════
+RULE 2 — STRUCTURE BY ARGUMENTATIVE FUNCTION
+══════════════════════════════════════════════════════════════════════
+
+Organize the report by what each section DOES in service of the thesis, not by which agent produced it. Use this arc:
+
+1. **Thesis (opening)** — state the position, name its load-bearing assumption
+2. **Supporting evidence** — the findings that establish the thesis is real
+3. **Complicating evidence** — the findings that pressure the thesis (counterexamples, exceptions, tradeoffs)
+4. **Resolution** — how the complications are reconciled; what specifically must be true for the thesis to hold
+5. **Prescription** — a concrete architectural/implementation recommendation that flows from the thesis
+6. **Conclusion** — restate the thesis with the prescription tied in, + ### Limitations subheading
+7. **Sources** — convenience index of URLs already cited inline; does NOT satisfy the citation requirement (a URL appearing only here is an uncited claim)
+
+Section HEADINGS should reflect argumentative function, not topic or agent. "The Empathy-Latency Tradeoff Emerges From Hardware Constraints" advances an argument. "Agent 1 Findings" or "Hardware" just labels a bucket.
+
+CRITICAL: Do NOT produce a report with sections named after the agent facets (e.g., "Task 1: checkpoint inhibitors", "Task 2: CAR-T", "Task 3: bispecifics") in sequence. That is the catalog shape reproducing the fan-in structure. Reject it. Cross-cut the facets — when a finding from task 2 supports a claim from task 1, put them in the same section.
+
+══════════════════════════════════════════════════════════════════════
+RULE 3 — PROSE AND NARRATIVE
+══════════════════════════════════════════════════════════════════════
+
+Write fluent, paragraph-based prose. A practitioner should be able to read the report end-to-end and understand the landscape.
+
+Use narrative connective tissue to link findings across agents:
+- "Building on what agent 1 surfaced about X, the evidence from agent 3 demonstrates..."
+- "The tradeoff between X and Y (agent 1) becomes concrete in the case of Z (agent 2)..."
+- "Unlike the approach in facet 1 (which prioritizes A), facet 3 takes the opposite approach by..."
+- "Taken together, the findings from agents 1, 2, and 3 point to a pattern where..."
+
+This connective tissue is interpretation, not invention — it draws out what the fan-in means when read as a whole, without adding entities or numbers that weren't found.
+
+Prefer fluent paragraphs over bulleted extracts. Use bulleted lists only for genuinely parallel items (side-by-side model comparisons, spec tables) — never as a substitute for argument.
+
+Tables serve the argument. A table comparing four models on three dimensions should support a claim being made in the prose, not stand alone as reference material.
+
+══════════════════════════════════════════════════════════════════════
+RULE 4 — CUTTING FINDINGS THAT DON'T SERVE THE THESIS
+══════════════════════════════════════════════════════════════════════
+
+The agents did thorough research. Not every finding belongs in the final report.
+
+If a finding does not advance, support, complicate, or resolve the thesis, either:
+- Mention it briefly and move on (one sentence), or
+- Cut it entirely.
+
+Do NOT include a finding because an agent found it. Include it because it serves the argument.
+
+A comprehensive but flat report is weaker than a focused argument that leaves some findings out. Comprehensiveness is a catalog virtue. Coherence is an argument virtue.
+
+══════════════════════════════════════════════════════════════════════
+HOW TO WRITE THE REPORT
+══════════════════════════════════════════════════════════════════════
+
+1. Read every agent's findings below.
+2. Take stock of the entities, sources, and quantitative claims the fan-in surfaced — these are your factual vocabulary, the only factual vocabulary you may use.
+3. Decide the thesis — one sentence that takes a position on the user's question, derived from what the findings collectively mean across agents.
+4. Identify which findings SUPPORT the thesis, which COMPLICATE it, and which are NOT RELEVANT to it. Don't bucket by which agent produced them — cross-cut.
+5. Draft the report with the structure above — thesis in the opening paragraph, sections that build the argument, prescription that flows from the resolution.
+6. For each section, write fluent paragraphs that cite findings inline (direct quotes, specific numbers, named sources). Every factual claim — every entity, number, quote, URL, or concrete technical assertion — must carry an inline citation in [source title](url) markdown form placed immediately at the claim, not deferred to the Sources list. A claim without an inline citation at its location is unsupported and must be cut or hedged. Bulleted extracts only when items are genuinely parallel.
+7. End with ## Conclusion (restating thesis + prescription, + ### Limitations naming specific gaps) and ## Sources — a convenience index of URLs ALREADY cited inline above. The Sources list does NOT satisfy the citation requirement: a URL that appears only in Sources, not inline at its claim, is an uncited claim.
+
+OUTPUT FORMAT: emit the markdown report directly as your reply. Do NOT wrap it in any tool call, JSON envelope, or `<tool_call>...</tool_call>` tags. Every factual claim in the body MUST carry its citation INLINE, in `[short source title](url)` form, right at the claim — e.g. `...grew 12% year over year ([Annual Report](https://example.com/report))` — not only in the Sources list. End naturally when the report is complete.
+---
+Research question: "<%= it.query %>"
+
+Findings from <%= it.agentCount %> parallel research agents:
+
+<%= it.findings %>
+
+Write the markdown report now.

--- a/packages/harness-cli/templates/research/prompts/synthesize.eta
+++ b/packages/harness-cli/templates/research/prompts/synthesize.eta
@@ -1,0 +1,113 @@
+You are writing an analytical research report that answers the user's question below.
+
+Above this message is the research that has been done: a series of conversation turns where each user turn asks a sub-question and the assistant turn that follows contains the findings for that sub-question.
+
+Your report is an ARGUMENT, not a catalog. The difference matters:
+- A catalog organizes findings by topic (hardware, quantization, TTS, LLMs) and lists what the research found on each. Readers can rearrange the sections without changing the report.
+- An argument organizes findings by argumentative function (thesis, supporting evidence, complicating evidence, resolution, prescription). Each section exists to move the argument forward. Rearranging the sections breaks the logic.
+
+Produce an argument.
+
+══════════════════════════════════════════════════════════════════════
+RULE 0 — GROUNDING (overrides all other considerations)
+══════════════════════════════════════════════════════════════════════
+
+Every factual claim must be traceable to the research turns above. "Factual claim" means: an entity (model, framework, library, paper, company, repository), a quantitative claim (benchmark number, VRAM, latency, size, percentage), a direct quote, a URL, or a concrete technical assertion (a technique, algorithm, or tradeoff that was evaluated).
+
+Do NOT introduce:
+- Models, frameworks, libraries, or papers the research did not name
+- Benchmark numbers the research did not measure or cite
+- Code examples or implementation snippets not shown in the research
+- Techniques, algorithms, or tuning strategies the research did not discuss
+- Architectural patterns, comparisons, or tradeoffs the research did not raise
+
+If the research is silent on something important to the user's question, name that gap explicitly in your Limitations section rather than filling it from prior knowledge.
+
+Cite only URLs that appear verbatim in the research turns above. Copy the URL exactly — never shorten, guess, or reconstruct it. Place every citation INLINE — in `[short source title](url)` form, right at the claim it supports — never collected only in a list at the end. Worked example (illustrative form; cite a REAL url from the research): `The tool was released in March 2024 ([Release Notes](https://example.com/notes)).` If a claim's source URL is not in the research turns, state the claim without a citation or cut it.
+
+══════════════════════════════════════════════════════════════════════
+RULE 1 — THESIS
+══════════════════════════════════════════════════════════════════════
+
+Commit to ONE thesis. State it in the opening paragraph. Every section that follows must advance that thesis.
+
+The thesis is a POSITION on the user's question, derived from the findings. Examples of the shape:
+- "Sub-100ms with native emotional nuance is not achievable with today's open-source stack — you must choose two of three."
+- "Local voice agents have solved latency; the frontier has shifted to empathy modeling."
+- "The market fragmentation reflects a deeper architectural split between cascading pipelines and end-to-end S2S models, and the right choice depends on N specific constraints."
+
+The thesis is NOT:
+- A restatement of the question
+- A list of findings ("we found that A, B, and C")
+- A hedge ("it depends on your needs")
+- Three competing framings left unresolved
+
+If the research points to multiple competing theses, PICK ONE based on which is most strongly supported by the findings, state it explicitly, and treat the others as complicating evidence to resolve within the report.
+
+══════════════════════════════════════════════════════════════════════
+RULE 2 — STRUCTURE BY ARGUMENTATIVE FUNCTION
+══════════════════════════════════════════════════════════════════════
+
+Organize the report by what each section DOES in service of the thesis, not by what topic it covers. Use this arc:
+
+1. **Thesis (opening)** — state the position, name its load-bearing assumption
+2. **Supporting evidence** — the findings that establish the thesis is real
+3. **Complicating evidence** — the findings that pressure the thesis (counterexamples, exceptions, tradeoffs)
+4. **Resolution** — how the complications are reconciled; what specifically must be true for the thesis to hold
+5. **Prescription** — a concrete architectural/implementation recommendation that flows from the thesis
+6. **Conclusion** — restate the thesis with the prescription tied in, + ### Limitations subheading
+7. **Sources** — convenience index of URLs already cited inline; does NOT satisfy the citation requirement (a URL appearing only here is an uncited claim)
+
+Section HEADINGS should reflect argumentative function, not topic. "The Empathy-Latency Tradeoff Emerges From Hardware Constraints" advances an argument. "Hardware Constraints" just labels a topic.
+
+Do NOT produce a report with sections named after the agents' research topics (e.g., "Task 1 findings", "Hardware", "Emotional Prosody", "Speaker Diarization") in sequence. That is the catalog shape. Reject it.
+
+══════════════════════════════════════════════════════════════════════
+RULE 3 — PROSE AND NARRATIVE
+══════════════════════════════════════════════════════════════════════
+
+Write fluent, paragraph-based prose. A practitioner should be able to read the report end-to-end and understand the landscape.
+
+Use narrative connective tissue to link findings into argument:
+- "Building on X's approach to Y, Z demonstrates..."
+- "The tradeoff between X and Y becomes concrete in the case of Z..."
+- "Unlike X (which prioritizes A), Y takes the opposite approach by..."
+- "Taken together, the findings on X, Y, and Z point to a pattern where..."
+
+This connective tissue is interpretation, not invention — it draws out what findings mean when read as a whole, without adding entities or numbers that weren't found.
+
+Prefer fluent paragraphs over bulleted extracts. Use bulleted lists only for genuinely parallel items (side-by-side model comparisons, spec tables) — never as a substitute for argument.
+
+Tables serve the argument. A table comparing four models on three dimensions should support a claim being made in the prose, not stand alone as reference material.
+
+══════════════════════════════════════════════════════════════════════
+RULE 4 — CUTTING FINDINGS THAT DON'T SERVE THE THESIS
+══════════════════════════════════════════════════════════════════════
+
+The agents did thorough research. Not every finding belongs in the final report.
+
+If a finding does not advance, support, complicate, or resolve the thesis, either:
+- Mention it briefly and move on (one sentence), or
+- Cut it entirely.
+
+Do NOT include a finding because the agents found it. Include it because it serves the argument.
+
+A comprehensive but flat report is weaker than a focused argument that leaves some findings out. Comprehensiveness is a catalog virtue. Coherence is an argument virtue.
+
+══════════════════════════════════════════════════════════════════════
+HOW TO WRITE THE REPORT
+══════════════════════════════════════════════════════════════════════
+
+1. Read every research turn above.
+2. Take stock of the entities, sources, and quantitative claims the research surfaced — these are your factual vocabulary, the only factual vocabulary you may use.
+3. Decide the thesis — one sentence that takes a position on the user's question, derived from what the findings collectively mean.
+4. Identify which findings SUPPORT the thesis, which COMPLICATE it, and which are NOT RELEVANT to it.
+5. Draft the report with the structure above — thesis in the opening paragraph, sections that build the argument, prescription that flows from the resolution.
+6. For each section, write fluent paragraphs that cite findings inline (direct quotes, specific numbers, named sources). Every factual claim — every entity, number, quote, URL, or concrete technical assertion — must carry an inline citation in [source title](url) markdown form placed immediately at the claim, not deferred to the Sources list. A claim without an inline citation at its location is unsupported and must be cut or hedged. Bulleted extracts only when items are genuinely parallel.
+7. End with ## Conclusion (restating thesis + prescription, + ### Limitations naming specific gaps) and ## Sources — a convenience index of URLs ALREADY cited inline above. The Sources list does NOT satisfy the citation requirement: a URL that appears only in Sources, not inline at its claim, is an uncited claim.
+
+OUTPUT FORMAT: emit the markdown report directly as your reply. Do NOT wrap it in any tool call, JSON envelope, or `<tool_call>...</tool_call>` tags. Every factual claim in the body MUST carry its citation INLINE, in `[short source title](url)` form, right at the claim — e.g. `...grew 12% year over year ([Annual Report](https://example.com/report))` — not only in the Sources list. End naturally when the report is complete.
+---
+Research question: "<%= it.query %>"
+
+Write the markdown report now.

--- a/packages/harness-cli/templates/research/targets/cli/index.ts
+++ b/packages/harness-cli/templates/research/targets/cli/index.ts
@@ -1,0 +1,162 @@
+/**
+ * The CLI target — where your research harness runs in a terminal.
+ *
+ * Generated for you and rarely touched. It does four things: resolve the
+ * resident reasoning model, provision the Services the enabled apps declare (the
+ * corpus/web apps need a reranker → `provisionAppModels` resolves + loads it and
+ * publishes it on `RerankerCtx`), build this harness's edge `Runner`, pick a
+ * surface, and run your harness over it. The surface pick is the whole "one
+ * harness, many targets" idea in miniature — the same `harness(ctx, events,
+ * commands)` mounts on Ink (a terminal), `ipc` (when a desktop shell forks this
+ * bin), or `ndjson` (a pipe), all over one binding.
+ *
+ * Both models are files in `models/<role>/`, resolved from `harness.yml` and —
+ * on first run — fetched + digest-verified by the platform (`rig.resolveModel`),
+ * with no API key. Drop your own `.gguf` into `models/llm/` (or point a `path:`
+ * at one) to skip the fetch entirely.
+ *
+ * SNAPSHOT: reasoning.run @ main
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+import { main, call, ensure, createSignal } from "effection";
+import { createBus } from "@lloyal-labs/binding";
+import { ipc, ndjson } from "@lloyal-labs/binding/node";
+import { createContext } from "@lloyal-labs/lloyal.node";
+import { resolveModel, provisionAppModels } from "@lloyal-labs/rig/node";
+import { harness, apps } from "../../harness/harness.js";
+import { RunnerCtx } from "../../harness/runner-ctx.js";
+import { makeEdgeRunner } from "../../harness/served-runtime.js";
+import type { Command, WorkflowEvent } from "../../harness/protocol.js";
+import type { Config } from "../../harness/config-types.js";
+import { renderCli } from "./view.js";
+
+interface ModelEntry {
+  id?: string;
+  path?: string;
+  context?: number;
+}
+interface HarnessConfig {
+  model?: { llm?: ModelEntry; reranker?: ModelEntry };
+}
+
+function loadConfig(): HarnessConfig {
+  let raw: string;
+  try {
+    raw = readFileSync(join(process.cwd(), "harness.yml"), "utf8");
+  } catch {
+    process.stderr.write("harness.yml not found — run from your harness project root.\n");
+    process.exit(1);
+  }
+  try {
+    return (parse(raw) ?? {}) as HarnessConfig;
+  } catch (err) {
+    process.stderr.write(
+      `harness.yml is not valid YAML: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
+  }
+}
+
+const config = loadConfig();
+const llm: ModelEntry = config.model?.llm ?? {};
+const context = llm.context ?? 32768;
+
+main(function* () {
+  // The reasoning model — a file in models/llm/, fetched + digest-verified on
+  // first run (no API key). rig owns the verified fetch; the boot just asks.
+  let modelPath: string;
+  let fetching = false;
+  try {
+    modelPath = yield* call(() =>
+      resolveModel({
+        projectRoot: process.cwd(),
+        role: "llm",
+        spec: { id: llm.id, path: llm.path },
+        onProgress: (got, total) => {
+          fetching = true;
+          const pct = total > 0 ? Math.round((100 * got) / total) : 0;
+          process.stderr.write(`\rfetching ${llm.id ?? "model"} — ${pct}%   `);
+        },
+      }),
+    );
+  } catch (err) {
+    process.stderr.write(`\n${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+  if (fetching) process.stderr.write("\n");
+
+  // The resident model context — one shared `llama_context`; the pipeline forks
+  // recon / research / synth branches over it as seq_ids.
+  const ctx = yield* call(() =>
+    createContext({
+      modelPath,
+      nCtx: context,
+      nSeqMax: 32,
+      typeK: "q4_0",
+      typeV: "q4_0",
+    }),
+  );
+
+  // Provision the Services the enabled apps declare — corpus + web both declare
+  // `services: ['reranker']`, so this resolves (fetch + digest-verify on first
+  // run, no key) + loads the cross-encoder and publishes it on RerankerCtx, which
+  // the harness's `registry.enable` reads. Reads the reranker spec from harness.yml
+  // (`model.reranker`), else the platform catalog default.
+  let fetchingReranker = false;
+  try {
+    yield* provisionAppModels({
+      apps,
+      projectRoot: process.cwd(),
+      reranker: config.model?.reranker,
+      // 10 leases (trunk + queryBranch + 8 scoring leaves); nCtx 16384 (rig
+      // defaults 4096) sizes the reranker for longer rerank inputs.
+      rerankerLoad: { nSeqMax: 10, nCtx: 16384 },
+      onProgress: (got, total) => {
+        fetchingReranker = true;
+        const pct = total > 0 ? Math.round((100 * got) / total) : 0;
+        process.stderr.write(`\rfetching reranker — ${pct}%   `);
+      },
+    });
+  } catch (err) {
+    process.stderr.write(`\n${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+  if (fetchingReranker) process.stderr.write("\n");
+
+  // The live, in-memory config the harness reads via RunnerCtx.
+  const cfg: Config = {
+    version: 1,
+    sources: {},
+    apps: {},
+    defaults: { reasoningMode: "flat", effort: "high", maxTurns: 10 },
+    model: { path: modelPath, nCtx: context },
+  };
+  yield* RunnerCtx.set(makeEdgeRunner(cfg));
+
+  const events = createBus<WorkflowEvent>();
+  const commands = createSignal<Command, void>();
+  const dispatch = (c: Command): void => {
+    commands.send(c);
+  };
+  const bootstrap: WorkflowEvent[] = [];
+
+  // Surface pick — the same events/commands, a different binding. Each binding
+  // returns a disposer; tie it to the scope so listeners are torn down on exit.
+  let dispose: () => void;
+  if (process.env.RR_BRIDGE) {
+    // A desktop shell forked this bin: stream over the process channel.
+    dispose = ipc<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+  } else if (process.stdout.isTTY) {
+    // A terminal: mount the Ink view.
+    dispose = renderCli(events, dispatch, bootstrap);
+  } else {
+    // A pipe: newline-delimited JSON.
+    dispose = ndjson<WorkflowEvent, Command>()(events, dispatch, bootstrap);
+  }
+  yield* ensure(() => dispose());
+
+  // Run the harness. Returns when it sees `quit` (or the scope unwinds).
+  yield* harness(ctx, events, commands);
+});

--- a/packages/harness-cli/templates/research/targets/cli/view.tsx
+++ b/packages/harness-cli/templates/research/targets/cli/view.tsx
@@ -1,0 +1,169 @@
+/**
+ * The terminal view — a `render`-style binding: `(bus, dispatch, bootstrap) =>
+ * dispose`. It subscribes to your events, folds them through the REAL research
+ * `reduce` (harness/state.ts), and renders an austere slice of the rich
+ * `AppState`: the phase, the live agents, a KV gauge, and the streaming answer.
+ *
+ * Austere on purpose. reasoning.run's own UI is a 19-component Ink suite with a
+ * plan-review editor, a sources ledger, and a settings drawer; this view folds
+ * the SAME state through a handful of lines. It auto-accepts the planner's plan
+ * (no interactive plan-review here) so a query runs recon → plan → agents →
+ * synth end-to-end. Swap it, or grow it, or bring a whole app — the harness
+ * never changes; the framework holds the binding seam, never the UI.
+ */
+import React, { useEffect, useReducer, useRef } from "react";
+import { Box, Text, render, useApp, useInput } from "ink";
+import { TextInput } from "@inkjs/ui";
+import type { EventBus } from "@lloyal-labs/binding";
+import { initialState, reduce } from "../../harness/state.js";
+import type { AgentRuntime, AppState } from "../../harness/state.js";
+import type { Command, WorkflowEvent } from "../../harness/protocol.js";
+
+const seed = (bootstrap: WorkflowEvent[]): AppState =>
+  bootstrap.reduce(reduce, initialState);
+
+const glyph = (p: AgentRuntime["phase"]): string =>
+  p === "done" ? "✓" : p === "failed" ? "✗" : p === "tool" ? "◍" : p === "idle" ? "·" : "●";
+
+/** Where the input line is offered — the harness is idle and awaiting a query. */
+const CAN_INPUT = new Set<AppState["uiPhase"]>(["boot", "composer", "done", "clarifying"]);
+
+function Gauge({ used, total }: { used: number; total: number }): React.ReactElement | null {
+  if (!total) return null;
+  const pct = Math.min(100, Math.round((100 * used) / total));
+  const width = 16;
+  const filled = Math.round((pct / 100) * width);
+  return (
+    <Text color="gray">
+      KV {"█".repeat(filled)}
+      {"░".repeat(width - filled)} {pct}%
+    </Text>
+  );
+}
+
+function View({
+  bus,
+  dispatch,
+  bootstrap,
+}: {
+  bus: EventBus<WorkflowEvent>;
+  dispatch: (c: Command) => void;
+  bootstrap: WorkflowEvent[];
+}): React.ReactElement {
+  const [state, apply] = useReducer(reduce, bootstrap, seed);
+  const app = useApp();
+  const acceptedRef = useRef(false);
+
+  useEffect(() => bus.subscribe((ev) => apply(ev)), [bus]);
+
+  // Auto-accept the planner's plan — this austere view has no plan-review editor,
+  // so a query flows straight through to research. `acceptedRef` de-bounces the
+  // one transition into `plan_review`.
+  useEffect(() => {
+    if (state.uiPhase === "plan_review" && !acceptedRef.current) {
+      acceptedRef.current = true;
+      dispatch({ type: "accept_plan" });
+    }
+    if (state.uiPhase !== "plan_review") acceptedRef.current = false;
+  }, [state.uiPhase, dispatch]);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === "c") {
+      dispatch({ type: "quit" });
+      app.exit();
+    }
+  });
+
+  // Recon + research agents (skip the tool-less synth agent — taskIndex null).
+  const agents = [...state.agents.values()].filter((a) => a.taskIndex !== null);
+
+  // The streaming answer: the live synth buffer, else the finalized answer, else
+  // the most recent synth body pushed to scrollback.
+  const lastSynth = [...state.scrollback].reverse().find((s) => s.kind === "synth");
+  const streaming =
+    (state.synth.open && state.synth.buffer) ||
+    state.answer ||
+    (lastSynth && lastSynth.kind === "synth" ? lastSynth.body : "");
+
+  const canInput = CAN_INPUT.has(state.uiPhase);
+
+  const onSubmit = (q: string): void => {
+    const text = q.trim();
+    if (!text) return;
+    if (state.uiPhase === "clarifying") {
+      dispatch({ type: "submit_clarification", answer: text });
+    } else {
+      dispatch({ type: "submit_query", query: text, mode: "flat" });
+    }
+  };
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Box flexDirection="column">
+        <Text bold>{"__NAME__"}</Text>
+        <Text color="gray">Model      resident · no API key</Text>
+        <Text color="gray">Inference  local · no provider</Text>
+        <Text color="gray">
+          Phase      {state.phase}
+          {state.uiPhase !== state.phase ? ` · ${state.uiPhase}` : ""}
+        </Text>
+      </Box>
+
+      {agents.length > 0 && (
+        <Box flexDirection="column">
+          {agents.map((a) => (
+            <Text key={a.id}>
+              {glyph(a.phase)} {a.label}
+              {a.taskDescription ? ` · ${a.taskDescription}` : ""} · {a.tokenCount} tok
+              {a.toolCallCount > 0 ? ` · ${a.toolCallCount} tools` : ""}
+            </Text>
+          ))}
+          {state.pressure && (
+            <Gauge used={state.pressure.cellsUsed} total={state.pressure.nCtx} />
+          )}
+        </Box>
+      )}
+
+      {state.uiPhase === "clarifying" && state.plan?.clarifyQuestions?.length ? (
+        <Box flexDirection="column">
+          <Text color="yellow">The planner needs to clarify:</Text>
+          {state.plan.clarifyQuestions.map((q, i) => (
+            <Text key={i} color="yellow">
+              {"  "}
+              {i + 1}. {q}
+            </Text>
+          ))}
+        </Box>
+      ) : null}
+
+      {streaming ? <Text color="cyan">{streaming}</Text> : null}
+      {state.bootError && (
+        <Text color="red">boot error ({state.bootError.kind}): {state.bootError.message}</Text>
+      )}
+      {state.toast?.tone === "error" && <Text color="red">error: {state.toast.message}</Text>}
+
+      {canInput && (
+        <Box>
+          <Text color="green">› </Text>
+          <TextInput
+            placeholder={
+              state.uiPhase === "clarifying"
+                ? "answer the planner, ctrl-c to stop"
+                : "type a question, ctrl-c to stop"
+            }
+            onSubmit={onSubmit}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+export function renderCli(
+  bus: EventBus<WorkflowEvent>,
+  dispatch: (c: Command) => void,
+  bootstrap: WorkflowEvent[],
+): () => void {
+  const instance = render(<View bus={bus} dispatch={dispatch} bootstrap={bootstrap} />);
+  return () => instance.unmount();
+}

--- a/packages/harness-cli/templates/research/targets/desktop/App.tsx
+++ b/packages/harness-cli/templates/research/targets/desktop/App.tsx
@@ -1,0 +1,200 @@
+/**
+ * The shared React view — BOTH desktop and web mount this ONE component, and it
+ * folds the SAME node-free `reduce` (`harness/state.ts`) that the cli's Ink view
+ * does. Two runtimes (Ink · React), one `reduce`, one rich research `AppState`.
+ *
+ * It is transport-agnostic: it only reads `window.harness` — a bridge injected
+ * by desktop's preload (contextBridge over IPC) or web's boot (`connectWss` over
+ * a socket). Austere on purpose — it renders the same slice the cli's Ink view
+ * does: the phase, the live research agents (glyph · label · task · tokens ·
+ * tools), a KV pressure gauge, the streaming synth answer, and one input that
+ * dispatches a query. Like the cli view it auto-accepts the planner's plan
+ * (there is no plan-review editor here), so a query flows recon → plan → agents
+ * → synth end-to-end. This is the floor — grow it into your product's UI (or
+ * bring your own app); the harness never changes.
+ *
+ * SNAPSHOT: reasoning.run @ 0.8.0
+ */
+import { useEffect, useRef, useState, type CSSProperties } from "react";
+import { reduce, initialState, type AppState, type AgentRuntime } from "../../harness/state.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+
+declare global {
+  interface Window {
+    harness: {
+      onEvent(cb: (frame: { seq: number; ev: WorkflowEvent }) => void): () => void;
+      send(command: Command): void;
+      requestSnapshot(): Promise<{ state: AppState; seq: number }>;
+    };
+  }
+}
+
+/** Terminal glyph per agent phase — the same vocabulary the Ink view uses. */
+const glyph = (p: AgentRuntime["phase"]): string =>
+  p === "done" ? "✓" : p === "failed" ? "✗" : p === "tool" ? "◍" : p === "idle" ? "·" : "●";
+
+/** Where the input line is offered — the harness is idle and awaiting a query. */
+const CAN_INPUT = new Set<AppState["uiPhase"]>(["boot", "composer", "done", "clarifying"]);
+
+export function HarnessApp() {
+  const [state, setState] = useState<AppState>(initialState);
+  const seqRef = useRef(-1);
+  const [query, setQuery] = useState("");
+  const acceptedRef = useRef(false);
+
+  useEffect(() => {
+    let alive = true;
+    let seeded = false;
+    // Subscribe FIRST so no frame is missed, but hold frames until the snapshot
+    // lands — applying them live would let a frame advance `seqRef` and then be
+    // overwritten by an older snapshot cut (a lost-event gap on reload).
+    const pending: { seq: number; ev: WorkflowEvent }[] = [];
+    const apply = (frame: { seq: number; ev: WorkflowEvent }): void => {
+      if (frame.seq <= seqRef.current) return;
+      seqRef.current = frame.seq;
+      setState((s) => reduce(s, frame.ev));
+    };
+    // Seed from `base`@`baseSeq`, then fold any buffered frames newer than the cut
+    // — computed OUTSIDE the updater so React StrictMode's double-invoke is safe.
+    const seed = (base: AppState, baseSeq: number): void => {
+      if (!alive || seeded) return;
+      let next = base;
+      let cur = baseSeq;
+      for (const f of pending) {
+        if (f.seq <= cur) continue;
+        cur = f.seq;
+        next = reduce(next, f.ev);
+      }
+      pending.length = 0;
+      seqRef.current = cur;
+      seeded = true;
+      setState(next);
+    };
+    const off = window.harness.onEvent((frame) => {
+      if (seeded) apply(frame);
+      else pending.push(frame);
+    });
+    window.harness
+      .requestSnapshot()
+      .then((snap) => seed(snap.state, snap.seq))
+      // No snapshot (e.g. the host is unreachable): seed from the initial state so
+      // the stream is never stuck buffering, and replay whatever we've buffered.
+      .catch(() => seed(initialState, -1));
+    return () => {
+      alive = false;
+      off();
+    };
+  }, []);
+
+  // Auto-accept the planner's plan — this austere view has no plan-review editor,
+  // so a query flows straight through to research. `acceptedRef` de-bounces the
+  // one transition into `plan_review` (mirrors the cli view).
+  useEffect(() => {
+    if (state.uiPhase === "plan_review" && !acceptedRef.current) {
+      acceptedRef.current = true;
+      window.harness.send({ type: "accept_plan" });
+    }
+    if (state.uiPhase !== "plan_review") acceptedRef.current = false;
+  }, [state.uiPhase]);
+
+  const submit = (): void => {
+    const q = query.trim();
+    if (!q) return;
+    if (state.uiPhase === "clarifying") {
+      window.harness.send({ type: "submit_clarification", answer: q });
+    } else {
+      window.harness.send({ type: "submit_query", query: q, mode: "flat" });
+    }
+    setQuery("");
+  };
+
+  // Recon + research agents (skip the tool-less synth agent — taskIndex null).
+  const agents: AgentRuntime[] = [...state.agents.values()].filter((a) => a.taskIndex !== null);
+
+  // The streaming answer: the live synth buffer, else the finalized answer, else
+  // the most recent synth body pushed to scrollback.
+  const lastSynth = [...state.scrollback].reverse().find((s) => s.kind === "synth");
+  const streaming =
+    (state.synth.open && state.synth.buffer) ||
+    state.answer ||
+    (lastSynth && lastSynth.kind === "synth" ? lastSynth.body : "");
+
+  const kvPct =
+    state.pressure && state.pressure.nCtx > 0
+      ? Math.min(100, Math.round((100 * state.pressure.cellsUsed) / state.pressure.nCtx))
+      : null;
+
+  const canInput = CAN_INPUT.has(state.uiPhase);
+
+  return (
+    <div style={S.page}>
+      <div style={S.head}>
+        __NAME__ · {state.phase}
+        {state.uiPhase !== state.phase ? ` · ${state.uiPhase}` : ""}
+        {kvPct !== null && ` · kv ${kvPct}%`}
+      </div>
+
+      {agents.map((a) => (
+        <div key={a.id} style={{ ...S.agent, opacity: a.phase === "done" ? 0.65 : 1 }}>
+          <div style={S.meta}>
+            {glyph(a.phase)} {a.label}
+            {a.taskDescription ? ` · ${a.taskDescription}` : ""} · {a.tokenCount} tok
+            {a.toolCallCount > 0 ? ` · ${a.toolCallCount} tools` : ""}
+          </div>
+        </div>
+      ))}
+
+      {state.uiPhase === "clarifying" && state.plan?.clarifyQuestions?.length ? (
+        <div style={S.clarify}>
+          <div style={S.clarifyHead}>The planner needs to clarify:</div>
+          {state.plan.clarifyQuestions.map((q, i) => (
+            <div key={i}>
+              {i + 1}. {q}
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      {streaming ? <div style={S.answer}>{streaming}</div> : null}
+      {state.bootError && (
+        <div style={S.error}>
+          boot error ({state.bootError.kind}): {state.bootError.message}
+        </div>
+      )}
+      {state.toast?.tone === "error" && <div style={S.error}>error: {state.toast.message}</div>}
+
+      {canInput && (
+        <div style={S.composer}>
+          <input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") submit();
+            }}
+            placeholder={
+              state.uiPhase === "clarifying" ? "Answer the planner…" : "Ask something…"
+            }
+            style={S.input}
+          />
+          <button type="button" onClick={submit} style={S.send}>
+            Send
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const S: Record<string, CSSProperties> = {
+  page: { font: "14px/1.55 ui-sans-serif, system-ui, sans-serif", color: "#e6e9ef", padding: 20, maxWidth: 820, margin: "0 auto" },
+  head: { opacity: 0.55, fontSize: 12, marginBottom: 14, letterSpacing: 0.3 },
+  agent: { borderLeft: "2px solid #2b3140", paddingLeft: 12, margin: "8px 0" },
+  meta: { fontSize: 13 },
+  clarify: { margin: "10px 0", color: "#e3c04a" },
+  clarifyHead: { marginBottom: 4 },
+  answer: { marginTop: 16, whiteSpace: "pre-wrap", lineHeight: 1.6, color: "#cfe6ff" },
+  error: { marginTop: 16, color: "#ff7a7a" },
+  composer: { display: "flex", gap: 8, marginTop: 22 },
+  input: { flex: 1, padding: "9px 12px", background: "#12151c", color: "#e6e9ef", border: "1px solid #2b3140", borderRadius: 8, outline: "none" },
+  send: { padding: "9px 18px", background: "#3b4a6b", color: "#fff", border: 0, borderRadius: 8, cursor: "pointer" },
+};

--- a/packages/harness-cli/templates/research/targets/desktop/index.html
+++ b/packages/harness-cli/templates/research/targets/desktop/index.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self' ws: wss:"
+    />
+    <title>__NAME__</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0d12;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./view.tsx"></script>
+  </body>
+</html>

--- a/packages/harness-cli/templates/research/targets/desktop/main.ts
+++ b/packages/harness-cli/templates/research/targets/desktop/main.ts
@@ -1,0 +1,129 @@
+/**
+ * The desktop target — your harness in a native window (Electron).
+ *
+ * Electron's MAIN process is a thin host: it owns the window and forks THIS
+ * project's OWN cli bin (`bin/run.js`) as the engine, with `RR_BRIDGE=1` set —
+ * which makes the cli boot mount the `ipc` binding instead of Ink (see
+ * `targets/cli/index.ts`). Heavy work (native inference, the Effection harness)
+ * lives in that forked engine process, so the UI thread never blocks.
+ *
+ * Streaming model (identical to cli/web): the engine emits raw `WorkflowEvent`s;
+ * main FORWARDS each one (+ a monotonic `seq`) to the renderer, which folds it
+ * through the SAME pure `reduce` — so only the small event crosses IPC, never
+ * the growing transcript. Main also mirrors state into `appState` purely to
+ * answer ONE snapshot per (re)load: the renderer seeds from it and applies only
+ * events with `seq > snapshot.seq` (a consistent cut — no gap, no double-apply).
+ */
+import { app, BrowserWindow, ipcMain, shell, utilityProcess, type UtilityProcess } from "electron";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+import { reduce, initialState, type AppState } from "../../harness/state.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+
+/** Only http(s) links may leave the app. */
+function isExternalUrl(url: string): boolean {
+  try {
+    const p = new URL(url).protocol;
+    return p === "http:" || p === "https:";
+  } catch {
+    return false;
+  }
+}
+
+let win: BrowserWindow | null = null;
+let engine: UtilityProcess | null = null;
+let appState: AppState = initialState;
+let seq = 0;
+
+/** Send to the renderer only if the window is still alive (`win?.` is not
+ *  enough — on close `win` is non-null but DESTROYED and `.send` throws). */
+function safeSend(channel: string, payload: unknown): void {
+  if (win && !win.isDestroyed()) win.webContents.send(channel, payload);
+}
+
+function spawnEngine(): void {
+  // The engine is THIS project's compiled cli boot (`bin/run.js` →
+  // `dist/targets/cli/index.js`), forked with RR_BRIDGE so it streams over
+  // parentPort. Build the cli first (`tsc`) — `npm run dev:desktop` does. cwd
+  // stays the project root so the forked cli reads `harness.yml` + `models/`.
+  const enginePath = join(process.cwd(), "bin", "run.js");
+  if (!existsSync(enginePath)) {
+    throw new Error(
+      `engine not built: ${enginePath} not found — run \`tsc\` (or \`npm run dev:desktop\`) first.`,
+    );
+  }
+  const env = { ...process.env, RR_BRIDGE: "1" };
+  engine = utilityProcess.fork(enginePath, [], {
+    serviceName: "harness-engine",
+    stdio: "pipe",
+    env,
+  });
+  engine.stdout?.on("data", (d) => console.log("[engine]", d.toString().trimEnd()));
+  engine.stderr?.on("data", (d) => console.error("[engine]", d.toString().trimEnd()));
+  engine.on("message", (msg: { t?: string; payload?: WorkflowEvent }) => {
+    if (msg?.t === "event" && msg.payload) {
+      seq++;
+      appState = reduce(appState, msg.payload);
+      safeSend("harness:event", { seq, ev: msg.payload });
+    }
+  });
+  engine.on("exit", (code) => console.log("[engine] exited", code));
+}
+
+function createWindow(): void {
+  win = new BrowserWindow({
+    width: 1100,
+    height: 760,
+    minWidth: 800,
+    minHeight: 520,
+    show: false,
+    backgroundColor: "#0b0d12",
+    title: "__NAME__",
+    webPreferences: {
+      preload: join(__dirname, "../preload/index.js"),
+      contextIsolation: true,
+      sandbox: false,
+    },
+  });
+  win.once("ready-to-show", () => win?.show());
+  win.on("closed", () => {
+    win = null;
+  });
+  // Links open in the system browser; never navigate the renderer away.
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    if (isExternalUrl(url)) void shell.openExternal(url);
+    return { action: "deny" };
+  });
+  // Same for in-place navigations (a bare <a href> with no target): keep the
+  // renderer pinned to the app, and hand http(s) links to the system browser.
+  win.webContents.on("will-navigate", (e, url) => {
+    if (url !== win?.webContents.getURL()) {
+      e.preventDefault();
+      if (isExternalUrl(url)) void shell.openExternal(url);
+    }
+  });
+  if (process.env.ELECTRON_RENDERER_URL) {
+    win.loadURL(process.env.ELECTRON_RENDERER_URL);
+  } else {
+    win.loadFile(join(__dirname, "../renderer/index.html"));
+  }
+}
+
+app.whenReady().then(() => {
+  spawnEngine();
+  createWindow();
+  // renderer → engine (Command)
+  ipcMain.on("harness:command", (_e, command: Command) => {
+    engine?.postMessage({ t: "command", payload: command });
+  });
+  // renderer (re)load → consistent cut: reduced state + the seq it reflects.
+  ipcMain.handle("harness:snapshot", () => ({ state: appState, seq }));
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});
+app.on("quit", () => engine?.kill());

--- a/packages/harness-cli/templates/research/targets/desktop/preload.ts
+++ b/packages/harness-cli/templates/research/targets/desktop/preload.ts
@@ -1,0 +1,30 @@
+/**
+ * The preload bridge — exposes a tiny `window.harness` to the renderer over
+ * Electron's contextBridge (contextIsolation-safe). The renderer talks ONLY to
+ * this surface, which is the SAME shape the web target backs with `connectWss`
+ * — so the React view is transport-agnostic and both surfaces reuse it.
+ */
+import { contextBridge, ipcRenderer } from "electron";
+import type { AppState } from "../../harness/state.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+
+const api = {
+  /** Subscribe to `{ seq, ev }` frames the main process forwards. */
+  onEvent(cb: (frame: { seq: number; ev: WorkflowEvent }) => void): () => void {
+    const h = (_e: unknown, frame: { seq: number; ev: WorkflowEvent }): void => cb(frame);
+    ipcRenderer.on("harness:event", h);
+    return () => {
+      ipcRenderer.removeListener("harness:event", h);
+    };
+  },
+  /** Send a Command up to the engine. */
+  send(command: Command): void {
+    ipcRenderer.send("harness:command", command);
+  },
+  /** One consistent-cut snapshot per (re)load: reduced state + the seq it reflects. */
+  requestSnapshot(): Promise<{ state: AppState; seq: number }> {
+    return ipcRenderer.invoke("harness:snapshot");
+  },
+};
+
+contextBridge.exposeInMainWorld("harness", api);

--- a/packages/harness-cli/templates/research/targets/desktop/view.tsx
+++ b/packages/harness-cli/templates/research/targets/desktop/view.tsx
@@ -1,0 +1,8 @@
+/**
+ * Desktop renderer entry — mounts the shared `HarnessApp` (see `App.tsx`). The
+ * preload has already injected `window.harness` (IPC bridge) before this runs.
+ */
+import { createRoot } from "react-dom/client";
+import { HarnessApp } from "./App.js";
+
+createRoot(document.getElementById("root")!).render(<HarnessApp />);

--- a/packages/harness-cli/templates/research/targets/web/boot.ts
+++ b/packages/harness-cli/templates/research/targets/web/boot.ts
@@ -1,0 +1,6 @@
+// Installs the wss `window.harness` bridge as a side effect. `main.tsx` imports
+// this FIRST (before the view), so `window.harness` exists when the view's effect
+// runs — mirroring how desktop's preload injects it before the renderer loads.
+import { installWebBridge } from "./web-bridge.js";
+
+installWebBridge();

--- a/packages/harness-cli/templates/research/targets/web/driver.ts
+++ b/packages/harness-cli/templates/research/targets/web/driver.ts
@@ -120,10 +120,13 @@ export function createServedHostDriver(
         // Client disconnect at ANY phase → release (queued=drop, warming=discard, live=halt).
         // `release()` returns the harness's halt promise, which CAN reject (a teardown
         // failure) — swallow it (matching the host's own internal fire-and-forget cancel)
-        // so a disconnect can't surface as an unhandled rejection.
+        // so a disconnect can't surface as an unhandled rejection. Do NOT delete `pending`
+        // here: if the disconnect races the `warming` phase the host still completes
+        // `materialise`, and a deleted stash would make it throw "no channels" → the host
+        // reports `died` instead of a clean `reaped`. The stash is claimed by `materialise`,
+        // or dropped by the terminal `reaped`/`died` in `onState` below.
         socket.on("close", () => {
           host.release(sessionId).catch(() => {});
-          pending.delete(sessionId);
         });
         host.admit({
           sessionId,

--- a/packages/harness-cli/templates/research/targets/web/driver.ts
+++ b/packages/harness-cli/templates/research/targets/web/driver.ts
@@ -99,6 +99,13 @@ export function createServedHostDriver(
 
     function serveConnection(socket: WsServerSocket): void {
       const sessionId = randomUUID();
+      // Defensive: an unhandled 'error' on a Node socket is thrown as an exception
+      // — which would take the WHOLE serving process down (every other live Session
+      // with it). The driver owns the wss binding, so it installs a no-op 'error'
+      // handler here — every call site is protected by default, not just ones that
+      // remember to attach one. (`WsServerSocket` doesn't declare 'error'; the real
+      // `ws` socket has it — narrow-cast + optional-call.)
+      (socket as unknown as { on?: (event: "error", cb: () => void) => void }).on?.("error", () => {});
       try {
         const { uiChannel, commands } = createServedChannels();
         pending.set(sessionId, { uiChannel, commands });

--- a/packages/harness-cli/templates/research/targets/web/driver.ts
+++ b/packages/harness-cli/templates/research/targets/web/driver.ts
@@ -1,0 +1,151 @@
+/**
+ * The served-host driver — this web target's half of the model-runtime host box.
+ *
+ * Assembles `@lloyal-labs/host`'s injected `ServedHarness { materialise, run }` from
+ * this harness's served factories (`harness/served-runtime.ts`), drives a `ModelRuntimeHost`
+ * (ONE resident model → N Sessions), and exposes `serveConnection(socket)` to bind
+ * each `ws` connection to a Session over binding's `wss()`. One active Session per
+ * connection.
+ *
+ * **Eager-channels** resolution of the ordering wrinkle: `wss()` needs the bus/commands
+ * at bind time, but the host materialises them asynchronously inside `materialise`. The
+ * driver owns the seam, so it creates the channels per connection (`createServedChannels`)
+ * and `materialise` returns those SAME channels (looked up by `sessionId`) — the socket
+ * binds once, at connect time, and the harness's events flow through the already-subscribed
+ * bus.
+ *
+ * **Harness-free by design:** this file imports only the harness-FREE served factories
+ * (`createServedContext`/`createServedChannels`) + the host + `wss`. The harness-running
+ * `run` (which pulls the `harness` + its `.eta`) is INJECTED — `serve.ts` supplies
+ * `runServedSession` — so this file needs no esbuild and stays unit-testable.
+ *
+ * SNAPSHOT: reasoning.run @ 0.8.0 (src/serve/driver.ts).
+ */
+import { randomUUID } from "node:crypto";
+import { resource } from "effection";
+import type { Operation, Signal } from "effection";
+import { createModelRuntimeHost } from "@lloyal-labs/host";
+import type { Materialised, ServedHarness, SessionState } from "@lloyal-labs/host";
+import { wss, type WsServerSocket } from "@lloyal-labs/binding/node";
+import type { EventBus } from "@lloyal-labs/binding";
+import type { SessionContext } from "@lloyal-labs/sdk";
+import { createServedContext, createServedChannels } from "../../harness/served-runtime.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+import type { Config } from "../../harness/config-types.js";
+
+type Channels = { uiChannel: EventBus<WorkflowEvent>; commands: Signal<Command, void> };
+
+export interface ServedHostDriverOpts {
+  maxNativeSessions: number;
+  /** Run one Session's harness over its substrate. `serve.ts` injects `runServedSession`
+   *  (which pulls the harness + `.eta`); a test injects a fake. Kept INJECTED so this
+   *  file stays harness-free + testable. */
+  run: (m: Materialised<SessionContext>, sessionId: string) => Operation<void>;
+  /** Build the per-session context over the resident model. Defaults to this harness's
+   *  served factory; a test overrides it with a fake (no model). */
+  buildContext?: () => Promise<SessionContext>;
+}
+
+export interface ServedHostDriver {
+  /** Bind one `ws` connection to a fresh Session. Call from `server.on("connection")`. */
+  serveConnection(socket: WsServerSocket): void;
+  /** Live-session occupancy (the host ledger — `sessions.size`). */
+  readonly occupancy: number;
+}
+
+/**
+ * Create the served-host driver as an Effection `resource`: the `ModelRuntimeHost` lives
+ * for the resource's scope; unwinding it halts every Session + frees every context.
+ */
+export function createServedHostDriver(
+  cfg: Config,
+  opts: ServedHostDriverOpts,
+): Operation<ServedHostDriver> {
+  return resource(function* (provide) {
+    // Channels a connection stashes BEFORE admission; `materialise` CLAIMS them (returns
+    // them AND removes the entry) so the socket (bound at connect time) and the harness
+    // share one bus/command pair. So `pending` holds ONLY not-yet-materialised sessions;
+    // the disconnect / terminal paths delete a still-un-claimed entry.
+    const pending = new Map<string, Channels>();
+    const buildContext = opts.buildContext ?? (() => createServedContext(cfg));
+
+    const served: ServedHarness<SessionContext> = {
+      async materialise(sessionId: string): Promise<Materialised<SessionContext>> {
+        const ch = pending.get(sessionId);
+        if (!ch) throw new Error(`serve: no channels for session ${sessionId}`);
+        pending.delete(sessionId); // claimed — the harness owns the channels now; a repeat
+        // materialise of this id now fails loud above instead of silently reusing them.
+        const context = await buildContext();
+        return {
+          context,
+          uiChannel: ch.uiChannel,
+          commands: ch.commands,
+          dispose() {
+            try {
+              context.dispose?.();
+            } catch {
+              /* freeing the served context — not the driver's error to surface */
+            }
+          },
+        };
+      },
+      run: opts.run,
+    };
+
+    const host = yield* createModelRuntimeHost<SessionContext>({
+      served,
+      maxNativeSessions: opts.maxNativeSessions,
+    });
+
+    function serveConnection(socket: WsServerSocket): void {
+      const sessionId = randomUUID();
+      try {
+        const { uiChannel, commands } = createServedChannels();
+        pending.set(sessionId, { uiChannel, commands });
+        // Bind the run plane NOW: events buffer on the bus until the harness subscribes
+        // (EventBus replays to its first subscriber); `postSession` writes the session plane.
+        const postSession = wss<WorkflowEvent, Command>(socket, {
+          uiChannel,
+          dispatch: (c) => commands.send(c),
+          bootstrap: [],
+          sessionId,
+        });
+        // Client disconnect at ANY phase → release (queued=drop, warming=discard, live=halt).
+        // `release()` returns the harness's halt promise, which CAN reject (a teardown
+        // failure) — swallow it (matching the host's own internal fire-and-forget cancel)
+        // so a disconnect can't surface as an unhandled rejection.
+        socket.on("close", () => {
+          host.release(sessionId).catch(() => {});
+          pending.delete(sessionId);
+        });
+        host.admit({
+          sessionId,
+          onState: (s: SessionState) => {
+            postSession(s);
+            if (s.phase === "reaped" || s.phase === "died") pending.delete(sessionId);
+          },
+        });
+      } catch (err) {
+        // `serveConnection` runs inside the ws "connection" emit — a synchronous setup
+        // failure here would escape into the emit and take the WHOLE host down (every
+        // other live Session with it). Contain it to THIS connection: free its slot,
+        // release any partial admission, best-effort close the socket, and let the rest
+        // keep serving. (`WsServerSocket` doesn't declare `close`; the real ws socket has
+        // it — call it if present.)
+        pending.delete(sessionId);
+        host.release(sessionId).catch(() => {});
+        (socket as { close?: () => void }).close?.();
+        console.error(
+          `[serve] connection setup failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    yield* provide({
+      serveConnection,
+      get occupancy() {
+        return host.occupancy;
+      },
+    });
+  });
+}

--- a/packages/harness-cli/templates/research/targets/web/index.html
+++ b/packages/harness-cli/templates/research/targets/web/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>__NAME__</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        height: 100%;
+        background: #0b0d12;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/packages/harness-cli/templates/research/targets/web/main.tsx
+++ b/packages/harness-cli/templates/research/targets/web/main.tsx
@@ -1,0 +1,7 @@
+// Web renderer entry. The side-effect import runs FIRST — it installs
+// `window.harness` (the wss bridge) before the shared view mounts and subscribes.
+import "./boot.js";
+import { createRoot } from "react-dom/client";
+import { HarnessApp } from "../desktop/App.js";
+
+createRoot(document.getElementById("root")!).render(<HarnessApp />);

--- a/packages/harness-cli/templates/research/targets/web/serve.ts
+++ b/packages/harness-cli/templates/research/targets/web/serve.ts
@@ -43,12 +43,23 @@ interface ModelEntry {
 }
 
 function loadYaml(): { model?: { llm?: ModelEntry; reranker?: ModelEntry } } {
+  // Fail loud, like the cli boot: a missing or malformed harness.yml must not be
+  // silently swallowed into `{}` (which would fall through to default model
+  // resolution and serve an unexpected model).
+  let raw: string;
   try {
-    return (parse(readFileSync(join(process.cwd(), "harness.yml"), "utf8")) ?? {}) as {
-      model?: { llm?: ModelEntry; reranker?: ModelEntry };
-    };
+    raw = readFileSync(join(process.cwd(), "harness.yml"), "utf8");
   } catch {
-    return {};
+    process.stderr.write("harness.yml not found — run `npm run serve` from your harness project root.\n");
+    process.exit(1);
+  }
+  try {
+    return (parse(raw) ?? {}) as { model?: { llm?: ModelEntry; reranker?: ModelEntry } };
+  } catch (err) {
+    process.stderr.write(
+      `harness.yml is not valid YAML: ${err instanceof Error ? err.message : String(err)}\n`,
+    );
+    process.exit(1);
   }
 }
 

--- a/packages/harness-cli/templates/research/targets/web/serve.ts
+++ b/packages/harness-cli/templates/research/targets/web/serve.ts
@@ -150,10 +150,8 @@ main(function* () {
     process.exit(1);
   });
   server.on("connection", (socket) => {
-    // The `ws` socket structurally satisfies binding's `WsServerSocket` (send + on
-    // message/close), but binding doesn't attach a `ws` 'error' handler — an unhandled
-    // 'error' on a Node EventEmitter throws, so the host must.
-    socket.on("error", () => {});
+    // The driver installs the socket's no-op 'error' handler itself (an unhandled
+    // 'error' on a Node EventEmitter throws), so the boot just hands the socket off.
     driver.serveConnection(socket as unknown as WsServerSocket);
   });
   // Plaintext ws:// — TLS terminates upstream (reverse proxy / the managed front door),

--- a/packages/harness-cli/templates/research/targets/web/serve.ts
+++ b/packages/harness-cli/templates/research/targets/web/serve.ts
@@ -1,0 +1,155 @@
+/**
+ * `bin/serve.js`'s entry — the web target's served-host runner. Stands up a `ws`
+ * server that serves N browser Sessions over ONE resident model (the model-runtime
+ * host + the wss front door in one process). It's the SAME
+ * `harness(ctx, events, commands)` the cli and desktop run — only the binding differs;
+ * the browser connects with `connectWss` (see `web-bridge.ts`).
+ *
+ * `npm run serve` builds + starts this; then `npm run dev:web` serves the browser
+ * app that talks to it. Loopback + no-auth for local dev — token auth is a
+ * front-door concern, deferred.
+ *
+ * ESBUILT (it injects `runServedSession` → the harness → its `.eta` prompts, so it
+ * must bundle with `--loader:.eta=text`, never tsx).
+ *
+ * ONE adaptation over reasoning.run's env-sourced `serve/main.ts`: the **config
+ * source**. Instead of `LLOYAL_MODEL`/`LLOYAL_RERANKER` env vars, `resolveConfig`
+ * reads `harness.yml` and resolves the llm + reranker specs to concrete
+ * digest-verified `.gguf` paths via rig's `resolveModel` (batteries included, no env
+ * needed). Everything else — `createServedHostDriver`, `createModelRuntimeHost`, the
+ * `ws` WebSocketServer, the wss per-connection binding, admit/release — is
+ * reasoning.run's serving code verbatim.
+ *
+ * SNAPSHOT: reasoning.run @ 0.8.0 (src/serve/main.ts).
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse } from "yaml";
+import { main, suspend, call } from "effection";
+import type { Operation, Signal } from "effection";
+import { WebSocketServer } from "ws";
+import type { WsServerSocket } from "@lloyal-labs/binding/node";
+import type { EventBus } from "@lloyal-labs/binding";
+import { resolveModel } from "@lloyal-labs/rig/node";
+import { createServedHostDriver } from "./driver.js";
+import { runServedSession } from "../../harness/served-session.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+import type { Config } from "../../harness/config-types.js";
+
+interface ModelEntry {
+  id?: string;
+  path?: string;
+  context?: number;
+}
+
+function loadYaml(): { model?: { llm?: ModelEntry; reranker?: ModelEntry } } {
+  try {
+    return (parse(readFileSync(join(process.cwd(), "harness.yml"), "utf8")) ?? {}) as {
+      model?: { llm?: ModelEntry; reranker?: ModelEntry };
+    };
+  } catch {
+    return {};
+  }
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  const n = raw ? Number.parseInt(raw, 10) : Number.NaN;
+  return Number.isFinite(n) ? n : fallback;
+}
+
+/**
+ * The web target's config source (the sole adaptation over reasoning.run's
+ * env-sourced `resolveConfig`): read `harness.yml`, then resolve the llm + reranker
+ * specs to concrete verified `.gguf` paths via rig's `resolveModel` (fetched +
+ * digest-verified on first run, no key). The served factories read `model.path`
+ * (+ `model.nCtx`) for the resident context and `model.reranker` for the per-session
+ * cross-encoder.
+ */
+function* resolveConfig(): Operation<Config> {
+  const yaml = loadYaml();
+  const llm: ModelEntry = yaml.model?.llm ?? {};
+  const reranker: ModelEntry = yaml.model?.reranker ?? {};
+
+  // Resolve the resident reasoning model ONCE → every Session's context is created
+  // over this one path (shared weights, weak-cached by lloyal.node's ModelRegistry).
+  const modelPath = yield* call(() =>
+    resolveModel({
+      projectRoot: process.cwd(),
+      role: "llm",
+      spec: { id: llm.id, path: llm.path },
+      onProgress: (got, total) => {
+        const pct = total > 0 ? Math.round((100 * got) / total) : 0;
+        process.stderr.write(`\rfetching ${llm.id ?? "model"} — ${pct}%   `);
+      },
+    }),
+  );
+
+  // Resolve the reranker the same verified way. Its weights are resident too (shared
+  // across Sessions); each Session gets its OWN KV context over them.
+  const rerankerPath = yield* call(() =>
+    resolveModel({
+      projectRoot: process.cwd(),
+      role: "reranker",
+      spec: { id: reranker.id, path: reranker.path },
+      onProgress: (got, total) => {
+        const pct = total > 0 ? Math.round((100 * got) / total) : 0;
+        process.stderr.write(`\rfetching reranker — ${pct}%   `);
+      },
+    }),
+  );
+
+  return {
+    version: 1,
+    sources: {},
+    apps: {},
+    defaults: { reasoningMode: "flat", effort: "high", maxTurns: 10 },
+    model: { path: modelPath, reranker: rerankerPath, nCtx: llm.context ?? 32768 },
+  };
+}
+
+main(function* () {
+  const cfg = yield* resolveConfig();
+  const port = envInt("PORT", 8787);
+  const maxNativeSessions = envInt("MAX_SESSIONS", 8);
+  // Default to loopback: the pilot is no-auth, and ws's default all-interfaces bind for
+  // `{ port }` would expose an unauthenticated model service on the LAN. `HOST=0.0.0.0`
+  // is an explicit opt-in once an operator fronts it with auth/TLS.
+  const bindHost = process.env.HOST ?? "127.0.0.1";
+
+  const driver = yield* createServedHostDriver(cfg, {
+    maxNativeSessions,
+    // The host is payload-opaque — it erases the bus/command types to `unknown`. The
+    // driver created these channels as WorkflowEvent/Command, so re-narrow them here.
+    run: (m) =>
+      runServedSession(
+        cfg,
+        m.context,
+        m.uiChannel as unknown as EventBus<WorkflowEvent>,
+        m.commands as unknown as Signal<Command, void>,
+      ),
+  });
+
+  const server = new WebSocketServer({ port, host: bindHost });
+  // Server-level errors are almost always a bind failure (EADDRINUSE / EACCES). Without a
+  // listener Node rethrows the EventEmitter 'error' as an uncaught exception with a bare
+  // stack — surface an actionable message + exit non-zero for the operator/orchestrator.
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    console.error(`[serve] failed to bind ${bindHost}:${port} — ${err.code ?? err.message}`);
+    process.exit(1);
+  });
+  server.on("connection", (socket) => {
+    // The `ws` socket structurally satisfies binding's `WsServerSocket` (send + on
+    // message/close), but binding doesn't attach a `ws` 'error' handler — an unhandled
+    // 'error' on a Node EventEmitter throws, so the host must.
+    socket.on("error", () => {});
+    driver.serveConnection(socket as unknown as WsServerSocket);
+  });
+  // Plaintext ws:// — TLS terminates upstream (reverse proxy / the managed front door),
+  // never in this process, so label it "ws" (not "wss") for operators.
+  console.log(
+    `\n__NAME__ serving on ws://${bindHost}:${port} — up to ${maxNativeSessions} browser session(s) over ${cfg.model.path}`,
+  );
+
+  yield* suspend(); // run until the process is signalled (main handles SIGINT/SIGTERM)
+});

--- a/packages/harness-cli/templates/research/targets/web/vite.web.config.ts
+++ b/packages/harness-cli/templates/research/targets/web/vite.web.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import { resolve } from "node:path";
+
+/**
+ * The web target's browser app (`npm run dev:web` / `npm run build:web`). Rooted
+ * at `targets/web`; it connects to the local `npm run serve` host over wss (see
+ * `web-bridge.ts`). Point it elsewhere with `VITE_WSS_URL` or `?server=`.
+ */
+export default defineConfig({
+  root: resolve(__dirname),
+  plugins: [react()],
+  server: { port: 5173 },
+  build: { outDir: resolve(__dirname, "../../dist-web"), emptyOutDir: true },
+});

--- a/packages/harness-cli/templates/research/targets/web/web-bridge.ts
+++ b/packages/harness-cli/templates/research/targets/web/web-bridge.ts
@@ -1,0 +1,59 @@
+/**
+ * The browser side of the web target — installs a `window.harness` bridge backed
+ * by `connectWss`, the SAME shape the desktop preload exposes over IPC. That's
+ * why the shared React view (`../desktop/App.tsx`) is transport-agnostic: it only
+ * reads `window.harness`, whether that's IPC (desktop) or wss (web).
+ */
+import { connectWss, type WssClient } from "@lloyal-labs/binding/web";
+import { initialState, type AppState } from "../../harness/state.js";
+import type { WorkflowEvent, Command } from "../../harness/protocol.js";
+
+/** Where the served host lives: build-time `VITE_WSS_URL`, a `?server=` query
+ *  param, then the local `npm run serve` default. */
+function resolveWssUrl(): string {
+  const env = (import.meta as unknown as { env?: { VITE_WSS_URL?: string } }).env?.VITE_WSS_URL;
+  if (env) return env;
+  const q = new URLSearchParams(window.location.search).get("server");
+  if (q) return q;
+  return "ws://127.0.0.1:8787";
+}
+
+export function installWebBridge(): void {
+  let client: WssClient<Command> | null = null;
+  let seq = 0;
+  const listeners = new Set<(f: { seq: number; ev: WorkflowEvent }) => void>();
+
+  const api = {
+    onEvent(cb: (f: { seq: number; ev: WorkflowEvent }) => void): () => void {
+      listeners.add(cb);
+      // Lazy-connect on first subscription (the view subscribes in its effect).
+      // Synthesize a monotonic seq the wire doesn't carry.
+      client ??= connectWss<WorkflowEvent, Command>(resolveWssUrl(), {
+        onEvent: (ev) => {
+          const frame = { seq: ++seq, ev };
+          for (const l of listeners) l(frame);
+        },
+      });
+      return () => {
+        listeners.delete(cb);
+        // Last listener gone (view unmount / HMR): close the socket so it isn't
+        // leaked, and reset — a later subscription reconnects a fresh session
+        // (which re-seeds from initialState @ 0, matching requestSnapshot).
+        if (listeners.size === 0) {
+          client?.close();
+          client = null;
+          seq = 0;
+        }
+      };
+    },
+    send(command: Command): void {
+      client?.send(command);
+    },
+    // The wss stream carries no snapshot — start from initialState at seq 0.
+    requestSnapshot(): Promise<{ state: AppState; seq: number }> {
+      return Promise.resolve({ state: initialState, seq: 0 });
+    },
+  };
+
+  (window as unknown as { harness: typeof api }).harness = api;
+}

--- a/packages/harness-cli/templates/research/tsconfig.electron.json
+++ b/packages/harness-cli/templates/research/tsconfig.electron.json
@@ -1,0 +1,20 @@
+{
+  // Typecheck-only config for the Electron main + preload. They run in Electron's
+  // CommonJS context (they use `__dirname` + electron's contextBridge/ipcRenderer),
+  // so they can't join the NodeNext-ESM `tsconfig.json` — hence a dedicated config.
+  // electron-vite BUILDS them via esbuild; run `tsc -p tsconfig.electron.json`
+  // (or `npm run typecheck`) to typecheck them in your editor / CI.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "Node10",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": ["targets/desktop/main.ts", "targets/desktop/preload.ts"]
+}

--- a/packages/harness-cli/templates/research/tsconfig.json
+++ b/packages/harness-cli/templates/research/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  // The Node build (`tsc --noEmit` typechecks; esbuild bundles): the harness
+  // center under `harness/` + the Node entrypoints under `targets/` — the cli
+  // boot + the web serve host — as NodeNext ESM. The cli + serve builds DIVERGE
+  // from `blank`: the harness imports the 7 tuned `.eta` prompt sources, so those
+  // bundles are produced by esbuild (`--loader:.eta=text`), not plain `tsc` —
+  // `types/eta.d.ts` is the type-only shim that lets tsc accept those imports.
+  // The tree is partitioned by runtime across THREE configs: the DOM sources
+  // (browser + Electron renderer React) typecheck via tsconfig.web.json; the
+  // Electron main + preload (CommonJS context, `__dirname`) via
+  // tsconfig.electron.json — so no `.ts` is left unchecked.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["harness/**/*", "targets/**/*", "types/**/*"],
+  // Excluded here (built/typechecked by the sibling configs above): the whole
+  // Electron target (main/preload are CJS, App/view are DOM-React) and the web
+  // browser sources.
+  "exclude": [
+    "targets/desktop",
+    "targets/web/main.tsx",
+    "targets/web/boot.ts",
+    "targets/web/web-bridge.ts"
+  ]
+}

--- a/packages/harness-cli/templates/research/tsconfig.web.json
+++ b/packages/harness-cli/templates/research/tsconfig.web.json
@@ -1,0 +1,29 @@
+{
+  // Typecheck-only config for the DOM sources — the web browser app + the
+  // Electron renderer view (React). The bundlers (vite / electron-vite) BUILD
+  // them via esbuild (no typecheck); run `tsc -p tsconfig.web.json` to typecheck
+  // them in your editor / CI. The Node `tsconfig.json` compiles the cli boot +
+  // web serve host; tsconfig.electron.json covers the Electron main + preload.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true
+  },
+  "include": [
+    "harness/protocol.ts",
+    "harness/state.ts",
+    "targets/desktop/App.tsx",
+    "targets/desktop/view.tsx",
+    "targets/web/main.tsx",
+    "targets/web/boot.ts",
+    "targets/web/web-bridge.ts"
+  ]
+}

--- a/packages/harness-cli/templates/research/types/eta.d.ts
+++ b/packages/harness-cli/templates/research/types/eta.d.ts
@@ -1,0 +1,13 @@
+/**
+ * `.eta` files are prompt-template sources. esbuild's `--loader:.eta=text`
+ * inlines them as string constants into the bundle at build time, so the
+ * running bundle does no fs.readFileSync. (The sources themselves DO ship as
+ * src/prompts/*.eta via the `files` whitelist — they're just carried inlined,
+ * not read from disk.) This ambient declaration is TYPE-only: it satisfies
+ * tsc for the imports but provides NO runtime loader, so a module that imports
+ * `.eta` must be esbuilt — it cannot be executed as raw TS under tsx/node.
+ */
+declare module '*.eta' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
Adds the second `create` template — reasoning.run's RACE/DRB-tuned **recon → plan → agents → synth** research pipeline as an editable starter — plus the `--template` flag. It's built on the **same uniform harness↔platform contract** as `blank` (#58): a reranker-less `Runner` + `provisionAppModels` for services, split from the served compute substrate.

> Depends conceptually on #58 (the shared contract) but touches no overlapping files — both are independently mergeable.

## Structure
- **`harness/`**: the copied pipeline (`harness.ts` / `pipeline.ts` / `reducer.ts` / `state-core.ts` + the 7 tuned `.eta` prompts under `prompts/`), plus the contract seam:
  - `runner-ctx.ts` — the reranker-less `Runner` interface + `RunnerCtx`.
  - `served-runtime.ts` — `makeEdgeRunner`/`makeServedRunner` (reranker-less) + `createServedContext`/`createServedChannels`.
  - `served-session.ts` — per-session `provisionAppModels` → `makeServedRunner` → `harness`.
  - `config-types.ts` — the `Config` family.
- **`targets/{cli,desktop,web}`**: cli esbuilds the harness (`.eta` loader); web serves over the canonical **host + generated driver** (`createServedHostDriver` + `wss`); desktop forks the cli bin (`RR_BRIDGE → ipc`). `corpus` + `web` declare `services:[reranker]`, so `provisionAppModels` resolves + loads the cross-encoder (nCtx 16384) and publishes it on `RerankerCtx`.
- **`create.ts`**: `--template <blank|research>` (default `blank`).

`SNAPSHOT: reasoning.run @ main` markers track drift from the reference.

## Verification
`create x --template research` → `npm install` → `npm run typecheck` (node/web/electron) clean; `esbuild` cli 134kb + serve 104kb (the `.eta` chain resolves through the `runner-ctx`/`served-runtime` split). A headless fork-IPC boot loaded the llm **and** the reranker via `provisionAppModels` (the nCtx-16384 context), then enabled `corpus`+`web` — reaching `ui:composer` with **zero** `boot:error` (corpus.enable hard-throws without a provisioned `RerankerCtx`, so a clean boot is the provisioning proof).

No `harness.dev` version bump — reaches users on the next CLI republish.
