### PR TITLE
feat(harness-cli): interactive create (Ink) + dispatcher hardening + ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@alcalzone/ansi-tokenize/-/ansi-tokenize-0.1.3.tgz",
       "integrity": "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -433,14 +432,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -582,7 +581,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -595,7 +593,6 @@
       "version": "6.2.3",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -621,7 +618,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/auto-bind/-/auto-bind-5.0.1.tgz",
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -665,7 +661,6 @@
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -694,7 +689,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
       "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -707,13 +701,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-4.0.0.tgz",
       "integrity": "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^4.0.0"
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-3.4.0.tgz",
+      "integrity": "sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -757,7 +762,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
       "integrity": "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "convert-to-spaces": "^2.0.1"
@@ -775,7 +779,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/convert-to-spaces/-/convert-to-spaces-2.0.1.tgz",
       "integrity": "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -813,8 +816,17 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -902,10 +914,33 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.50.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.50.0.tgz",
+      "integrity": "sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks",
+        "tests/types"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.27.4",
@@ -1376,7 +1411,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1447,6 +1481,21 @@
         }
       }
     },
+    "node_modules/figures": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
+      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-unicode-supported": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "dev": true,
@@ -1457,6 +1506,18 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -1518,7 +1579,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
       "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -1577,6 +1637,24 @@
         }
       }
     },
+    "node_modules/ink-testing-library": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/ink-testing-library/-/ink-testing-library-4.0.0.tgz",
+      "integrity": "sha512-yF92kj3pmBvk7oKbSq5vEALO//o7Z9Ck/OaLNlkzXNeYdwfpxMQkSowGTFUCS5MSu9bWfSZMewGpp7bFc66D7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/is-ci": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
@@ -1594,10 +1672,24 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
       "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-in-ci": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ci/-/is-in-ci-1.0.0.tgz",
+      "integrity": "sha512-eUuAjybVTHMYWm/U+vBO1sY/JOCgoPCXRxzdju0K+K0BiGW0SChEL1MLC0PoCIR1OlPo5YAp8HuQoUlsWEICwg==",
+      "license": "MIT",
+      "bin": {
+        "is-in-ci": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -1611,6 +1703,18 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-upper-case": {
@@ -1627,7 +1731,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lightningcss": {
@@ -1718,7 +1821,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -1765,7 +1867,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -1834,7 +1935,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -1850,7 +1950,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/patch-console/-/patch-console-2.0.0.tgz",
       "integrity": "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -1933,7 +2032,6 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -1946,7 +2044,6 @@
       "version": "0.29.2",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.29.2.tgz",
       "integrity": "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -1971,7 +2068,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-4.0.0.tgz",
       "integrity": "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^5.1.0",
@@ -2020,7 +2116,6 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -2047,7 +2142,6 @@
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/slice-ansi": {
@@ -2079,7 +2173,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
@@ -2120,7 +2213,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -2474,7 +2566,6 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -2505,6 +2596,12 @@
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
       }
+    },
+    "node_modules/yoga-layout": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+      "integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+      "license": "MIT"
     },
     "node_modules/yoga-wasm-web": {
       "version": "0.3.3",
@@ -2567,11 +2664,231 @@
       "name": "harness.dev",
       "version": "0.5.1",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@inkjs/ui": "^2.0.0",
+        "ink": "^5.0.1",
+        "react": "^18.3.1"
+      },
       "bin": {
         "harness.dev": "dist/cli.js"
       },
+      "devDependencies": {
+        "@types/react": "^18.3.12",
+        "ink-testing-library": "^4.0.0"
+      },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "packages/harness-cli/node_modules/@inkjs/ui": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@inkjs/ui/-/ui-2.0.0.tgz",
+      "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "cli-spinners": "^3.0.0",
+        "deepmerge": "^4.3.1",
+        "figures": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "ink": ">=5"
+      }
+    },
+    "packages/harness-cli/node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/cli-truncate": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
+      "integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^5.0.0",
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/cli-truncate/node_modules/slice-ansi": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+      "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.0.0",
+        "is-fullwidth-code-point": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "packages/harness-cli/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT"
+    },
+    "packages/harness-cli/node_modules/ink": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/ink/-/ink-5.2.1.tgz",
+      "integrity": "sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@alcalzone/ansi-tokenize": "^0.1.3",
+        "ansi-escapes": "^7.0.0",
+        "ansi-styles": "^6.2.1",
+        "auto-bind": "^5.0.1",
+        "chalk": "^5.3.0",
+        "cli-boxes": "^3.0.0",
+        "cli-cursor": "^4.0.0",
+        "cli-truncate": "^4.0.0",
+        "code-excerpt": "^4.0.0",
+        "es-toolkit": "^1.22.0",
+        "indent-string": "^5.0.0",
+        "is-in-ci": "^1.0.0",
+        "patch-console": "^2.0.0",
+        "react-reconciler": "^0.29.0",
+        "scheduler": "^0.23.0",
+        "signal-exit": "^3.0.7",
+        "slice-ansi": "^7.1.0",
+        "stack-utils": "^2.0.6",
+        "string-width": "^7.2.0",
+        "type-fest": "^4.27.0",
+        "widest-line": "^5.0.0",
+        "wrap-ansi": "^9.0.0",
+        "ws": "^8.18.0",
+        "yoga-layout": "~3.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "react": ">=18.0.0",
+        "react-devtools-core": "^4.19.1"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react-devtools-core": {
+          "optional": true
+        }
+      }
+    },
+    "packages/harness-cli/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "packages/harness-cli/node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/widest-line": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-5.0.0.tgz",
+      "integrity": "sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/harness-cli/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "packages/host": {

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -26,13 +26,22 @@
     "llm"
   ],
   "license": "Apache-2.0",
-  "type": "commonjs",
+  "type": "module",
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "build": "tsc -b",
     "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "@inkjs/ui": "^2.0.0",
+    "ink": "^5.0.1",
+    "react": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.12",
+    "ink-testing-library": "^4.0.0"
   },
   "files": [
     "dist/**/*.js",

--- a/packages/harness-cli/src/cli.ts
+++ b/packages/harness-cli/src/cli.ts
@@ -17,11 +17,12 @@
  */
 
 import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
-import { DEFAULT_COMMAND, findCommand } from './commands';
+import { join, dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { findCommand } from './commands/index.js';
 
 function version(): string {
-  const pkgPath = join(__dirname, '..', 'package.json');
+  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json');
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
   return pkg.version;
 }
@@ -32,7 +33,8 @@ function printHelp(): void {
       'harness.dev — Harness Development Kit CLI',
       '',
       'Usage:',
-      '  npx harness.dev <name>               Scaffold a new harness',
+      '  npx harness.dev create [name]        Scaffold a new harness (interactive if no name)',
+      '  npx harness.dev create --template research   Use the tuned research template',
       '  npx harness.dev app <name>           Scaffold a new app',
       '  npx harness.dev install <name>       Install a signed app from apps.lloyal.ai',
       '  npx harness.dev publish              Submit an app for review + signing',
@@ -53,7 +55,7 @@ function printHelp(): void {
   );
 }
 
-async function main(argv: readonly string[]): Promise<number> {
+export async function main(argv: readonly string[]): Promise<number> {
   const [first, ...rest] = argv;
 
   if (first === '--version' || first === '-v') {
@@ -70,17 +72,26 @@ async function main(argv: readonly string[]): Promise<number> {
     return named.run(rest);
   }
 
-  // Not a recognized subcommand → default action (scaffold a harness),
-  // treating `first` as the harness name.
-  return DEFAULT_COMMAND.run([...argv]);
+  // Unknown command → error, NOT a silent scaffold. Scaffolding now requires the
+  // explicit `create` verb (a bare `harness.dev my-harness` used to make a
+  // directory, so a mistyped subcommand silently scaffolded one).
+  const suggestion = first.startsWith('-') ? '' : ` Did you mean \`harness.dev create ${first}\`?`;
+  process.stderr.write(
+    `harness.dev: unknown command "${first}".${suggestion} Run \`harness.dev --help\` for usage.\n`,
+  );
+  return 1;
 }
 
-void main(process.argv.slice(2)).then(
-  (code) => {
-    process.exitCode = code;
-  },
-  (err: unknown) => {
-    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-    process.exitCode = 1;
-  },
-);
+// Auto-run only when invoked as the CLI entrypoint — importing this module (e.g.
+// from a test) must NOT dispatch on the importer's argv.
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  void main(process.argv.slice(2)).then(
+    (code) => {
+      process.exitCode = code;
+    },
+    (err: unknown) => {
+      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+      process.exitCode = 1;
+    },
+  );
+}

--- a/packages/harness-cli/src/cli.ts
+++ b/packages/harness-cli/src/cli.ts
@@ -2,10 +2,9 @@
 /**
  * `harness.dev` — the Harness Development Kit CLI.
  *
- * Thin dispatcher. The first positional selects a named subcommand
- * (currently just `app`); if it isn't one, the whole argv is treated as
- * the default action — scaffolding a harness (`harness.dev <name>`),
- * also reachable as the explicit `create` verb.
+ * Thin dispatcher. The first token selects a command by name (`new`,
+ * `app:new`, `install`, …); an unknown token is an ERROR, never a silent
+ * scaffold. Scaffolding a harness is the explicit `new` verb.
  * Global `--help` / `--version` are handled here; all other flag parsing
  * belongs to the individual command.
  *
@@ -33,9 +32,9 @@ function printHelp(): void {
       'harness.dev — Harness Development Kit CLI',
       '',
       'Usage:',
-      '  npx harness.dev create [name]        Scaffold a new harness (interactive if no name)',
-      '  npx harness.dev create --template research   Use the tuned research template',
-      '  npx harness.dev app <name>           Scaffold a new app',
+      '  npx harness.dev new [name]           Scaffold a new harness (interactive if no name)',
+      '  npx harness.dev new --template research       Start from the tuned research template',
+      '  npx harness.dev app:new <name>       Scaffold a new app',
       '  npx harness.dev install <name>       Install a signed app from apps.lloyal.ai',
       '  npx harness.dev publish              Submit an app for review + signing',
       '  npx harness.dev publish status <id>  Check the status of a submission',
@@ -73,9 +72,9 @@ export async function main(argv: readonly string[]): Promise<number> {
   }
 
   // Unknown command → error, NOT a silent scaffold. Scaffolding now requires the
-  // explicit `create` verb (a bare `harness.dev my-harness` used to make a
+  // explicit `new` verb (a bare `harness.dev my-harness` used to make a
   // directory, so a mistyped subcommand silently scaffolded one).
-  const suggestion = first.startsWith('-') ? '' : ` Did you mean \`harness.dev create ${first}\`?`;
+  const suggestion = first.startsWith('-') ? '' : ` Did you mean \`harness.dev new ${first}\`?`;
   process.stderr.write(
     `harness.dev: unknown command "${first}".${suggestion} Run \`harness.dev --help\` for usage.\n`,
   );

--- a/packages/harness-cli/src/cli.ts
+++ b/packages/harness-cli/src/cli.ts
@@ -35,7 +35,7 @@ function printHelp(): void {
       '  npx harness.dev new [name]           Scaffold a new harness (interactive if no name)',
       '  npx harness.dev new --template research       Start from the tuned research template',
       '  npx harness.dev app:new <name>       Scaffold a new app',
-      '  npx harness.dev install <name>       Install a signed app from apps.lloyal.ai',
+      '  npx harness.dev install <pub>/<name>[@<semver>]   Install a signed app from apps.lloyal.ai',
       '  npx harness.dev publish              Submit an app for review + signing',
       '  npx harness.dev publish status <id>  Check the status of a submission',
       '  npx harness.dev publishers register  Claim a publisher handle + attest ToS',

--- a/packages/harness-cli/src/command.ts
+++ b/packages/harness-cli/src/command.ts
@@ -8,7 +8,7 @@
  */
 
 export interface Command {
-  /** The token typed after `harness` (e.g. `create-app`). */
+  /** The token typed after `harness.dev` (e.g. `new`, `app:new`, `install`). */
   readonly name: string;
   /** One-line description shown in the top-level help listing. */
   readonly summary: string;

--- a/packages/harness-cli/src/commands/app.ts
+++ b/packages/harness-cli/src/commands/app.ts
@@ -5,10 +5,10 @@ import { fileURLToPath } from 'node:url';
 import type { Command } from '../command.js';
 
 const USAGE = [
-  'harness.dev app — scaffold a new HDK app',
+  'harness.dev app:new — scaffold a new HDK app',
   '',
   'Usage:',
-  '  npx harness.dev app <name> [--dir <path>] [--publisher <handle>]',
+  '  npx harness.dev app:new <name> [--dir <path>] [--publisher <handle>]',
   '',
   'Arguments:',
   '  <name>              App name (lowercase, [a-z][a-z0-9_-]{1,63}) — also the',
@@ -28,12 +28,12 @@ const USAGE = [
   'compatible.',
 ].join('\n');
 
-// Pattern shared with `harness.dev create`: identifier grammar that
+// Pattern shared with `harness.dev new`: identifier grammar that
 // satisfies App protocol + npm scoped-name conventions.
 const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
 
 export const appCommand: Command = {
-  name: 'app',
+  name: 'app:new',
   summary: 'Scaffold a new HDK app',
   usage: USAGE,
   async run(argv) {
@@ -54,12 +54,12 @@ export const appCommand: Command = {
 
     const name = positionals[0];
     if (!name) {
-      process.stderr.write('harness.dev app: missing <name>\n\n' + USAGE + '\n');
+      process.stderr.write('harness.dev app:new: missing <name>\n\n' + USAGE + '\n');
       return 1;
     }
     if (!NAME_RE.test(name)) {
       process.stderr.write(
-        `harness.dev app: invalid <name> "${name}" — expected [a-z][a-z0-9_-]{1,63}.\n`,
+        `harness.dev app:new: invalid <name> "${name}" — expected [a-z][a-z0-9_-]{1,63}.\n`,
       );
       return 1;
     }
@@ -69,7 +69,7 @@ export const appCommand: Command = {
     const publisher = (values.publisher ?? 'your-handle').replace(/^@/, '');
     if (!NAME_RE.test(publisher)) {
       process.stderr.write(
-        `harness.dev app: invalid --publisher "${publisher}" — expected [a-z][a-z0-9_-]{1,63}.\n`,
+        `harness.dev app:new: invalid --publisher "${publisher}" — expected [a-z][a-z0-9_-]{1,63}.\n`,
       );
       return 1;
     }
@@ -79,7 +79,7 @@ export const appCommand: Command = {
     try {
       if (statSync(dest).isDirectory()) {
         process.stderr.write(
-          `harness.dev app: ${dest} already exists. Choose a different name or remove the directory first.\n`,
+          `harness.dev app:new: ${dest} already exists. Choose a different name or remove the directory first.\n`,
         );
         return 1;
       }
@@ -94,7 +94,7 @@ export const appCommand: Command = {
       copyTreeWithSubstitutions(templateDir, dest, substitutions);
     } catch (err) {
       process.stderr.write(
-        `harness.dev app: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        `harness.dev app:new: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       return 1;
     }

--- a/packages/harness-cli/src/commands/app.ts
+++ b/packages/harness-cli/src/commands/app.ts
@@ -1,7 +1,8 @@
 import { parseArgs } from 'node:util';
 import { readdirSync, readFileSync, mkdirSync, writeFileSync, statSync } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
-import type { Command } from '../command';
+import { fileURLToPath } from 'node:url';
+import type { Command } from '../command.js';
 
 const USAGE = [
   'harness.dev app — scaffold a new HDK app',
@@ -121,7 +122,7 @@ export const appCommand: Command = {
  * `<pkg-root>/templates/<kind>`.
  */
 function resolveTemplateDir(kind: 'app' | 'harness'): string {
-  const here = __dirname;
+  const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
     resolve(here, '..', '..', 'templates', kind),
     resolve(here, '..', 'templates', kind),

--- a/packages/harness-cli/src/commands/create-wizard.tsx
+++ b/packages/harness-cli/src/commands/create-wizard.tsx
@@ -1,0 +1,154 @@
+/**
+ * The interactive `create` picker — an Ink wizard that collects
+ * name → targets → model → template, then hands the answers back for the pure
+ * scaffold logic to act on. Mounted ONLY when `create` runs in a TTY with
+ * arguments missing; flags + non-TTY take the plain path in `create.ts`.
+ *
+ * Built on Ink + `@inkjs/ui` (pure-JS, MIT) — the same stack the scaffolded
+ * harnesses render in, so the tool eats its own dog food. It stays thin: no
+ * scaffolding happens here, only data collection.
+ */
+import { useState } from 'react';
+import { Box, Text, render, useApp, useInput } from 'ink';
+import { TextInput, Select, MultiSelect, StatusMessage } from '@inkjs/ui';
+import { modelsForRole } from '../scaffold/model-catalog.js';
+import type { Target } from '../scaffold/prune-targets.js';
+
+export type TemplateKind = 'blank' | 'research';
+
+export interface WizardResult {
+  name: string;
+  targets: Target[];
+  llmId: string;
+  template: TemplateKind;
+}
+
+/** Same grammar as the non-interactive path (`create.ts` NAME_RE). */
+const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
+const TARGET_ORDER: Target[] = ['cli', 'desktop', 'web'];
+
+export function orderTargets(values: string[]): Target[] {
+  const set = new Set(values);
+  set.add('cli'); // cli carries the engine bin — always kept
+  return TARGET_ORDER.filter((t) => set.has(t));
+}
+
+export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => void }): React.ReactElement {
+  const { exit } = useApp();
+  const llms = modelsForRole('llm');
+  const defaultLlm = llms[0]?.id ?? 'reasoning-4b';
+
+  const [step, setStep] = useState(0);
+  const [name, setName] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [targets, setTargets] = useState<Target[]>(['cli', 'desktop', 'web']);
+  const [llmId, setLlmId] = useState(defaultLlm);
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') {
+      onDone(null);
+      exit();
+    }
+  });
+
+  const submitName = (value: string): void => {
+    const trimmed = value.trim();
+    if (!NAME_RE.test(trimmed)) {
+      setNameError(`"${trimmed}" — expected [a-z][a-z0-9_-]{1,63} (lowercase, starts with a letter).`);
+      return;
+    }
+    setName(trimmed);
+    setNameError(null);
+    setStep(1);
+  };
+
+  const submitTargets = (values: string[]): void => {
+    setTargets(orderTargets(values));
+    setStep(2);
+  };
+
+  const submitModel = (value: string): void => {
+    setLlmId(value);
+    setStep(3);
+  };
+
+  const submitTemplate = (value: string): void => {
+    onDone({ name, targets, llmId, template: value as TemplateKind });
+    exit();
+  };
+
+  return (
+    <Box flexDirection="column" gap={1}>
+      <Text bold>Scaffold a new harness</Text>
+
+      {step > 0 && <Text dimColor>{`  name      ${name}`}</Text>}
+      {step > 1 && <Text dimColor>{`  targets   ${targets.join(', ')}`}</Text>}
+      {step > 2 && <Text dimColor>{`  model     ${llmId}`}</Text>}
+
+      {step === 0 && (
+        <Box flexDirection="column">
+          <Text>Harness name:</Text>
+          <TextInput placeholder="my-harness" onSubmit={submitName} />
+          {nameError && <StatusMessage variant="error">{nameError}</StatusMessage>}
+        </Box>
+      )}
+
+      {step === 1 && (
+        <Box flexDirection="column">
+          <Text>Targets (space to toggle, enter to confirm — cli is always included):</Text>
+          <MultiSelect
+            options={[
+              { label: 'cli (required)', value: 'cli' },
+              { label: 'desktop', value: 'desktop' },
+              { label: 'web', value: 'web' },
+            ]}
+            defaultValue={targets}
+            onSubmit={submitTargets}
+          />
+        </Box>
+      )}
+
+      {step === 2 && (
+        <Box flexDirection="column">
+          <Text>Model:</Text>
+          <Select
+            options={llms.map((m) => ({ label: m.label, value: m.id }))}
+            defaultValue={defaultLlm}
+            onChange={submitModel}
+          />
+        </Box>
+      )}
+
+      {step === 3 && (
+        <Box flexDirection="column">
+          <Text>Template:</Text>
+          <Select
+            options={[
+              { label: 'blank — minimal 2-agent pipeline', value: 'blank' },
+              { label: 'research — tuned recon → plan → agents → synth', value: 'research' },
+            ]}
+            onChange={submitTemplate}
+          />
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+/**
+ * Mount the wizard and resolve with the collected answers, or `null` if the
+ * user cancels (Ctrl-C / the Ink app exits before completing).
+ */
+export function runCreateWizard(): Promise<WizardResult | null> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const done = (result: WizardResult | null): void => {
+      if (!settled) {
+        settled = true;
+        resolve(result);
+      }
+    };
+    const { waitUntilExit } = render(<Wizard onDone={done} />);
+    void waitUntilExit().then(() => done(null));
+  });
+}

--- a/packages/harness-cli/src/commands/create-wizard.tsx
+++ b/packages/harness-cli/src/commands/create-wizard.tsx
@@ -1,14 +1,20 @@
 /**
- * The interactive `create` picker — an Ink wizard that collects
+ * The interactive `new` picker — an Ink wizard that collects
  * name → targets → model → template, then hands the answers back for the pure
- * scaffold logic to act on. Mounted ONLY when `create` runs in a TTY with
- * arguments missing; flags + non-TTY take the plain path in `create.ts`.
+ * scaffold logic to act on. Mounted ONLY when `new` runs in a TTY with the
+ * name missing; a provided name / `--yes` / non-TTY take the plain path in
+ * `create.ts`.
+ *
+ * Any flags the user DID pass (`--template`/`--targets`/`--model`) pre-seed the
+ * wizard, so it prompts only for what's missing (flag-compose). Each question
+ * carries a one-line teaching note — the picker doubles as a tour of the
+ * conventions.
  *
  * Built on Ink + `@inkjs/ui` (pure-JS, MIT) — the same stack the scaffolded
  * harnesses render in, so the tool eats its own dog food. It stays thin: no
  * scaffolding happens here, only data collection.
  */
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { Box, Text, render, useApp, useInput } from 'ink';
 import { TextInput, Select, MultiSelect, StatusMessage } from '@inkjs/ui';
 import { modelsForRole } from '../scaffold/model-catalog.js';
@@ -19,13 +25,22 @@ export type TemplateKind = 'blank' | 'research';
 export interface WizardResult {
   name: string;
   targets: Target[];
-  llmId: string;
+  /** Catalog id OR a BYO `.gguf` path (see `applyModelChoice`). */
+  llm: string;
   template: TemplateKind;
+}
+
+/** Flags already provided on the command line — the wizard skips these steps. */
+export interface WizardPrefill {
+  template?: TemplateKind;
+  targets?: Target[];
+  llm?: string;
 }
 
 /** Same grammar as the non-interactive path (`create.ts` NAME_RE). */
 const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
 const TARGET_ORDER: Target[] = ['cli', 'desktop', 'web'];
+const DEFAULT_TARGETS: Target[] = ['cli', 'desktop', 'web'];
 
 export function orderTargets(values: string[]): Target[] {
   const set = new Set(values);
@@ -33,16 +48,40 @@ export function orderTargets(values: string[]): Target[] {
   return TARGET_ORDER.filter((t) => set.has(t));
 }
 
-export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => void }): React.ReactElement {
+/** The screens the wizard walks, minus any the flags already answered. */
+type StepId = 'name' | 'targets' | 'model' | 'byo' | 'template';
+
+function initialQueue(prefill: WizardPrefill): StepId[] {
+  const q: StepId[] = ['name']; // the wizard only mounts when the name is missing
+  if (!prefill.targets) q.push('targets');
+  if (!prefill.llm) q.push('model');
+  if (!prefill.template) q.push('template');
+  return q;
+}
+
+export function Wizard({
+  onDone,
+  prefill = {},
+}: {
+  onDone: (result: WizardResult | null) => void;
+  prefill?: WizardPrefill;
+}): React.ReactElement {
   const { exit } = useApp();
   const llms = modelsForRole('llm');
   const defaultLlm = llms[0]?.id ?? 'reasoning-4b';
+  const defaultLlmLabel = llms[0]?.label ?? defaultLlm;
 
-  const [step, setStep] = useState(0);
+  const [queue, setQueue] = useState<StepId[]>(() => initialQueue(prefill));
+  const step = queue[0];
+
+  // The running answers. A ref so finalize() never reads stale state after the
+  // last step's setState hasn't flushed; useState mirrors it for the summary.
+  const collected = useRef<Partial<WizardResult>>({});
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState<string | null>(null);
-  const [targets, setTargets] = useState<Target[]>(['cli', 'desktop', 'web']);
-  const [llmId, setLlmId] = useState(defaultLlm);
+  const [byoError, setByoError] = useState<string | null>(null);
+  const [targets, setTargets] = useState<Target[]>(prefill.targets ?? DEFAULT_TARGETS);
+  const [llm, setLlm] = useState(prefill.llm ?? defaultLlm);
 
   useInput((input, key) => {
     if (key.ctrl && input === 'c') {
@@ -50,6 +89,22 @@ export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => vo
       exit();
     }
   });
+
+  /** Commit a patch, then move to `nextQueue` — or finalize when it's empty. */
+  const advance = (nextQueue: StepId[], patch: Partial<WizardResult>): void => {
+    collected.current = { ...collected.current, ...patch };
+    if (nextQueue.length === 0) {
+      onDone({
+        name: collected.current.name ?? '',
+        targets: collected.current.targets ?? prefill.targets ?? DEFAULT_TARGETS,
+        llm: collected.current.llm ?? prefill.llm ?? defaultLlm,
+        template: collected.current.template ?? prefill.template ?? 'blank',
+      });
+      exit();
+      return;
+    }
+    setQueue(nextQueue);
+  };
 
   const submitName = (value: string): void => {
     const trimmed = value.trim();
@@ -59,43 +114,67 @@ export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => vo
     }
     setName(trimmed);
     setNameError(null);
-    setStep(1);
+    advance(queue.slice(1), { name: trimmed });
   };
 
   const submitTargets = (values: string[]): void => {
-    setTargets(orderTargets(values));
-    setStep(2);
+    const ordered = orderTargets(values);
+    setTargets(ordered);
+    advance(queue.slice(1), { targets: ordered });
   };
 
   const submitModel = (value: string): void => {
-    setLlmId(value);
-    setStep(3);
+    if (value === 'byo') {
+      // Detour to the path prompt before continuing with the remaining steps.
+      setQueue(['byo', ...queue.slice(1)]);
+      return;
+    }
+    // 'recommended' and 'later' both write the catalog default; the difference
+    // is framing (the summary note nudges "later" toward editing harness.yml).
+    setLlm(defaultLlm);
+    advance(queue.slice(1), { llm: defaultLlm });
+  };
+
+  const submitByo = (value: string): void => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      setByoError('Enter a path to a local .gguf, or press Ctrl-C to cancel.');
+      return;
+    }
+    setLlm(trimmed);
+    setByoError(null);
+    advance(queue.slice(1), { llm: trimmed });
   };
 
   const submitTemplate = (value: string): void => {
-    onDone({ name, targets, llmId, template: value as TemplateKind });
-    exit();
+    advance(queue.slice(1), { template: value as TemplateKind });
   };
 
   return (
     <Box flexDirection="column" gap={1}>
       <Text bold>Scaffold a new harness</Text>
 
-      {step > 0 && <Text dimColor>{`  name      ${name}`}</Text>}
-      {step > 1 && <Text dimColor>{`  targets   ${targets.join(', ')}`}</Text>}
-      {step > 2 && <Text dimColor>{`  model     ${llmId}`}</Text>}
+      {collected.current.name && <Text dimColor>{`  name      ${collected.current.name}`}</Text>}
+      {collected.current.targets && (
+        <Text dimColor>{`  targets   ${collected.current.targets.join(', ')}`}</Text>
+      )}
+      {collected.current.llm && <Text dimColor>{`  model     ${collected.current.llm}`}</Text>}
 
-      {step === 0 && (
+      {step === 'name' && (
         <Box flexDirection="column">
           <Text>Harness name:</Text>
+          <Text dimColor>lowercase letters, digits, - and _ — becomes the folder and npm name.</Text>
           <TextInput placeholder="my-harness" onSubmit={submitName} />
           {nameError && <StatusMessage variant="error">{nameError}</StatusMessage>}
         </Box>
       )}
 
-      {step === 1 && (
+      {step === 'targets' && (
         <Box flexDirection="column">
           <Text>Targets (space to toggle, enter to confirm — cli is always included):</Text>
+          <Text dimColor>
+            cli = terminal · desktop = native window · web = browser app + host, one reduce.
+          </Text>
           <MultiSelect
             options={[
               { label: 'cli (required)', value: 'cli' },
@@ -108,20 +187,34 @@ export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => vo
         </Box>
       )}
 
-      {step === 2 && (
+      {step === 'model' && (
         <Box flexDirection="column">
-          <Text>Model:</Text>
+          <Text>Trunk model:</Text>
+          <Text dimColor>catalog models are fetched + digest-verified on first run — no API key.</Text>
           <Select
-            options={llms.map((m) => ({ label: m.label, value: m.id }))}
-            defaultValue={defaultLlm}
+            options={[
+              { label: `Recommended — ${defaultLlmLabel}`, value: 'recommended' },
+              { label: 'Bring your own — a local .gguf you already have', value: 'byo' },
+              { label: 'Decide later — keep the default, edit harness.yml', value: 'later' },
+            ]}
             onChange={submitModel}
           />
         </Box>
       )}
 
-      {step === 3 && (
+      {step === 'byo' && (
+        <Box flexDirection="column">
+          <Text>Path to your .gguf:</Text>
+          <Text dimColor>absolute, or relative to the project — trusted as-is, not digest-verified.</Text>
+          <TextInput placeholder="./models/llm/my-model.gguf" onSubmit={submitByo} />
+          {byoError && <StatusMessage variant="error">{byoError}</StatusMessage>}
+        </Box>
+      )}
+
+      {step === 'template' && (
         <Box flexDirection="column">
           <Text>Template:</Text>
+          <Text dimColor>the starting point — you own the code either way.</Text>
           <Select
             options={[
               { label: 'blank — minimal 2-agent pipeline', value: 'blank' },
@@ -137,9 +230,10 @@ export function Wizard({ onDone }: { onDone: (result: WizardResult | null) => vo
 
 /**
  * Mount the wizard and resolve with the collected answers, or `null` if the
- * user cancels (Ctrl-C / the Ink app exits before completing).
+ * user cancels (Ctrl-C / the Ink app exits before completing). Any `prefill`
+ * (flags already provided) narrows the questions asked.
  */
-export function runCreateWizard(): Promise<WizardResult | null> {
+export function runCreateWizard(prefill: WizardPrefill = {}): Promise<WizardResult | null> {
   return new Promise((resolve) => {
     let settled = false;
     const done = (result: WizardResult | null): void => {
@@ -148,7 +242,7 @@ export function runCreateWizard(): Promise<WizardResult | null> {
         resolve(result);
       }
     };
-    const { waitUntilExit } = render(<Wizard onDone={done} />);
+    const { waitUntilExit } = render(<Wizard onDone={done} prefill={prefill} />);
     void waitUntilExit().then(() => done(null));
   });
 }

--- a/packages/harness-cli/src/commands/create.ts
+++ b/packages/harness-cli/src/commands/create.ts
@@ -12,17 +12,18 @@ import type { Command } from '../command.js';
 import { pruneTargets, type Target } from '../scaffold/prune-targets.js';
 import { applyModelChoice } from '../scaffold/apply-model.js';
 import { MODEL_CATALOG, modelsForRole } from '../scaffold/model-catalog.js';
-import { runCreateWizard, type TemplateKind } from './create-wizard.js';
+import { runCreateWizard, type TemplateKind, type WizardPrefill } from './create-wizard.js';
 
 const USAGE = [
-  'harness.dev create — scaffold a new harness project',
+  'harness.dev new — scaffold a new harness project',
   '',
   'Usage:',
-  '  npx harness.dev create                      Interactive: name → targets → model → template',
-  '  npx harness.dev create <name> [options]     Non-interactive (flags below)',
+  '  npx harness.dev new                         Interactive: name → targets → model → template',
+  '  npx harness.dev new <name> [options]        Non-interactive (flags below)',
   '',
   'Arguments:',
-  '  <name>        Harness project name — also the directory created.',
+  '  <name>        Harness project name — also the directory created. Omit it in a',
+  '                terminal to launch the interactive picker.',
   '',
   'Options:',
   '  --template <blank|research>',
@@ -32,16 +33,19 @@ const USAGE = [
   '  --targets <list>',
   '                Comma-separated run surfaces to keep (default: cli,desktop,web).',
   '                cli is always included; the rest are pruned from the scaffold.',
-  '  --model <id>  Trunk model id (default: the catalog default). See the catalog',
-  '                with the interactive picker.',
+  '  --model <id|path>',
+  '                Trunk model — a catalog id (fetched + digest-verified) or a path',
+  '                to a local .gguf you already have. Default: the catalog default.',
   '  --dir <path>  Parent directory to create the harness in (default: cwd)',
+  '  -y, --yes     Skip the picker; accept defaults for anything not given a flag.',
   '  -h, --help    Show this help',
   '',
-  'Emits a runnable harness on the selected surfaces, on a resident model (fetched',
-  '+ verified on first run — no API key). Run `npm install && npm start`.',
+  'Any flags you pass also pre-seed the picker, so it prompts only for what is',
+  'missing. Emits a runnable harness on the selected surfaces, on a resident model',
+  '(fetched + verified on first run — no API key). Run `npm install && npm start`.',
 ].join('\n');
 
-// Same grammar as `harness.dev app`: identifier-safe lowercase that
+// Same grammar as `harness.dev app:new`: identifier-safe lowercase that
 // satisfies both directory and npm package-name conventions.
 const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
 const ALL_TARGETS: Target[] = ['cli', 'desktop', 'web'];
@@ -50,12 +54,16 @@ interface ScaffoldPlan {
   name: string;
   template: TemplateKind;
   targets: Target[];
-  llmId: string;
+  /** Catalog id OR a BYO `.gguf` path (see `applyModelChoice`). */
+  llm: string;
 }
 
+/** Flags shared by both paths — undefined means "not provided" (ask / default). */
+type Flags = WizardPrefill;
+
 export const createCommand: Command = {
-  name: 'create',
-  summary: 'Scaffold a new harness (the default action — name is optional verb)',
+  name: 'new',
+  summary: 'Scaffold a new harness (interactive when run without a name)',
   usage: USAGE,
   async run(argv) {
     const { values, positionals } = parseArgs({
@@ -66,6 +74,7 @@ export const createCommand: Command = {
         template: { type: 'string' },
         targets: { type: 'string' },
         model: { type: 'string' },
+        yes: { type: 'boolean', short: 'y' },
       },
       allowPositionals: true,
     });
@@ -78,18 +87,27 @@ export const createCommand: Command = {
     const parentDir = resolve(values.dir ?? process.cwd());
     const name = positionals[0];
 
-    // Interactive picker: a bare `harness.dev create` in a TTY. A provided name
-    // (or a non-TTY / piped stdin — CI) takes the flag path below.
+    // Validate any flags once — they seed BOTH the wizard (as a prefill) and the
+    // non-interactive plan (with defaults filled in).
+    const flags = validateFlags(values);
+    if ('error' in flags) {
+      process.stderr.write(`${flags.error}\n`);
+      return 1;
+    }
+
+    // Interactive picker: a bare `harness.dev new` in a TTY. A provided name,
+    // `--yes`, or a non-TTY / piped stdin (CI) takes the flag path below. Any
+    // flags already given pre-seed the picker so it asks only for the rest.
     let plan: ScaffoldPlan;
-    if (!name && process.stdin.isTTY) {
-      const result = await runCreateWizard();
+    if (!name && !values.yes && Boolean(process.stdin.isTTY)) {
+      const result = await runCreateWizard(flags);
       if (!result) {
-        process.stderr.write('create cancelled.\n');
+        process.stderr.write('cancelled.\n');
         return 1;
       }
       plan = result;
     } else {
-      const built = planFromFlags(name, values);
+      const built = planFromFlags(name, flags);
       if ('error' in built) {
         process.stderr.write(`${built.error}\n`);
         if (built.usage) process.stderr.write(`\n${USAGE}\n`);
@@ -102,10 +120,34 @@ export const createCommand: Command = {
   },
 };
 
+/** Validate provided flags without filling defaults (undefined = ask/default). */
+function validateFlags(values: {
+  template?: string;
+  targets?: string;
+  model?: string;
+}): Flags | { error: string } {
+  let template: TemplateKind | undefined;
+  if (values.template != null) {
+    if (values.template !== 'blank' && values.template !== 'research') {
+      return { error: `harness.dev: invalid --template "${values.template}" — expected "blank" or "research".` };
+    }
+    template = values.template;
+  }
+
+  let targets: Target[] | undefined;
+  if (values.targets != null) {
+    const parsed = parseTargets(values.targets);
+    if ('error' in parsed) return { error: `harness.dev: ${parsed.error}` };
+    targets = parsed.targets;
+  }
+
+  return { template, targets, llm: values.model };
+}
+
 /** Build a scaffold plan from CLI flags (the non-interactive path). */
 function planFromFlags(
   name: string | undefined,
-  values: { template?: string; targets?: string; model?: string },
+  flags: Flags,
 ): ScaffoldPlan | { error: string; usage?: boolean } {
   if (!name) {
     return { error: 'harness.dev: missing harness <name>', usage: true };
@@ -114,17 +156,12 @@ function planFromFlags(
     return { error: `harness.dev: invalid <name> "${name}" — expected [a-z][a-z0-9_-]{1,63}.` };
   }
 
-  const template = (values.template ?? 'blank') as TemplateKind;
-  if (template !== 'blank' && template !== 'research') {
-    return { error: `harness.dev: invalid --template "${values.template}" — expected "blank" or "research".` };
-  }
-
-  const targets = parseTargets(values.targets);
-  if ('error' in targets) return { error: `harness.dev: ${targets.error}` };
-
-  const llmId = values.model ?? modelsForRole('llm')[0]?.id ?? 'reasoning-4b';
-
-  return { name, template, targets: targets.targets, llmId };
+  return {
+    name,
+    template: flags.template ?? 'blank',
+    targets: flags.targets ?? [...ALL_TARGETS],
+    llm: flags.llm ?? modelsForRole('llm')[0]?.id ?? 'reasoning-4b',
+  };
 }
 
 /** Parse a `--targets cli,web` list; cli is always retained. */
@@ -162,9 +199,9 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
       pruneTargets(dest, plan.targets);
     }
     const recommendedContext = MODEL_CATALOG.find(
-      (m) => m.role === 'llm' && m.id === plan.llmId,
+      (m) => m.role === 'llm' && m.id === plan.llm,
     )?.recommendedContext;
-    applyModelChoice(dest, { llmId: plan.llmId, context: recommendedContext });
+    applyModelChoice(dest, { llm: plan.llm, context: recommendedContext });
   } catch (err) {
     process.stderr.write(
       `harness.dev: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
@@ -180,7 +217,7 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
 
   process.stdout.write(
     `scaffolded ${plan.name} (${plan.template}) at ${dest}\n` +
-      `  targets: ${plan.targets.join(', ')} · model: ${plan.llmId}\n` +
+      `  targets: ${plan.targets.join(', ')} · model: ${plan.llm}\n` +
       '  next steps:\n' +
       `    cd ${plan.name}\n` +
       '    npm install\n' +
@@ -199,7 +236,7 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
  * `<pkg-root>/dist/commands/create.js`, so the templates are at
  * `<pkg-root>/templates/<kind>`.
  */
-function resolveTemplateDir(kind: 'app' | 'harness' | 'blank' | 'research'): string {
+function resolveTemplateDir(kind: TemplateKind): string {
   const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
     resolve(here, '..', '..', 'templates', kind),

--- a/packages/harness-cli/src/commands/create.ts
+++ b/packages/harness-cli/src/commands/create.ts
@@ -7,13 +7,19 @@ import {
   statSync,
 } from 'node:fs';
 import { join, resolve, dirname } from 'node:path';
-import type { Command } from '../command';
+import { fileURLToPath } from 'node:url';
+import type { Command } from '../command.js';
+import { pruneTargets, type Target } from '../scaffold/prune-targets.js';
+import { applyModelChoice } from '../scaffold/apply-model.js';
+import { MODEL_CATALOG, modelsForRole } from '../scaffold/model-catalog.js';
+import { runCreateWizard, type TemplateKind } from './create-wizard.js';
 
 const USAGE = [
-  'harness.dev — scaffold a new harness project (the default action)',
+  'harness.dev create — scaffold a new harness project',
   '',
   'Usage:',
-  '  npx harness.dev <name> [--template <blank|research>] [--dir <path>]',
+  '  npx harness.dev create                      Interactive: name → targets → model → template',
+  '  npx harness.dev create <name> [options]     Non-interactive (flags below)',
   '',
   'Arguments:',
   '  <name>        Harness project name — also the directory created.',
@@ -23,18 +29,29 @@ const USAGE = [
   '                Starting point (default: blank). blank = a minimal parallel',
   '                pool + synth; research = the tuned recon→plan→agents→synth',
   '                pipeline (grounded multi-agent research).',
+  '  --targets <list>',
+  '                Comma-separated run surfaces to keep (default: cli,desktop,web).',
+  '                cli is always included; the rest are pruned from the scaffold.',
+  '  --model <id>  Trunk model id (default: the catalog default). See the catalog',
+  '                with the interactive picker.',
   '  --dir <path>  Parent directory to create the harness in (default: cwd)',
   '  -h, --help    Show this help',
   '',
-  'Emits a runnable harness on cli + desktop + web off one center, on a resident',
-  'model (fetched + verified on first run — no API key). Run `npm install && npm start`.',
+  'Emits a runnable harness on the selected surfaces, on a resident model (fetched',
+  '+ verified on first run — no API key). Run `npm install && npm start`.',
 ].join('\n');
-
-type TemplateKind = 'blank' | 'research';
 
 // Same grammar as `harness.dev app`: identifier-safe lowercase that
 // satisfies both directory and npm package-name conventions.
 const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
+const ALL_TARGETS: Target[] = ['cli', 'desktop', 'web'];
+
+interface ScaffoldPlan {
+  name: string;
+  template: TemplateKind;
+  targets: Target[];
+  llmId: string;
+}
 
 export const createCommand: Command = {
   name: 'create',
@@ -47,6 +64,8 @@ export const createCommand: Command = {
         help: { type: 'boolean', short: 'h' },
         dir: { type: 'string' },
         template: { type: 'string' },
+        targets: { type: 'string' },
+        model: { type: 'string' },
       },
       allowPositionals: true,
     });
@@ -56,72 +75,123 @@ export const createCommand: Command = {
       return 0;
     }
 
-    const name = positionals[0];
-    if (!name) {
-      process.stderr.write('harness.dev: missing harness <name>\n\n' + USAGE + '\n');
-      return 1;
-    }
-    if (!NAME_RE.test(name)) {
-      process.stderr.write(
-        `harness.dev: invalid <name> "${name}" — expected [a-z][a-z0-9_-]{1,63}.\n`,
-      );
-      return 1;
-    }
-
-    const template = (values.template ?? 'blank') as TemplateKind;
-    if (template !== 'blank' && template !== 'research') {
-      process.stderr.write(
-        `harness.dev: invalid --template "${values.template}" — expected "blank" or "research".\n`,
-      );
-      return 1;
-    }
-
     const parentDir = resolve(values.dir ?? process.cwd());
-    const dest = join(parentDir, name);
+    const name = positionals[0];
 
-    try {
-      if (statSync(dest).isDirectory()) {
-        process.stderr.write(
-          `harness.dev: ${dest} already exists. Choose a different name or remove the directory first.\n`,
-        );
+    // Interactive picker: a bare `harness.dev create` in a TTY. A provided name
+    // (or a non-TTY / piped stdin — CI) takes the flag path below.
+    let plan: ScaffoldPlan;
+    if (!name && process.stdin.isTTY) {
+      const result = await runCreateWizard();
+      if (!result) {
+        process.stderr.write('create cancelled.\n');
         return 1;
       }
-    } catch {
-      // ENOENT — good
+      plan = result;
+    } else {
+      const built = planFromFlags(name, values);
+      if ('error' in built) {
+        process.stderr.write(`${built.error}\n`);
+        if (built.usage) process.stderr.write(`\n${USAGE}\n`);
+        return 1;
+      }
+      plan = built;
     }
 
-    const templateDir = resolveTemplateDir(template);
-    const substitutions = buildSubstitutions(name);
+    return performScaffold(plan, parentDir);
+  },
+};
 
-    try {
-      copyTreeWithSubstitutions(templateDir, dest, substitutions);
-    } catch (err) {
+/** Build a scaffold plan from CLI flags (the non-interactive path). */
+function planFromFlags(
+  name: string | undefined,
+  values: { template?: string; targets?: string; model?: string },
+): ScaffoldPlan | { error: string; usage?: boolean } {
+  if (!name) {
+    return { error: 'harness.dev: missing harness <name>', usage: true };
+  }
+  if (!NAME_RE.test(name)) {
+    return { error: `harness.dev: invalid <name> "${name}" — expected [a-z][a-z0-9_-]{1,63}.` };
+  }
+
+  const template = (values.template ?? 'blank') as TemplateKind;
+  if (template !== 'blank' && template !== 'research') {
+    return { error: `harness.dev: invalid --template "${values.template}" — expected "blank" or "research".` };
+  }
+
+  const targets = parseTargets(values.targets);
+  if ('error' in targets) return { error: `harness.dev: ${targets.error}` };
+
+  const llmId = values.model ?? modelsForRole('llm')[0]?.id ?? 'reasoning-4b';
+
+  return { name, template, targets: targets.targets, llmId };
+}
+
+/** Parse a `--targets cli,web` list; cli is always retained. */
+function parseTargets(csv: string | undefined): { targets: Target[] } | { error: string } {
+  if (!csv) return { targets: [...ALL_TARGETS] };
+  const parts = csv.split(',').map((s) => s.trim()).filter(Boolean);
+  const bad = parts.filter((p) => !ALL_TARGETS.includes(p as Target));
+  if (bad.length) {
+    return { error: `unknown --targets value(s): ${bad.join(', ')} — expected cli, desktop, web` };
+  }
+  const set = new Set(parts as Target[]);
+  set.add('cli');
+  return { targets: ALL_TARGETS.filter((t) => set.has(t)) };
+}
+
+/** Copy the template, prune to the selected targets, write the model. */
+function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
+  const dest = join(parentDir, plan.name);
+
+  try {
+    if (statSync(dest).isDirectory()) {
       process.stderr.write(
-        `harness.dev: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
+        `harness.dev: ${dest} already exists. Choose a different name or remove the directory first.\n`,
       );
       return 1;
     }
+  } catch {
+    // ENOENT — good
+  }
 
-    const appsNote =
-      template === 'research'
-        ? '  it runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
-          '  preinstalled (grounded multi-agent research);\n'
-        : '  it runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
-
-    process.stdout.write(
-      `scaffolded ${name} (${template}) at ${dest}\n` +
-        '  next steps:\n' +
-        `    cd ${name}\n` +
-        '    npm install\n' +
-        '    npm start\n' +
-        '\n' +
-        '  No API key needed — the model is fetched + digest-verified on first run;\n' +
-        appsNote +
-        '  add more via: npx harness.dev install <publisher>/<name>\n',
+  const templateDir = resolveTemplateDir(plan.template);
+  try {
+    copyTreeWithSubstitutions(templateDir, dest, buildSubstitutions(plan.name));
+    if (plan.targets.length < ALL_TARGETS.length) {
+      pruneTargets(dest, plan.targets);
+    }
+    const recommendedContext = MODEL_CATALOG.find(
+      (m) => m.role === 'llm' && m.id === plan.llmId,
+    )?.recommendedContext;
+    applyModelChoice(dest, { llmId: plan.llmId, context: recommendedContext });
+  } catch (err) {
+    process.stderr.write(
+      `harness.dev: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
     );
-    return 0;
-  },
-};
+    return 1;
+  }
+
+  const appsNote =
+    plan.template === 'research'
+      ? '  it runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
+        '  preinstalled (grounded multi-agent research);\n'
+      : '  it runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
+
+  process.stdout.write(
+    `scaffolded ${plan.name} (${plan.template}) at ${dest}\n` +
+      `  targets: ${plan.targets.join(', ')} · model: ${plan.llmId}\n` +
+      '  next steps:\n' +
+      `    cd ${plan.name}\n` +
+      '    npm install\n' +
+      '    npm start\n' +
+      '\n' +
+      '  No API key needed — the model is fetched + digest-verified on first run;\n' +
+      appsNote +
+      '  add more via: npx harness.dev install <publisher>/<name>\n',
+  );
+  return 0;
+}
 
 /**
  * Resolve the templates directory by walking up from this module's
@@ -130,7 +200,7 @@ export const createCommand: Command = {
  * `<pkg-root>/templates/<kind>`.
  */
 function resolveTemplateDir(kind: 'app' | 'harness' | 'blank' | 'research'): string {
-  const here = __dirname;
+  const here = dirname(fileURLToPath(import.meta.url));
   const candidates = [
     resolve(here, '..', '..', 'templates', kind),
     resolve(here, '..', 'templates', kind),

--- a/packages/harness-cli/src/commands/index.ts
+++ b/packages/harness-cli/src/commands/index.ts
@@ -1,10 +1,10 @@
-import type { Command } from '../command';
-import { createCommand } from './create';
-import { appCommand } from './app';
-import { installCommand } from './install';
-import { publishCommand } from './publish';
-import { publishersCommand } from './publishers';
-import { reviewCommand } from './review';
+import type { Command } from '../command.js';
+import { createCommand } from './create.js';
+import { appCommand } from './app.js';
+import { installCommand } from './install.js';
+import { publishCommand } from './publish.js';
+import { publishersCommand } from './publishers.js';
+import { reviewCommand } from './review.js';
 
 /**
  * The default command — runs when no recognized subcommand is given

--- a/packages/harness-cli/src/commands/index.ts
+++ b/packages/harness-cli/src/commands/index.ts
@@ -1,5 +1,5 @@
 import type { Command } from '../command.js';
-import { createCommand } from './create.js';
+import { newCommand } from './new.js';
 import { appCommand } from './app.js';
 import { installCommand } from './install.js';
 import { publishCommand } from './publish.js';
@@ -21,6 +21,6 @@ export const SUBCOMMANDS: readonly Command[] = [
  * the dispatcher errors instead of scaffolding.
  */
 export function findCommand(name: string): Command | undefined {
-  if (name === createCommand.name) return createCommand;
+  if (name === newCommand.name) return newCommand;
   return SUBCOMMANDS.find((c) => c.name === name);
 }

--- a/packages/harness-cli/src/commands/index.ts
+++ b/packages/harness-cli/src/commands/index.ts
@@ -6,13 +6,6 @@ import { publishCommand } from './publish.js';
 import { publishersCommand } from './publishers.js';
 import { reviewCommand } from './review.js';
 
-/**
- * The default command — runs when no recognized subcommand is given
- * (bare `harness.dev <name>` scaffolds a harness). Also reachable as the
- * explicit `create` verb.
- */
-export const DEFAULT_COMMAND = createCommand;
-
 /** Named subcommands, in help-listing order. */
 export const SUBCOMMANDS: readonly Command[] = [
   appCommand,
@@ -22,7 +15,11 @@ export const SUBCOMMANDS: readonly Command[] = [
   reviewCommand,
 ];
 
-/** Resolve a typed token to a subcommand (or the explicit `create` verb). */
+/**
+ * Resolve a typed token to a command. `new` (harness scaffold) plus the named
+ * subcommands (`app:new`, `install`, …); an unknown token returns undefined so
+ * the dispatcher errors instead of scaffolding.
+ */
 export function findCommand(name: string): Command | undefined {
   if (name === createCommand.name) return createCommand;
   return SUBCOMMANDS.find((c) => c.name === name);

--- a/packages/harness-cli/src/commands/install.ts
+++ b/packages/harness-cli/src/commands/install.ts
@@ -3,7 +3,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { Command } from '../command';
+import type { Command } from '../command.js';
 import {
   fetchAndVerifyCatalog,
   resolveAppVersion,
@@ -11,9 +11,9 @@ import {
   verifyBundle,
   sha512Integrity,
   BundleVerificationError,
-} from '../verify';
-import { readTarEntry, isGzipReadable } from '../tar-read';
-import type { AttentionSurface } from '../describe';
+} from '../verify.js';
+import { readTarEntry, isGzipReadable } from '../tar-read.js';
+import type { AttentionSurface } from '../describe.js';
 
 const USAGE = [
   'harness.dev install — install a signed HDK app from apps.lloyal.ai into the current project',

--- a/packages/harness-cli/src/commands/new-wizard.tsx
+++ b/packages/harness-cli/src/commands/new-wizard.tsx
@@ -14,7 +14,7 @@
  * harnesses render in, so the tool eats its own dog food. It stays thin: no
  * scaffolding happens here, only data collection.
  */
-import { useRef, useState } from 'react';
+import { useRef, useState, type ReactElement } from 'react';
 import { Box, Text, render, useApp, useInput } from 'ink';
 import { TextInput, Select, MultiSelect, StatusMessage } from '@inkjs/ui';
 import { modelsForRole } from '../scaffold/model-catalog.js';
@@ -65,7 +65,7 @@ export function Wizard({
 }: {
   onDone: (result: WizardResult | null) => void;
   prefill?: WizardPrefill;
-}): React.ReactElement {
+}): ReactElement {
   const { exit } = useApp();
   const llms = modelsForRole('llm');
   const defaultLlm = llms[0]?.id ?? 'reasoning-4b';

--- a/packages/harness-cli/src/commands/new-wizard.tsx
+++ b/packages/harness-cli/src/commands/new-wizard.tsx
@@ -3,7 +3,7 @@
  * name → targets → model → template, then hands the answers back for the pure
  * scaffold logic to act on. Mounted ONLY when `new` runs in a TTY with the
  * name missing; a provided name / `--yes` / non-TTY take the plain path in
- * `create.ts`.
+ * `new.ts`.
  *
  * Any flags the user DID pass (`--template`/`--targets`/`--model`) pre-seed the
  * wizard, so it prompts only for what's missing (flag-compose). Each question
@@ -37,7 +37,7 @@ export interface WizardPrefill {
   llm?: string;
 }
 
-/** Same grammar as the non-interactive path (`create.ts` NAME_RE). */
+/** Same grammar as the non-interactive path (`new.ts` NAME_RE). */
 const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
 const TARGET_ORDER: Target[] = ['cli', 'desktop', 'web'];
 const DEFAULT_TARGETS: Target[] = ['cli', 'desktop', 'web'];
@@ -233,7 +233,7 @@ export function Wizard({
  * user cancels (Ctrl-C / the Ink app exits before completing). Any `prefill`
  * (flags already provided) narrows the questions asked.
  */
-export function runCreateWizard(prefill: WizardPrefill = {}): Promise<WizardResult | null> {
+export function runNewWizard(prefill: WizardPrefill = {}): Promise<WizardResult | null> {
   return new Promise((resolve) => {
     let settled = false;
     const done = (result: WizardResult | null): void => {

--- a/packages/harness-cli/src/commands/new.ts
+++ b/packages/harness-cli/src/commands/new.ts
@@ -12,7 +12,7 @@ import type { Command } from '../command.js';
 import { pruneTargets, type Target } from '../scaffold/prune-targets.js';
 import { applyModelChoice } from '../scaffold/apply-model.js';
 import { MODEL_CATALOG, modelsForRole } from '../scaffold/model-catalog.js';
-import { runCreateWizard, type TemplateKind, type WizardPrefill } from './create-wizard.js';
+import { runNewWizard, type TemplateKind, type WizardPrefill } from './new-wizard.js';
 
 const USAGE = [
   'harness.dev new — scaffold a new harness project',
@@ -61,7 +61,7 @@ interface ScaffoldPlan {
 /** Flags shared by both paths — undefined means "not provided" (ask / default). */
 type Flags = WizardPrefill;
 
-export const createCommand: Command = {
+export const newCommand: Command = {
   name: 'new',
   summary: 'Scaffold a new harness (interactive when run without a name)',
   usage: USAGE,
@@ -100,7 +100,7 @@ export const createCommand: Command = {
     // flags already given pre-seed the picker so it asks only for the rest.
     let plan: ScaffoldPlan;
     if (!name && !values.yes && Boolean(process.stdin.isTTY)) {
-      const result = await runCreateWizard(flags);
+      const result = await runNewWizard(flags);
       if (!result) {
         process.stderr.write('cancelled.\n');
         return 1;
@@ -233,7 +233,7 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
 /**
  * Resolve the templates directory by walking up from this module's
  * compiled location. After build, the CLI lives at
- * `<pkg-root>/dist/commands/create.js`, so the templates are at
+ * `<pkg-root>/dist/commands/new.js`, so the templates are at
  * `<pkg-root>/templates/<kind>`.
  */
 function resolveTemplateDir(kind: TemplateKind): string {

--- a/packages/harness-cli/src/commands/new.ts
+++ b/packages/harness-cli/src/commands/new.ts
@@ -189,15 +189,23 @@ function parseTargets(csv: string | undefined): { targets: Target[] } | { error:
 function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
   const dest = join(parentDir, plan.name);
 
+  // Refuse to clobber ANY existing path (dir, file, or symlink) — falling
+  // through would fail later with a cryptic mkdirSync EEXIST/ENOTDIR. Only a
+  // missing path (ENOENT) is safe; any other stat error is surfaced, not eaten.
   try {
-    if (statSync(dest).isDirectory()) {
+    statSync(dest);
+    process.stderr.write(
+      `harness.dev: ${dest} already exists. Choose a different name or remove it first.\n`,
+    );
+    return 1;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
       process.stderr.write(
-        `harness.dev: ${dest} already exists. Choose a different name or remove the directory first.\n`,
+        `harness.dev: cannot access ${dest}: ${err instanceof Error ? err.message : String(err)}\n`,
       );
       return 1;
     }
-  } catch {
-    // ENOENT — good
+    // ENOENT — the destination is free.
   }
 
   const templateDir = resolveTemplateDir(plan.template);

--- a/packages/harness-cli/src/commands/new.ts
+++ b/packages/harness-cli/src/commands/new.ts
@@ -95,11 +95,15 @@ export const newCommand: Command = {
       return 1;
     }
 
-    // Interactive picker: a bare `harness.dev new` in a TTY. A provided name,
-    // `--yes`, or a non-TTY / piped stdin (CI) takes the flag path below. Any
+    // Interactive picker: a bare `harness.dev new` in a real terminal. A provided
+    // name, `--yes`, or a non-TTY (CI, or stdin/stdout redirected) takes the flag
+    // path below — Ink needs BOTH stdin and stdout to be a TTY, else its
+    // keyboard/render UX is broken (piped output would get ANSI garbage). Any
     // flags already given pre-seed the picker so it asks only for the rest.
+    const interactive =
+      !name && !values.yes && Boolean(process.stdin.isTTY) && Boolean(process.stdout.isTTY);
     let plan: ScaffoldPlan;
-    if (!name && !values.yes && Boolean(process.stdin.isTTY)) {
+    if (interactive) {
       const result = await runNewWizard(flags);
       if (!result) {
         process.stderr.write('cancelled.\n');
@@ -141,7 +145,11 @@ function validateFlags(values: {
     targets = parsed.targets;
   }
 
-  return { template, targets, llm: values.model };
+  // Trim `--model`; an empty/whitespace value is "not provided" (falls to the
+  // catalog default) — `??` alone would treat `""` as a real id and write an
+  // empty `model.llm`, breaking resolution.
+  const llm = values.model?.trim();
+  return { template, targets, llm: llm || undefined };
 }
 
 /** Build a scaffold plan from CLI flags (the non-interactive path). */

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -3,10 +3,10 @@ import { readFile, writeFile, mkdtemp, rm } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { Command } from '../command';
-import { ensureFreshToken } from '../cf-access-oauth';
-import { buildAttentionSurface } from '../describe';
-import { readTarEntry, isGzipReadable } from '../tar-read';
+import type { Command } from '../command.js';
+import { ensureFreshToken } from '../cf-access-oauth.js';
+import { buildAttentionSurface } from '../describe.js';
+import { readTarEntry, isGzipReadable } from '../tar-read.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const DEFAULT_PUBLISH_ENDPOINT = `${API_BASE}/v1/publish`;

--- a/packages/harness-cli/src/commands/publishers.ts
+++ b/packages/harness-cli/src/commands/publishers.ts
@@ -1,7 +1,7 @@
 import { parseArgs } from 'node:util';
 import { createInterface } from 'node:readline/promises';
-import type { Command } from '../command';
-import { ensureFreshToken } from '../cf-access-oauth';
+import type { Command } from '../command.js';
+import { ensureFreshToken } from '../cf-access-oauth.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const REGISTER_ENDPOINT = `${API_BASE}/v1/publishers/register`;

--- a/packages/harness-cli/src/commands/review.ts
+++ b/packages/harness-cli/src/commands/review.ts
@@ -1,8 +1,8 @@
 import { parseArgs } from 'node:util';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
-import type { Command } from '../command';
-import { ensureFreshToken } from '../cf-access-oauth';
+import type { Command } from '../command.js';
+import { ensureFreshToken } from '../cf-access-oauth.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const REVIEW_BASE = `${API_BASE}/v1/review`;

--- a/packages/harness-cli/src/scaffold/apply-model.ts
+++ b/packages/harness-cli/src/scaffold/apply-model.ts
@@ -1,0 +1,55 @@
+/**
+ * Write the chosen model into a scaffolded project's `harness.yml`.
+ *
+ * A targeted line edit — NOT a YAML parse/re-serialize — so every guidance
+ * comment in the template's `harness.yml` (the `kvCache`/`gpu`/`branches` hints,
+ * the reranker note) survives untouched. Only the llm `id:` value (and, when
+ * given, `context:`) inside the `model.llm:` block is rewritten.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ModelChoice {
+  /** Catalog id (or path) for the trunk llm — replaces `model.llm.id`. */
+  llmId: string;
+  /** Optional `model.llm.context` (nCtx). Omit to leave the template default. */
+  context?: number;
+}
+
+/**
+ * Rewrite `model.llm.id` (+ optional `context`) in `<projectDir>/harness.yml`.
+ * Throws if the file has no `model.llm:` block. The reranker is NOT written
+ * here — apps declare it and it auto-provisions from the catalog default; the
+ * template's reranker note documents how to pin one.
+ */
+export function applyModelChoice(projectDir: string, choice: ModelChoice): void {
+  const ymlPath = join(projectDir, 'harness.yml');
+  const lines = readFileSync(ymlPath, 'utf8').split('\n');
+
+  const llmIdx = lines.findIndex((l) => /^\s*llm:\s*$/.test(l));
+  if (llmIdx === -1) {
+    throw new Error(`applyModelChoice: no \`model.llm:\` block in ${ymlPath}`);
+  }
+
+  // Scan forward from `llm:` and rewrite the FIRST `id:` (the llm's) — a value-
+  // only replace so any trailing comment stays. `context:` appears only in the
+  // llm block, so the first match is unambiguous. Replace each at most once.
+  let idDone = false;
+  let ctxDone = choice.context == null;
+  for (let i = llmIdx + 1; i < lines.length && !(idDone && ctxDone); i++) {
+    if (!idDone && /^\s+id:\s*"[^"]*"/.test(lines[i])) {
+      lines[i] = lines[i].replace(/"[^"]*"/, `"${choice.llmId}"`);
+      idDone = true;
+      continue;
+    }
+    if (!ctxDone && /^\s+context:\s*\d+/.test(lines[i])) {
+      lines[i] = lines[i].replace(/context:\s*\d+/, `context: ${choice.context}`);
+      ctxDone = true;
+    }
+  }
+  if (!idDone) {
+    throw new Error(`applyModelChoice: no \`id:\` under \`model.llm:\` in ${ymlPath}`);
+  }
+
+  writeFileSync(ymlPath, lines.join('\n'));
+}

--- a/packages/harness-cli/src/scaffold/apply-model.ts
+++ b/packages/harness-cli/src/scaffold/apply-model.ts
@@ -3,24 +3,43 @@
  *
  * A targeted line edit — NOT a YAML parse/re-serialize — so every guidance
  * comment in the template's `harness.yml` (the `kvCache`/`gpu`/`branches` hints,
- * the reranker note) survives untouched. Only the llm `id:` value (and, when
- * given, `context:`) inside the `model.llm:` block is rewritten.
+ * the reranker note) survives untouched. Only the llm entry (and, when given,
+ * `context:`) inside the `model.llm:` block is rewritten.
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 export interface ModelChoice {
-  /** Catalog id (or path) for the trunk llm — replaces `model.llm.id`. */
-  llmId: string;
+  /**
+   * The trunk llm — either a catalog `id` (rig fetches + digest-verifies,
+   * fail-closed) or a local `path` to a `.gguf` you already have (BYO, trusted
+   * by possession). Path-shaped values are written as `path:`, everything else
+   * as `id:` — see {@link isModelPath}.
+   */
+  llm: string;
   /** Optional `model.llm.context` (nCtx). Omit to leave the template default. */
   context?: number;
 }
 
 /**
- * Rewrite `model.llm.id` (+ optional `context`) in `<projectDir>/harness.yml`.
- * Throws if the file has no `model.llm:` block. The reranker is NOT written
- * here — apps declare it and it auto-provisions from the catalog default; the
- * template's reranker note documents how to pin one.
+ * A model value is a BYO **path** (not a catalog id) if it looks like a
+ * filesystem path: it contains a slash, ends in `.gguf`, or starts with `~`.
+ * Catalog ids are bare slugs (`reasoning-4b`) and stay ids even when unknown to
+ * the vendored catalog, so the picker survives catalog drift. This is the fix
+ * for the bug where a BYO `./x.gguf` was written as `id:` and rig then looked
+ * for `models/llm/./x.gguf.gguf`.
+ */
+export function isModelPath(value: string): boolean {
+  return /[\\/]/.test(value) || value.endsWith('.gguf') || value.startsWith('~');
+}
+
+/**
+ * Rewrite the llm entry (+ optional `context`) in `<projectDir>/harness.yml`.
+ * A catalog id keeps the `id:` key and swaps the value; a BYO path swaps BOTH
+ * the key → `path:` and the value (a model entry is `{ id | path }`, never
+ * both). Throws if the file has no `model.llm:` block. The reranker is NOT
+ * written here — apps declare it and it auto-provisions from the catalog
+ * default; the template's reranker note documents how to pin one.
  */
 export function applyModelChoice(projectDir: string, choice: ModelChoice): void {
   const ymlPath = join(projectDir, 'harness.yml');
@@ -31,15 +50,21 @@ export function applyModelChoice(projectDir: string, choice: ModelChoice): void 
     throw new Error(`applyModelChoice: no \`model.llm:\` block in ${ymlPath}`);
   }
 
-  // Scan forward from `llm:` and rewrite the FIRST `id:` (the llm's) — a value-
-  // only replace so any trailing comment stays. `context:` appears only in the
-  // llm block, so the first match is unambiguous. Replace each at most once.
-  let idDone = false;
+  const asPath = isModelPath(choice.llm);
+  // Scan forward from `llm:` and rewrite the FIRST entry line — the template
+  // ships either `id:` or `path:`; we normalize to the right one for this
+  // choice. `context:` appears only in the llm block, so the first match is
+  // unambiguous. Both preserve any trailing guidance comment. Replace once.
+  const key = asPath ? 'path' : 'id';
+  let keyDone = false;
   let ctxDone = choice.context == null;
-  for (let i = llmIdx + 1; i < lines.length && !(idDone && ctxDone); i++) {
-    if (!idDone && /^\s+id:\s*"[^"]*"/.test(lines[i])) {
-      lines[i] = lines[i].replace(/"[^"]*"/, `"${choice.llmId}"`);
-      idDone = true;
+  for (let i = llmIdx + 1; i < lines.length && !(keyDone && ctxDone); i++) {
+    if (!keyDone && /^\s+(?:id|path):\s*"[^"]*"/.test(lines[i])) {
+      lines[i] = lines[i].replace(
+        /^(\s+)(?:id|path):(\s*)"[^"]*"/,
+        `$1${key}:$2"${choice.llm}"`,
+      );
+      keyDone = true;
       continue;
     }
     if (!ctxDone && /^\s+context:\s*\d+/.test(lines[i])) {
@@ -47,8 +72,8 @@ export function applyModelChoice(projectDir: string, choice: ModelChoice): void 
       ctxDone = true;
     }
   }
-  if (!idDone) {
-    throw new Error(`applyModelChoice: no \`id:\` under \`model.llm:\` in ${ymlPath}`);
+  if (!keyDone) {
+    throw new Error(`applyModelChoice: no \`id:\`/\`path:\` under \`model.llm:\` in ${ymlPath}`);
   }
 
   writeFileSync(ymlPath, lines.join('\n'));

--- a/packages/harness-cli/src/scaffold/apply-model.ts
+++ b/packages/harness-cli/src/scaffold/apply-model.ts
@@ -60,9 +60,13 @@ export function applyModelChoice(projectDir: string, choice: ModelChoice): void 
   let ctxDone = choice.context == null;
   for (let i = llmIdx + 1; i < lines.length && !(keyDone && ctxDone); i++) {
     if (!keyDone && /^\s+(?:id|path):\s*"[^"]*"/.test(lines[i])) {
+      // JSON.stringify quotes + escapes the value — YAML 1.2 double-quoted
+      // strings share JSON's escape sequences, so a Windows path (`C:\x.gguf`),
+      // a `"`, or a newline round-trips correctly. A replacer fn (not a string)
+      // keeps a `$` in the value from being read as a replace token.
       lines[i] = lines[i].replace(
         /^(\s+)(?:id|path):(\s*)"[^"]*"/,
-        `$1${key}:$2"${choice.llm}"`,
+        (_m, indent: string, sp: string) => `${indent}${key}:${sp}${JSON.stringify(choice.llm)}`,
       );
       keyDone = true;
       continue;

--- a/packages/harness-cli/src/scaffold/model-catalog.ts
+++ b/packages/harness-cli/src/scaffold/model-catalog.ts
@@ -1,0 +1,45 @@
+/**
+ * A minimal, vendored copy of `@lloyal-labs/rig`'s model catalog — just the
+ * fields the interactive `create` model picker needs (`id` / `role` / `label` /
+ * `recommendedContext`), NOT the download URLs or digests (rig owns fetching +
+ * verification; the CLI only offers the choice).
+ *
+ * It is vendored, not imported, on purpose: the catalog is only exported from
+ * `@lloyal-labs/rig/node`, whose barrel also pulls in `createReranker` (the
+ * NATIVE `@lloyal-labs/lloyal.node`) + the App registry. `harness.dev` is the
+ * Apache-2.0, zero-native-dep CLI — `verify.ts` duplicates rig's verify surface
+ * for exactly this reason. Keep these rows in sync with rig's `MODEL_CATALOG`
+ * (packages/rig/src/models.ts); adding a row here only widens the picker.
+ */
+
+export type ModelRole = 'llm' | 'reranker';
+
+export interface CatalogModel {
+  /** Stable id — what gets written into `harness.yml` `model.<role>.id`. */
+  id: string;
+  role: ModelRole;
+  /** Human label for the picker row. */
+  label: string;
+  /** Suggested `context` (nCtx) — written alongside an `llm` choice. */
+  recommendedContext?: number;
+}
+
+/** Mirrors `@lloyal-labs/rig`'s `MODEL_CATALOG`, minus urls/sha256/sizeBytes. */
+export const MODEL_CATALOG: readonly CatalogModel[] = [
+  {
+    id: 'reasoning-4b',
+    role: 'llm',
+    label: 'Reasoning 4B · Q4_K_M',
+    recommendedContext: 32768,
+  },
+  {
+    id: 'qwen3-reranker-0.6b-q8',
+    role: 'reranker',
+    label: 'Qwen3 Reranker 0.6B · Q8_0',
+  },
+];
+
+/** The catalog entries for one role, in listing order. */
+export function modelsForRole(role: ModelRole): readonly CatalogModel[] {
+  return MODEL_CATALOG.filter((m) => m.role === role);
+}

--- a/packages/harness-cli/src/scaffold/model-catalog.ts
+++ b/packages/harness-cli/src/scaffold/model-catalog.ts
@@ -1,6 +1,6 @@
 /**
  * A minimal, vendored copy of `@lloyal-labs/rig`'s model catalog — just the
- * fields the interactive `create` model picker needs (`id` / `role` / `label` /
+ * fields the interactive `new` model picker needs (`id` / `role` / `label` /
  * `recommendedContext`), NOT the download URLs or digests (rig owns fetching +
  * verification; the CLI only offers the choice).
  *

--- a/packages/harness-cli/src/scaffold/prune-targets.ts
+++ b/packages/harness-cli/src/scaffold/prune-targets.ts
@@ -1,0 +1,184 @@
+/**
+ * Prune a scaffolded harness project down to the selected run targets.
+ *
+ * `create` copies the FULL template (cli + desktop + web), then this removes the
+ * surfaces the user didn't pick — their `targets/<t>/` dir, their bin shim,
+ * their npm scripts + exclusive deps, and their slice of the tsconfig split — so
+ * a "cli-only" project doesn't drag in electron/vite. `cli` is mandatory (it
+ * carries the engine bin) and is never pruned.
+ *
+ * Edits are surgical: `package.json` is pure JSON (parse → delete keys →
+ * re-stringify), while `harness.yml` + the tsconfig files are edited line-wise
+ * so their guidance comments survive. The `targets:` field in `harness.yml` is
+ * documentation (nothing reads it at runtime); what makes a target real is its
+ * dir + scripts + deps, which is what we remove here.
+ */
+import { readFileSync, writeFileSync, rmSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export type Target = 'cli' | 'desktop' | 'web';
+
+/** Per-target npm entries removed when that target is pruned. */
+const TARGET_SCRIPTS: Record<Exclude<Target, 'cli'>, string[]> = {
+  desktop: ['dev:desktop', 'build:desktop'],
+  web: ['serve', 'dev:web', 'build:web'],
+};
+const TARGET_DEPS: Record<Exclude<Target, 'cli'>, string[]> = {
+  desktop: [], // desktop's exclusive deps are all devDeps
+  web: ['@lloyal-labs/host', 'ws'],
+};
+const TARGET_DEV_DEPS: Record<Exclude<Target, 'cli'>, string[]> = {
+  desktop: ['electron', 'electron-vite'],
+  web: ['@types/ws'],
+};
+/**
+ * Deps shared by the DOM renderers (web browser + Electron renderer). Kept while
+ * EITHER desktop or web survives; removed only for a cli-only project. `vite` is
+ * here because `electron-vite` lists it as a peerDependency.
+ */
+const SHARED_RENDERER_DEPS = ['react-dom'];
+const SHARED_RENDERER_DEV_DEPS = ['@vitejs/plugin-react', '@types/react-dom', 'vite'];
+
+/**
+ * Reduce `<projectDir>` to `keep`. `keep` MUST include `'cli'`. A no-op when all
+ * three targets are kept (beyond normalizing the `harness.yml` `targets:` line).
+ */
+export function pruneTargets(projectDir: string, keep: readonly Target[]): void {
+  const keepSet = new Set(keep);
+  if (!keepSet.has('cli')) {
+    throw new Error("pruneTargets: 'cli' is mandatory and cannot be pruned");
+  }
+  const pruneDesktop = !keepSet.has('desktop');
+  const pruneWeb = !keepSet.has('web');
+
+  const rm = (rel: string): void => rmSync(join(projectDir, rel), { recursive: true, force: true });
+
+  // 1. Dirs + files.
+  if (pruneDesktop) {
+    rm('targets/desktop');
+    rm('electron.vite.config.ts');
+    rm('tsconfig.electron.json');
+  }
+  if (pruneWeb) {
+    rm('targets/web');
+    rm('bin/serve.js');
+  }
+
+  // 2. package.json — scripts + deps.
+  if (pruneDesktop || pruneWeb) {
+    prunePackageJson(projectDir, { pruneDesktop, pruneWeb });
+  }
+
+  // 3. tsconfig split (only when a target was actually removed).
+  if (pruneDesktop || pruneWeb) {
+    const someDom = !pruneDesktop || !pruneWeb; // a DOM target (web or desktop renderer) remains
+    const webCfg = join(projectDir, 'tsconfig.web.json');
+    if (existsSync(webCfg)) {
+      if (!someDom) {
+        rm('tsconfig.web.json'); // cli-only: no DOM sources left to typecheck
+      } else {
+        filterJsoncArray(webCfg, 'include', (entry) => !isUnderPruned(entry, pruneDesktop, pruneWeb));
+      }
+    }
+    const nodeCfg = join(projectDir, 'tsconfig.json');
+    if (existsSync(nodeCfg)) {
+      filterJsoncArray(nodeCfg, 'exclude', (entry) => !isUnderPruned(entry, pruneDesktop, pruneWeb));
+    }
+  }
+
+  // 4. harness.yml `targets:` line (documentation).
+  rewriteTargetsLine(projectDir, keep);
+}
+
+function prunePackageJson(
+  projectDir: string,
+  { pruneDesktop, pruneWeb }: { pruneDesktop: boolean; pruneWeb: boolean },
+): void {
+  const pkgPath = join(projectDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as {
+    scripts?: Record<string, string>;
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+
+  const drop = (obj: Record<string, string> | undefined, keys: string[]): void => {
+    if (!obj) return;
+    for (const k of keys) delete obj[k];
+  };
+
+  if (pruneDesktop) {
+    drop(pkg.scripts, TARGET_SCRIPTS.desktop);
+    drop(pkg.dependencies, TARGET_DEPS.desktop);
+    drop(pkg.devDependencies, TARGET_DEV_DEPS.desktop);
+  }
+  if (pruneWeb) {
+    drop(pkg.scripts, TARGET_SCRIPTS.web);
+    drop(pkg.dependencies, TARGET_DEPS.web);
+    drop(pkg.devDependencies, TARGET_DEV_DEPS.web);
+  }
+  if (pruneDesktop && pruneWeb) {
+    drop(pkg.dependencies, SHARED_RENDERER_DEPS);
+    drop(pkg.devDependencies, SHARED_RENDERER_DEV_DEPS);
+  }
+
+  // Rebuild the `typecheck` script from the tsconfigs that survive.
+  if (pkg.scripts?.typecheck) {
+    const someDom = !pruneDesktop || !pruneWeb;
+    const parts = ['tsc --noEmit'];
+    if (someDom) parts.push('tsc -p tsconfig.web.json');
+    if (!pruneDesktop) parts.push('tsc -p tsconfig.electron.json');
+    pkg.scripts.typecheck = parts.join(' && ');
+  }
+
+  writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
+}
+
+/** True when a tsconfig path entry lives under a pruned target directory. */
+function isUnderPruned(entry: string, pruneDesktop: boolean, pruneWeb: boolean): boolean {
+  return (
+    (pruneDesktop && entry.startsWith('targets/desktop')) ||
+    (pruneWeb && entry.startsWith('targets/web'))
+  );
+}
+
+/**
+ * Filter a multi-line JSONC string array (`"key": [ ... ]`, one quoted entry per
+ * line) in place, keeping only entries for which `keep(entry)` is true, and
+ * fixing up trailing commas so the result stays valid JSON. Comments outside the
+ * array are untouched. Templates author these arrays one-entry-per-line, so a
+ * single-line array is left alone (nothing to prune line-wise).
+ */
+function filterJsoncArray(filePath: string, key: string, keep: (entry: string) => boolean): void {
+  const lines = readFileSync(filePath, 'utf8').split('\n');
+  const openRe = new RegExp(`"${key}"\\s*:\\s*\\[\\s*$`);
+  const startIdx = lines.findIndex((l) => openRe.test(l));
+  if (startIdx === -1) return; // key absent or single-line array — nothing to do
+  let endIdx = -1;
+  for (let i = startIdx + 1; i < lines.length; i++) {
+    if (/^\s*\]/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  if (endIdx === -1) return;
+
+  const kept: string[] = [];
+  for (let i = startIdx + 1; i < endIdx; i++) {
+    const m = lines[i].match(/"([^"]+)"/);
+    if (m && !keep(m[1])) continue;
+    kept.push(lines[i].replace(/,\s*$/, '')); // strip any trailing comma; re-added below
+  }
+  const rebuilt = kept.map((l, idx) => (idx === kept.length - 1 ? l : `${l},`));
+  const out = [...lines.slice(0, startIdx + 1), ...rebuilt, ...lines.slice(endIdx)];
+  writeFileSync(filePath, out.join('\n'));
+}
+
+/** Rewrite the `targets: [...]` line in `harness.yml` to the kept set. */
+function rewriteTargetsLine(projectDir: string, keep: readonly Target[]): void {
+  const ymlPath = join(projectDir, 'harness.yml');
+  if (!existsSync(ymlPath)) return;
+  const text = readFileSync(ymlPath, 'utf8');
+  const rendered = `targets: [${keep.join(', ')}]`;
+  const next = text.replace(/^targets:\s*\[[^\]]*\]/m, rendered);
+  if (next !== text) writeFileSync(ymlPath, next);
+}

--- a/packages/harness-cli/src/scaffold/prune-targets.ts
+++ b/packages/harness-cli/src/scaffold/prune-targets.ts
@@ -1,7 +1,7 @@
 /**
  * Prune a scaffolded harness project down to the selected run targets.
  *
- * `create` copies the FULL template (cli + desktop + web), then this removes the
+ * `new` copies the FULL template (cli + desktop + web), then this removes the
  * surfaces the user didn't pick — their `targets/<t>/` dir, their bin shim,
  * their npm scripts + exclusive deps, and their slice of the tsconfig split — so
  * a "cli-only" project doesn't drag in electron/vite. `cli` is mandatory (it

--- a/packages/harness-cli/templates/blank/harness/config-types.ts
+++ b/packages/harness-cli/templates/blank/harness/config-types.ts
@@ -48,6 +48,11 @@ export interface ConfigModel {
   nCtx?: number;
   /** GPU backend variant. Null/undefined = the platform default backend. */
   gpu?: ConfigGpu;
+  /** The model's display id + its measured on-disk size — the boot stats the
+   *  resolved weight and stores these so the harness can render a *measured*
+   *  boot header (see `BootFacts`), never a hardcoded string. */
+  id?: string;
+  sizeBytes?: number;
 }
 
 export interface Config {
@@ -58,6 +63,9 @@ export interface Config {
    *  an app's entry on `set_app_config`. */
   apps: ConfigApps;
   model: ConfigModel;
+  /** Which surface this process mounted (`cli` · `desktop` · `pipe` · `web`) —
+   *  a boot-time runtime fact the harness echoes into the boot header. */
+  surface?: string;
 }
 
 /** Which layer supplied a given harness-level field — used for composer UI

--- a/packages/harness-cli/templates/blank/harness/harness.ts
+++ b/packages/harness-cli/templates/blank/harness/harness.ts
@@ -130,7 +130,19 @@ export function* harness(
   const registry = yield* createAppRegistry({ configStore });
   for (const app of apps) yield* registry.enable(app);
 
-  events.send({ type: "ready" });
+  // Boot done — announce it with MEASURED facts, not hardcoded strings: the
+  // model's id + on-disk size (the boot stat'd the weight into the config), the
+  // surface that mounted, and the apps actually enabled (read from the registry).
+  // Every surface folds this one event, so the header is identical everywhere.
+  const cfg = runner.config();
+  events.send({
+    type: "ready",
+    facts: {
+      model: { id: cfg.model.id ?? "model", sizeBytes: cfg.model.sizeBytes ?? 0 },
+      surface: cfg.surface ?? "cli",
+      apps: registry.enabled().map((a) => a.name),
+    },
+  });
 
   // The command loop. Ends on `quit` (or when the Session closes and the scope
   // unwinds). Everything the surface can ask for is a member of `Command`.

--- a/packages/harness-cli/templates/blank/harness/protocol.ts
+++ b/packages/harness-cli/templates/blank/harness/protocol.ts
@@ -12,11 +12,26 @@
  */
 import type { AgentEvent } from "@lloyal-labs/lloyal-agents";
 
+/**
+ * The measured facts the boot surface renders — every line a runtime truth,
+ * not a hardcoded string: the model's id + its on-disk size, which surface
+ * mounted, and the AgentApps actually enabled (read from the registry). The
+ * harness emits these on `ready`, so the header is identical in a terminal, an
+ * Electron window, or a browser tab. (Tools' network-boundness + a trace path
+ * are the next facts to surface — blank writes no trace and doesn't yet
+ * introspect app entitlements, so it renders neither rather than a lie.)
+ */
+export interface BootFacts {
+  model: { id: string; sizeBytes: number };
+  surface: string;
+  apps: string[];
+}
+
 export type WorkflowEvent =
   // Forwarded verbatim from the agent pool (spawn / produce / return / …).
   | AgentEvent
-  // Boot finished — the surface may accept a query.
-  | { type: "ready" }
+  // Boot finished — the surface may accept a query. Carries the measured facts.
+  | { type: "ready"; facts: BootFacts }
   // The answer for the last query.
   | { type: "answer"; text: string }
   // A recoverable error to show; the surface returns to accepting input.

--- a/packages/harness-cli/templates/blank/harness/state.ts
+++ b/packages/harness-cli/templates/blank/harness/state.ts
@@ -19,11 +19,15 @@ import type { WorkflowEvent, BootFacts } from "./protocol.js";
 
 export type Phase = "booting" | "ready" | "working" | "answered" | "error";
 
-/** Human-readable file size — the boot header renders the model's measured bytes. */
+/** Human-readable file size — the boot header renders the model's measured bytes.
+ *  `sizeBytes` is best-effort (0 when the stat failed), so 0/unknown reads as
+ *  "unknown" rather than a fabricated "1 KB". */
 export function formatSize(bytes: number): string {
+  if (bytes <= 0) return "unknown";
   if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
   if (bytes >= 1e6) return `${Math.round(bytes / 1e6)} MB`;
-  return `${Math.max(1, Math.round(bytes / 1e3))} KB`;
+  if (bytes >= 1e3) return `${Math.round(bytes / 1e3)} KB`;
+  return `${bytes} B`;
 }
 
 export type AgentStatus = "active" | "tool" | "done" | "failed";

--- a/packages/harness-cli/templates/blank/harness/state.ts
+++ b/packages/harness-cli/templates/blank/harness/state.ts
@@ -15,9 +15,16 @@
  * fold immutable (new `Map` + new object only for what changed), and the views
  * update for free.
  */
-import type { WorkflowEvent } from "./protocol.js";
+import type { WorkflowEvent, BootFacts } from "./protocol.js";
 
 export type Phase = "booting" | "ready" | "working" | "answered" | "error";
+
+/** Human-readable file size — the boot header renders the model's measured bytes. */
+export function formatSize(bytes: number): string {
+  if (bytes >= 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
+  if (bytes >= 1e6) return `${Math.round(bytes / 1e6)} MB`;
+  return `${Math.max(1, Math.round(bytes / 1e3))} KB`;
+}
 
 export type AgentStatus = "active" | "tool" | "done" | "failed";
 
@@ -34,6 +41,8 @@ export interface AgentView {
 
 export interface AppState {
   phase: Phase;
+  /** Measured boot facts for the header — null until `ready` lands. */
+  boot: BootFacts | null;
   /** Insertion-ordered by spawn — the auto-view renders the tree from `parentId`. */
   agents: Map<number, AgentView>;
   answer: string;
@@ -44,6 +53,7 @@ export interface AppState {
 
 export const initialState: AppState = {
   phase: "booting",
+  boot: null,
   agents: new Map(),
   answer: "",
   error: null,
@@ -54,7 +64,8 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
   switch (ev.type) {
     // ── your harness's own events ──
     case "ready":
-      return s.phase === "booting" ? { ...s, phase: "ready" } : s;
+      // Boot facts land here — the view renders the header from `s.boot`.
+      return { ...s, phase: s.phase === "booting" ? "ready" : s.phase, boot: ev.facts };
     case "answer":
       return { ...s, phase: "answered", answer: ev.text, error: null };
     case "error":

--- a/packages/harness-cli/templates/blank/targets/cli/index.ts
+++ b/packages/harness-cli/templates/blank/targets/cli/index.ts
@@ -55,6 +55,16 @@ function loadConfig(): HarnessConfig {
   }
 }
 
+/** Best-effort file size for the boot header — a stat failure never blocks boot
+ *  (the header size is cosmetic; the real model-load error surfaces on its own). */
+function fileSize(p: string): number {
+  try {
+    return statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
 const config = loadConfig();
 const llm: ModelEntry = config.model?.llm ?? {};
 const context = llm.context ?? 32768;
@@ -135,7 +145,7 @@ main(function* () {
       path: modelPath,
       nCtx: context,
       id: llm.id ?? llm.path ?? "model",
-      sizeBytes: statSync(modelPath).size,
+      sizeBytes: fileSize(modelPath),
     },
   };
   yield* RunnerCtx.set(makeEdgeRunner(cfg));

--- a/packages/harness-cli/templates/blank/targets/cli/index.ts
+++ b/packages/harness-cli/templates/blank/targets/cli/index.ts
@@ -13,7 +13,7 @@
  * the platform (`rig.resolveModel`), with no API key. Drop your own `.gguf`
  * into `models/llm/` (or point `path:` at one) to skip the fetch entirely.
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { parse } from "yaml";
 import { main, call, ensure, createSignal } from "effection";
@@ -118,13 +118,25 @@ main(function* () {
   }
   if (fetchingReranker) process.stderr.write("\n");
 
+  // Which surface is mounting — decided once, here, then echoed into the boot
+  // header (as a measured fact) and used to pick the binding below.
+  const surface = process.env.RR_BRIDGE ? "desktop" : process.stdout.isTTY ? "cli" : "pipe";
+
   // The live, in-memory config the harness reads via RunnerCtx — the edge
   // substrate (config, trace sink, wind-down / cancel signals) every harness gets.
+  // `model.id` + `model.sizeBytes` (stat'd here) + `surface` feed the measured
+  // boot header the harness emits on `ready`.
   const cfg: Config = {
     version: 1,
     sources: {},
     apps: {},
-    model: { path: modelPath, nCtx: context },
+    surface,
+    model: {
+      path: modelPath,
+      nCtx: context,
+      id: llm.id ?? llm.path ?? "model",
+      sizeBytes: statSync(modelPath).size,
+    },
   };
   yield* RunnerCtx.set(makeEdgeRunner(cfg));
 
@@ -138,10 +150,10 @@ main(function* () {
   // Surface pick — the same events/commands, a different binding. Each binding
   // returns a disposer; tie it to the scope so listeners are torn down on exit.
   let dispose: () => void;
-  if (process.env.RR_BRIDGE) {
+  if (surface === "desktop") {
     // A desktop shell forked this bin: stream over the process channel.
     dispose = ipc<WorkflowEvent, Command>()(events, dispatch, bootstrap);
-  } else if (process.stdout.isTTY) {
+  } else if (surface === "cli") {
     // A terminal: mount the Ink view.
     dispose = renderCli(events, dispatch, bootstrap);
   } else {

--- a/packages/harness-cli/templates/blank/targets/cli/view.tsx
+++ b/packages/harness-cli/templates/blank/targets/cli/view.tsx
@@ -13,7 +13,7 @@ import React, { useEffect, useReducer } from "react";
 import { Box, Text, render, useApp, useInput } from "ink";
 import { TextInput } from "@inkjs/ui";
 import type { EventBus } from "@lloyal-labs/binding";
-import { initialState, reduce } from "../../harness/state.js";
+import { initialState, reduce, formatSize } from "../../harness/state.js";
 import type { AgentView, AppState } from "../../harness/state.js";
 import type { Command, WorkflowEvent } from "../../harness/protocol.js";
 
@@ -71,9 +71,18 @@ function View({
     <Box flexDirection="column" gap={1}>
       <Box flexDirection="column">
         <Text bold>{"__NAME__"}</Text>
-        <Text color="gray">Model      resident · no API key</Text>
-        <Text color="gray">Inference  local · no provider</Text>
-        <Text color="gray">Surface    cli</Text>
+        {/* Measured facts from the `ready` event — the model's real size + the
+            apps actually enabled, never a hardcoded string. */}
+        {state.boot ? (
+          <>
+            <Text color="gray">{`Model      ${state.boot.model.id} · ${formatSize(state.boot.model.sizeBytes)} · resident`}</Text>
+            <Text color="gray">Inference  local · no provider</Text>
+            <Text color="gray">{`Apps       ${state.boot.apps.length ? state.boot.apps.join(", ") : "none installed"}`}</Text>
+            <Text color="gray">{`Surface    ${state.boot.surface}`}</Text>
+          </>
+        ) : (
+          <Text color="gray">booting…</Text>
+        )}
       </Box>
 
       {agents.length > 0 && (

--- a/packages/harness-cli/templates/blank/targets/desktop/App.tsx
+++ b/packages/harness-cli/templates/blank/targets/desktop/App.tsx
@@ -10,7 +10,7 @@
  * is the floor — grow it into your product's UI (or bring your own app).
  */
 import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { reduce, initialState, type AppState, type AgentView } from "../../harness/state.js";
+import { reduce, initialState, formatSize, type AppState, type AgentView } from "../../harness/state.js";
 import type { WorkflowEvent, Command } from "../../harness/protocol.js";
 
 declare global {
@@ -83,7 +83,12 @@ export function HarnessApp() {
   return (
     <div style={S.page}>
       <div style={S.head}>
-        __NAME__ · {state.phase}
+        __NAME__
+        {/* Measured boot facts (from the `ready` event) — the resident model +
+            surface, not a hardcoded string; falls back to the phase pre-ready. */}
+        {state.boot
+          ? ` · ${state.boot.model.id} · ${formatSize(state.boot.model.sizeBytes)} · ${state.boot.surface}`
+          : ` · ${state.phase}`}
         {state.kv.total > 0 && ` · kv ${Math.round((100 * state.kv.used) / state.kv.total)}%`}
       </div>
       {agents.map((a) => (

--- a/packages/harness-cli/templates/blank/targets/web/serve.ts
+++ b/packages/harness-cli/templates/blank/targets/web/serve.ts
@@ -14,7 +14,7 @@
  * app that talks to it. Config from `harness.yml` + env (PORT / HOST /
  * MAX_SESSIONS). Loopback + no-auth for local dev — TLS/auth terminate upstream.
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { main, suspend, call } from "effection";
 import type { Signal } from "effection";
@@ -107,7 +107,16 @@ main(function* () {
     version: 1,
     sources: {},
     apps: {},
-    model: { path: modelPath, reranker: rerankerPath, nCtx: llm.context ?? 32768 },
+    surface: "web",
+    // `id` + `sizeBytes` feed the measured boot header the harness emits on
+    // `ready`; every served session renders the same resident-model facts.
+    model: {
+      path: modelPath,
+      reranker: rerankerPath,
+      nCtx: llm.context ?? 32768,
+      id: llm.id ?? llm.path ?? "model",
+      sizeBytes: statSync(modelPath).size,
+    },
   };
 
   // Hand the harness to the host through the driver. The host is payload-opaque

--- a/packages/harness-cli/templates/blank/targets/web/serve.ts
+++ b/packages/harness-cli/templates/blank/targets/web/serve.ts
@@ -56,6 +56,15 @@ function loadConfig(): { model?: { llm?: ModelEntry; reranker?: ModelEntry } } {
   }
 }
 
+/** Best-effort file size for the boot header — never blocks the server boot. */
+function fileSize(p: string): number {
+  try {
+    return statSync(p).size;
+  } catch {
+    return 0;
+  }
+}
+
 const config = loadConfig();
 const llm: ModelEntry = config.model?.llm ?? {};
 const reranker: ModelEntry = config.model?.reranker ?? {};
@@ -115,7 +124,7 @@ main(function* () {
       reranker: rerankerPath,
       nCtx: llm.context ?? 32768,
       id: llm.id ?? llm.path ?? "model",
-      sizeBytes: statSync(modelPath).size,
+      sizeBytes: fileSize(modelPath),
     },
   };
 

--- a/packages/harness-cli/templates/research/README.md
+++ b/packages/harness-cli/templates/research/README.md
@@ -7,7 +7,7 @@ dispatches a pool of agents that gather evidence in parallel (or in a dependency
 chain), then synthesizes one cited answer.
 
 > **SNAPSHOT: reasoning.run @ 0.8.0.** This template is a curated separate copy of
-> reasoning.run's RACE/DRB-tuned pipeline, conforming to the `harness.dev create`
+> reasoning.run's RACE/DRB-tuned pipeline, conforming to the `harness.dev new`
 > conventions — a real, editable starter, not a dependency. Drift from upstream is
 > expected.
 

--- a/packages/harness-cli/templates/research/harness/harness.ts
+++ b/packages/harness-cli/templates/research/harness/harness.ts
@@ -17,7 +17,7 @@
  * drop a `prompts/<name>.eta` into the project to override a tuned prompt.
  *
  * SNAPSHOT: reasoning.run @ 0.8.0 — a curated separate copy of its pipeline,
- * conforming to the harness.dev create conventions. Drift from upstream is
+ * conforming to the harness.dev new conventions. Drift from upstream is
  * expected and accepted.
  */
 import * as fs from "node:fs";

--- a/packages/harness-cli/test/cli-dispatch.test.ts
+++ b/packages/harness-cli/test/cli-dispatch.test.ts
@@ -18,22 +18,22 @@ function captureStdout(): { restore: () => void } {
 afterEach(() => vi.restoreAllMocks());
 
 describe('dispatcher — unknown command', () => {
-  it('errors (exit 1) and suggests create, does NOT scaffold', async () => {
+  it('errors (exit 1) and suggests `new`, does NOT scaffold', async () => {
     const err = captureStderr();
     const code = await main(['approve']);
     err.restore();
     expect(code).toBe(1);
     expect(err.output()).toContain('unknown command "approve"');
-    expect(err.output()).toContain('harness.dev create approve');
+    expect(err.output()).toContain('harness.dev new approve');
   });
 
-  it('does not suggest `create` for a flag-like token', async () => {
+  it('does not suggest `new` for a flag-like token', async () => {
     const err = captureStderr();
     const code = await main(['--frobnicate']);
     err.restore();
     expect(code).toBe(1);
     expect(err.output()).toContain('unknown command "--frobnicate"');
-    expect(err.output()).not.toContain('create --frobnicate');
+    expect(err.output()).not.toContain('new --frobnicate');
   });
 });
 
@@ -61,13 +61,16 @@ describe('dispatcher — help + version', () => {
 });
 
 describe('findCommand', () => {
-  it('resolves the explicit create verb + named subcommands', () => {
-    expect(findCommand('create')?.name).toBe('create');
-    expect(findCommand('app')?.name).toBe('app');
+  it('resolves the `new` verb + named subcommands', () => {
+    expect(findCommand('new')?.name).toBe('new');
+    expect(findCommand('app:new')?.name).toBe('app:new');
     expect(findCommand('install')?.name).toBe('install');
   });
 
-  it('returns undefined for an unknown token (so the dispatcher errors)', () => {
+  it('returns undefined for retired/unknown tokens (so the dispatcher errors)', () => {
+    // `create` and `app` were renamed — no backward-compat alias.
+    expect(findCommand('create')).toBeUndefined();
+    expect(findCommand('app')).toBeUndefined();
     expect(findCommand('approve')).toBeUndefined();
     expect(findCommand('bogus')).toBeUndefined();
   });

--- a/packages/harness-cli/test/cli-dispatch.test.ts
+++ b/packages/harness-cli/test/cli-dispatch.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { main } from '../src/cli.js';
+import { findCommand } from '../src/commands/index.js';
+
+function captureStderr(): { output: () => string; restore: () => void } {
+  let buf = '';
+  const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    buf += chunk.toString();
+    return true;
+  });
+  return { output: () => buf, restore: () => spy.mockRestore() };
+}
+function captureStdout(): { restore: () => void } {
+  const spy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  return { restore: () => spy.mockRestore() };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('dispatcher — unknown command', () => {
+  it('errors (exit 1) and suggests create, does NOT scaffold', async () => {
+    const err = captureStderr();
+    const code = await main(['approve']);
+    err.restore();
+    expect(code).toBe(1);
+    expect(err.output()).toContain('unknown command "approve"');
+    expect(err.output()).toContain('harness.dev create approve');
+  });
+
+  it('does not suggest `create` for a flag-like token', async () => {
+    const err = captureStderr();
+    const code = await main(['--frobnicate']);
+    err.restore();
+    expect(code).toBe(1);
+    expect(err.output()).toContain('unknown command "--frobnicate"');
+    expect(err.output()).not.toContain('create --frobnicate');
+  });
+});
+
+describe('dispatcher — help + version', () => {
+  it('bare invocation prints help (exit 0)', async () => {
+    const out = captureStdout();
+    const code = await main([]);
+    out.restore();
+    expect(code).toBe(0);
+  });
+
+  it('--help prints help (exit 0)', async () => {
+    const out = captureStdout();
+    const code = await main(['--help']);
+    out.restore();
+    expect(code).toBe(0);
+  });
+
+  it('--version prints the version (exit 0)', async () => {
+    const out = captureStdout();
+    const code = await main(['--version']);
+    out.restore();
+    expect(code).toBe(0);
+  });
+});
+
+describe('findCommand', () => {
+  it('resolves the explicit create verb + named subcommands', () => {
+    expect(findCommand('create')?.name).toBe('create');
+    expect(findCommand('app')?.name).toBe('app');
+    expect(findCommand('install')?.name).toBe('install');
+  });
+
+  it('returns undefined for an unknown token (so the dispatcher errors)', () => {
+    expect(findCommand('approve')).toBeUndefined();
+    expect(findCommand('bogus')).toBeUndefined();
+  });
+});

--- a/packages/harness-cli/test/create-scaffold.test.ts
+++ b/packages/harness-cli/test/create-scaffold.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { cpSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { pruneTargets } from '../src/scaffold/prune-targets.js';
-import { applyModelChoice } from '../src/scaffold/apply-model.js';
+import { applyModelChoice, isModelPath } from '../src/scaffold/apply-model.js';
 import { modelsForRole, MODEL_CATALOG } from '../src/scaffold/model-catalog.js';
+import { createCommand } from '../src/commands/create.js';
 
 const BLANK_TEMPLATE = join(dirname(fileURLToPath(import.meta.url)), '..', 'templates', 'blank');
 
@@ -110,26 +111,78 @@ describe('pruneTargets — guards', () => {
   });
 });
 
+describe('isModelPath', () => {
+  it('classifies catalog ids as ids and .gguf/paths as paths', () => {
+    // Bare slugs stay ids — even unknown ones, so the picker survives catalog drift.
+    expect(isModelPath('reasoning-4b')).toBe(false);
+    expect(isModelPath('custom-model')).toBe(false);
+    // Anything path-shaped is BYO.
+    expect(isModelPath('./models/llm/x.gguf')).toBe(true);
+    expect(isModelPath('/abs/path/model.gguf')).toBe(true);
+    expect(isModelPath('models/llm/x.gguf')).toBe(true);
+    expect(isModelPath('bare.gguf')).toBe(true);
+    expect(isModelPath('~/models/x.gguf')).toBe(true);
+  });
+});
+
 describe('applyModelChoice', () => {
   it('rewrites model.llm id + context, preserving comments', () => {
     const dir = freshBlankProject();
-    applyModelChoice(dir, { llmId: 'custom-model', context: 8192 });
+    applyModelChoice(dir, { llm: 'custom-model', context: 8192 });
     const yml = readFileSync(join(dir, 'harness.yml'), 'utf8');
     expect(yml).toMatch(/id:\s*"custom-model"/);
     expect(yml).toMatch(/context:\s*8192/);
     expect(yml).toContain('kvCache'); // the inline guidance comment survives
   });
 
+  it('writes a BYO path as `path:` (not `id:`), keeping the comment', () => {
+    const dir = freshBlankProject();
+    applyModelChoice(dir, { llm: './models/llm/custom.gguf' });
+    const yml = readFileSync(join(dir, 'harness.yml'), 'utf8');
+    expect(yml).toMatch(/path:\s*"\.\/models\/llm\/custom\.gguf"/);
+    // The llm block must NOT still carry an `id:` line — a model entry is id XOR path.
+    const llmBlock = yml.slice(yml.indexOf('llm:'), yml.indexOf('context:'));
+    expect(llmBlock).not.toMatch(/\bid:/);
+    expect(yml).toContain('kvCache'); // guidance comment survives the key swap
+    expect(yml).toMatch(/context:\s*32768/); // context left at the template default
+  });
+
   it('leaves context untouched when not given', () => {
     const dir = freshBlankProject();
-    applyModelChoice(dir, { llmId: 'reasoning-4b' });
+    applyModelChoice(dir, { llm: 'reasoning-4b' });
     expect(readFileSync(join(dir, 'harness.yml'), 'utf8')).toMatch(/context:\s*32768/);
   });
 
   it('throws when there is no model.llm block', () => {
     const dir = freshBlankProject();
     writeFileSync(join(dir, 'harness.yml'), 'targets: [cli]\n');
-    expect(() => applyModelChoice(dir, { llmId: 'x' })).toThrow(/model\.llm/);
+    expect(() => applyModelChoice(dir, { llm: 'x' })).toThrow(/model\.llm/);
+  });
+});
+
+describe('createCommand.run — non-interactive flag path (end-to-end)', () => {
+  it('scaffolds a cli-only blank with a BYO --model path written as `path:`', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'harness-new-'));
+    created.push(parent);
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await createCommand.run([
+      'byoproj',
+      '--dir',
+      parent,
+      '--targets',
+      'cli',
+      '--model',
+      './models/llm/mine.gguf',
+    ]);
+    out.mockRestore();
+
+    expect(code).toBe(0);
+    const yml = readFileSync(join(parent, 'byoproj', 'harness.yml'), 'utf8');
+    expect(yml).toMatch(/path:\s*"\.\/models\/llm\/mine\.gguf"/);
+    // cli-only prune landed too — desktop/web are gone.
+    expect(existsSync(join(parent, 'byoproj', 'targets/desktop'))).toBe(false);
+    expect(existsSync(join(parent, 'byoproj', 'targets/web'))).toBe(false);
+    expect(existsSync(join(parent, 'byoproj', 'targets/cli'))).toBe(true);
   });
 });
 

--- a/packages/harness-cli/test/create-scaffold.test.ts
+++ b/packages/harness-cli/test/create-scaffold.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { cpSync, mkdtempSync, rmSync, existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { pruneTargets } from '../src/scaffold/prune-targets.js';
+import { applyModelChoice } from '../src/scaffold/apply-model.js';
+import { modelsForRole, MODEL_CATALOG } from '../src/scaffold/model-catalog.js';
+
+const BLANK_TEMPLATE = join(dirname(fileURLToPath(import.meta.url)), '..', 'templates', 'blank');
+
+const created: string[] = [];
+function freshBlankProject(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'harness-scaffold-'));
+  cpSync(BLANK_TEMPLATE, dir, { recursive: true });
+  created.push(dir);
+  return dir;
+}
+function pkg(dir: string): {
+  scripts: Record<string, string>;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+} {
+  return JSON.parse(readFileSync(join(dir, 'package.json'), 'utf8'));
+}
+
+afterEach(() => {
+  while (created.length) rmSync(created.pop() as string, { recursive: true, force: true });
+});
+
+describe('pruneTargets — cli-only', () => {
+  it('removes desktop + web dirs, bin shim, and both extra tsconfigs', () => {
+    const dir = freshBlankProject();
+    pruneTargets(dir, ['cli']);
+    expect(existsSync(join(dir, 'targets/cli'))).toBe(true);
+    expect(existsSync(join(dir, 'targets/desktop'))).toBe(false);
+    expect(existsSync(join(dir, 'targets/web'))).toBe(false);
+    expect(existsSync(join(dir, 'bin/serve.js'))).toBe(false);
+    expect(existsSync(join(dir, 'electron.vite.config.ts'))).toBe(false);
+    expect(existsSync(join(dir, 'tsconfig.electron.json'))).toBe(false);
+    expect(existsSync(join(dir, 'tsconfig.web.json'))).toBe(false);
+  });
+
+  it('drops every per-target dep incl. the shared renderer deps', () => {
+    const dir = freshBlankProject();
+    pruneTargets(dir, ['cli']);
+    const p = pkg(dir);
+    for (const dep of ['@lloyal-labs/host', 'ws', 'react-dom']) {
+      expect(p.dependencies?.[dep]).toBeUndefined();
+    }
+    for (const dep of ['electron', 'electron-vite', 'vite', '@vitejs/plugin-react', '@types/ws', '@types/react-dom']) {
+      expect(p.devDependencies?.[dep]).toBeUndefined();
+    }
+    // cli core deps survive
+    expect(p.dependencies?.ink).toBeDefined();
+    expect(p.dependencies?.react).toBeDefined();
+  });
+
+  it('collapses scripts + typecheck to the cli set', () => {
+    const dir = freshBlankProject();
+    pruneTargets(dir, ['cli']);
+    const p = pkg(dir);
+    for (const s of ['dev:desktop', 'build:desktop', 'serve', 'dev:web', 'build:web']) {
+      expect(p.scripts[s]).toBeUndefined();
+    }
+    expect(p.scripts.start).toBeDefined();
+    expect(p.scripts.typecheck).toBe('tsc --noEmit');
+    expect(readFileSync(join(dir, 'harness.yml'), 'utf8')).toMatch(/^targets: \[cli\]$/m);
+  });
+});
+
+describe('pruneTargets — cli + web (desktop pruned)', () => {
+  it('keeps web deps/scripts, drops only desktop, trims tsconfig.web include', () => {
+    const dir = freshBlankProject();
+    pruneTargets(dir, ['cli', 'web']);
+    expect(existsSync(join(dir, 'targets/web'))).toBe(true);
+    expect(existsSync(join(dir, 'targets/desktop'))).toBe(false);
+    expect(existsSync(join(dir, 'electron.vite.config.ts'))).toBe(false);
+    expect(existsSync(join(dir, 'tsconfig.electron.json'))).toBe(false);
+    expect(existsSync(join(dir, 'tsconfig.web.json'))).toBe(true);
+
+    const p = pkg(dir);
+    expect(p.devDependencies?.electron).toBeUndefined();
+    expect(p.devDependencies?.['electron-vite']).toBeUndefined();
+    expect(p.dependencies?.['@lloyal-labs/host']).toBeDefined();
+    expect(p.devDependencies?.vite).toBeDefined(); // shared renderer dep kept — web survives
+    expect(p.dependencies?.['react-dom']).toBeDefined();
+    expect(p.scripts.serve).toBeDefined();
+    expect(p.scripts['dev:desktop']).toBeUndefined();
+    expect(p.scripts.typecheck).toBe('tsc --noEmit && tsc -p tsconfig.web.json');
+
+    const webCfg = readFileSync(join(dir, 'tsconfig.web.json'), 'utf8');
+    expect(webCfg).not.toContain('targets/desktop');
+    expect(webCfg).toContain('targets/web/main.tsx');
+    expect(readFileSync(join(dir, 'harness.yml'), 'utf8')).toMatch(/^targets: \[cli, web\]$/m);
+  });
+});
+
+describe('pruneTargets — guards', () => {
+  it('throws when cli is not kept', () => {
+    const dir = freshBlankProject();
+    expect(() => pruneTargets(dir, ['desktop', 'web'])).toThrow(/cli.*mandatory/i);
+  });
+
+  it('all three kept is a no-op for the target dirs', () => {
+    const dir = freshBlankProject();
+    pruneTargets(dir, ['cli', 'desktop', 'web']);
+    expect(existsSync(join(dir, 'targets/desktop'))).toBe(true);
+    expect(existsSync(join(dir, 'targets/web'))).toBe(true);
+  });
+});
+
+describe('applyModelChoice', () => {
+  it('rewrites model.llm id + context, preserving comments', () => {
+    const dir = freshBlankProject();
+    applyModelChoice(dir, { llmId: 'custom-model', context: 8192 });
+    const yml = readFileSync(join(dir, 'harness.yml'), 'utf8');
+    expect(yml).toMatch(/id:\s*"custom-model"/);
+    expect(yml).toMatch(/context:\s*8192/);
+    expect(yml).toContain('kvCache'); // the inline guidance comment survives
+  });
+
+  it('leaves context untouched when not given', () => {
+    const dir = freshBlankProject();
+    applyModelChoice(dir, { llmId: 'reasoning-4b' });
+    expect(readFileSync(join(dir, 'harness.yml'), 'utf8')).toMatch(/context:\s*32768/);
+  });
+
+  it('throws when there is no model.llm block', () => {
+    const dir = freshBlankProject();
+    writeFileSync(join(dir, 'harness.yml'), 'targets: [cli]\n');
+    expect(() => applyModelChoice(dir, { llmId: 'x' })).toThrow(/model\.llm/);
+  });
+});
+
+describe('model-catalog (vendored)', () => {
+  it('offers the default llm', () => {
+    const llms = modelsForRole('llm');
+    expect(llms.length).toBeGreaterThan(0);
+    expect(llms[0].id).toBe('reasoning-4b');
+    expect(llms[0].recommendedContext).toBe(32768);
+  });
+
+  it('carries a reranker entry too', () => {
+    expect(MODEL_CATALOG.some((m) => m.role === 'reranker')).toBe(true);
+  });
+});

--- a/packages/harness-cli/test/create-wizard.test.ts
+++ b/packages/harness-cli/test/create-wizard.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'ink-testing-library';
+import { createElement } from 'react';
+import { Wizard, orderTargets } from '../src/commands/create-wizard.js';
+
+// COVERAGE BOUNDARY: the full keystroke-driven flow (name → targets → model →
+// template) is NOT asserted here. Character input to @inkjs/ui's `TextInput`
+// does not deliver under ink-testing-library's simulated stdin (the field keeps
+// showing its placeholder), so an end-to-end keystroke test can't be driven
+// headlessly — it needs a human smoke in a real terminal before release. What
+// IS covered: the wizard mounts + renders the name prompt (below); the
+// "cli always kept" invariant it enforces (orderTargets, below); and the pure
+// scaffold logic it hands off to (pruneTargets / applyModelChoice — see
+// create-scaffold.test.ts). The wizard drives the SAME @inkjs/ui TextInput/
+// Select components the shipped `targets/cli/view.tsx` templates use.
+
+describe('create wizard — render', () => {
+  it('mounts and renders the name prompt first (no crash)', () => {
+    const { lastFrame } = render(createElement(Wizard, { onDone: () => {} }));
+    expect(lastFrame()).toContain('Scaffold a new harness');
+    expect(lastFrame()).toContain('Harness name:');
+  });
+});
+
+describe('orderTargets — cli is never droppable', () => {
+  it('re-adds cli even when the user unchecked it', () => {
+    expect(orderTargets(['web'])).toEqual(['cli', 'web']);
+    expect(orderTargets([])).toEqual(['cli']);
+    expect(orderTargets(['desktop', 'web'])).toEqual(['cli', 'desktop', 'web']);
+  });
+
+  it('returns targets in canonical order regardless of selection order', () => {
+    expect(orderTargets(['web', 'desktop', 'cli'])).toEqual(['cli', 'desktop', 'web']);
+  });
+});

--- a/packages/harness-cli/test/new-scaffold.test.ts
+++ b/packages/harness-cli/test/new-scaffold.test.ts
@@ -206,6 +206,19 @@ describe('newCommand.run — non-interactive flag path (end-to-end)', () => {
     expect(yml).toMatch(/id:\s*"reasoning-4b"/); // the catalog default, not an empty value
     expect(yml).not.toMatch(/(id|path):\s*""/);
   });
+
+  it('refuses to scaffold over an existing FILE (not just a directory)', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'harness-new-'));
+    created.push(parent);
+    writeFileSync(join(parent, 'taken'), 'i am a file, not a directory');
+    const err = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await newCommand.run(['taken', '--dir', parent, '--yes']);
+    err.mockRestore();
+    out.mockRestore();
+    // Errors cleanly (exit 1) rather than crashing later on mkdirSync EEXIST.
+    expect(code).toBe(1);
+  });
 });
 
 describe('model-catalog (vendored)', () => {

--- a/packages/harness-cli/test/new-scaffold.test.ts
+++ b/packages/harness-cli/test/new-scaffold.test.ts
@@ -147,6 +147,15 @@ describe('applyModelChoice', () => {
     expect(yml).toMatch(/context:\s*32768/); // context left at the template default
   });
 
+  it('escapes a BYO path with backslashes + quotes into valid double-quoted YAML', () => {
+    const dir = freshBlankProject();
+    // A Windows path with an embedded quote — must not produce invalid YAML.
+    applyModelChoice(dir, { llm: 'C:\\models\\my "best".gguf' });
+    const yml = readFileSync(join(dir, 'harness.yml'), 'utf8');
+    // JSON.stringify escaping: backslashes doubled, inner quotes backslash-escaped.
+    expect(yml).toContain('path: "C:\\\\models\\\\my \\"best\\".gguf"');
+  });
+
   it('leaves context untouched when not given', () => {
     const dir = freshBlankProject();
     applyModelChoice(dir, { llm: 'reasoning-4b' });
@@ -183,6 +192,19 @@ describe('newCommand.run — non-interactive flag path (end-to-end)', () => {
     expect(existsSync(join(parent, 'byoproj', 'targets/desktop'))).toBe(false);
     expect(existsSync(join(parent, 'byoproj', 'targets/web'))).toBe(false);
     expect(existsSync(join(parent, 'byoproj', 'targets/cli'))).toBe(true);
+  });
+
+  it('treats an empty/whitespace --model as not provided (uses the catalog default)', async () => {
+    const parent = mkdtempSync(join(tmpdir(), 'harness-new-'));
+    created.push(parent);
+    const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const code = await newCommand.run(['dflt', '--dir', parent, '--targets', 'cli', '--model', '   ']);
+    out.mockRestore();
+
+    expect(code).toBe(0);
+    const yml = readFileSync(join(parent, 'dflt', 'harness.yml'), 'utf8');
+    expect(yml).toMatch(/id:\s*"reasoning-4b"/); // the catalog default, not an empty value
+    expect(yml).not.toMatch(/(id|path):\s*""/);
   });
 });
 

--- a/packages/harness-cli/test/new-scaffold.test.ts
+++ b/packages/harness-cli/test/new-scaffold.test.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 import { pruneTargets } from '../src/scaffold/prune-targets.js';
 import { applyModelChoice, isModelPath } from '../src/scaffold/apply-model.js';
 import { modelsForRole, MODEL_CATALOG } from '../src/scaffold/model-catalog.js';
-import { createCommand } from '../src/commands/create.js';
+import { newCommand } from '../src/commands/new.js';
 
 const BLANK_TEMPLATE = join(dirname(fileURLToPath(import.meta.url)), '..', 'templates', 'blank');
 
@@ -160,12 +160,12 @@ describe('applyModelChoice', () => {
   });
 });
 
-describe('createCommand.run — non-interactive flag path (end-to-end)', () => {
+describe('newCommand.run — non-interactive flag path (end-to-end)', () => {
   it('scaffolds a cli-only blank with a BYO --model path written as `path:`', async () => {
     const parent = mkdtempSync(join(tmpdir(), 'harness-new-'));
     created.push(parent);
     const out = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    const code = await createCommand.run([
+    const code = await newCommand.run([
       'byoproj',
       '--dir',
       parent,

--- a/packages/harness-cli/test/new-wizard.test.ts
+++ b/packages/harness-cli/test/new-wizard.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
-import { Wizard, orderTargets } from '../src/commands/create-wizard.js';
+import { Wizard, orderTargets } from '../src/commands/new-wizard.js';
 
 // COVERAGE BOUNDARY: the full keystroke-driven flow (name → targets → model →
 // template) is NOT asserted here. Character input to @inkjs/ui's `TextInput`
@@ -11,10 +11,10 @@ import { Wizard, orderTargets } from '../src/commands/create-wizard.js';
 // IS covered: the wizard mounts + renders the name prompt (below); the
 // "cli always kept" invariant it enforces (orderTargets, below); and the pure
 // scaffold logic it hands off to (pruneTargets / applyModelChoice — see
-// create-scaffold.test.ts). The wizard drives the SAME @inkjs/ui TextInput/
+// new-scaffold.test.ts). The wizard drives the SAME @inkjs/ui TextInput/
 // Select components the shipped `targets/cli/view.tsx` templates use.
 
-describe('create wizard — render', () => {
+describe('new wizard — render', () => {
   it('mounts and renders the name prompt first (no crash)', () => {
     const { lastFrame } = render(createElement(Wizard, { onDone: () => {} }));
     expect(lastFrame()).toContain('Scaffold a new harness');

--- a/packages/harness-cli/tsconfig.json
+++ b/packages/harness-cli/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "src",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "jsx": "react-jsx"
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
 }


### PR DESCRIPTION
Adds the guided interactive `create` flow to `harness.dev` and hardens the dispatcher. This is the DX slice that makes the merged two-template contract reachable to strangers (a follow-up 0.6.0 republish, separately gated, actually ships it to npm).

## ESM migration (Slice A — behavior-preserving)
`ink@5` / `@inkjs/ui@2` are ESM-only, so building the picker in Ink (the platform's own DX idiom — the blank template is `type: module` + tsc + Ink) requires the CLI to be ESM. Purely mechanical, all 46 existing tests stay green:
- `type: commonjs` → `module`; tsconfig → `NodeNext`
- `.js` specifiers on relative imports; `__dirname` → `import.meta.url` (3 sites)
- `describe.ts`'s `require()` is a `node -e` subprocess body — untouched

## Interactive create + targets/model prune + dispatcher (Slice B)
- **`create-wizard.tsx`** — Ink picker (`@inkjs/ui` `TextInput`/`MultiSelect`/`Select`) for **name → targets → model → template**. Mounts only on a TTY with no name; flags stay the non-interactive/CI path.
- **`scaffold/prune-targets.ts`** — reduces a scaffolded project to the selected targets: deletes deselected `targets/<t>/` + `bin/serve.js`, drops per-target scripts + deps (electron/vite/`@lloyal-labs/host`/ws/react-dom — keeps the electron-vite peer), trims the tsconfig split, rewrites `harness.yml` `targets:`. `cli` is never prunable.
- **`scaffold/apply-model.ts`** — writes the chosen model into `harness.yml` via a targeted line edit (preserves guidance comments).
- **`scaffold/model-catalog.ts`** — vendored copy of rig's `MODEL_CATALOG` rows, keeping the CLI zero-native-dep (same reason `verify.ts` duplicates rig's surface).
- **`create.ts`** — `--targets` / `--model` flags; interactive + flag paths converge on one `performScaffold`.
- **Dispatcher** — an unknown command now **errors + suggests `create`** (previously a silent scaffold of a stray directory, e.g. `harness.dev approve` → `./approve/`); help features `create`.

## Verification
`tsc -b` clean · **67/67 tests** (46 original + dispatcher / scaffold-prune / model / wizard) · `grep API_KEY` clean · non-interactive path smoke-verified across cli-only / cli+web / all-three / research permutations.

**Coverage caveat (honest):** the wizard's keystroke flow (name→targets→model→template) is **not** asserted — character input to `@inkjs/ui`'s `TextInput` does not deliver under ink-testing-library's simulated stdin (a real pty didn't drive it either). It wants a ~60s **human terminal smoke** (`npx harness.dev create`) before the 0.6.0 republish. The wizard uses the same `TextInput`/`Select` the shipped `targets/cli/view.tsx` templates use.

Not published here — `harness.dev` stays at 0.5.1; the 0.6.0 tag/republish is a separate gated step.