### PR TITLE
chore: rename model catalog id reasoning-4b → qwen3.5-4b

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.6.2",
+      "version": "0.6.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -2914,7 +2914,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.7.0",
+      "version": "3.8.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/lloyal-agents": "^3.4.0",

--- a/packages/harness-cli/README.md
+++ b/packages/harness-cli/README.md
@@ -11,9 +11,9 @@ cd my-harness && npm install && npm start
 
 ```text
 first run:
-  scaffolded acme (blank) · targets: cli, desktop, web · model: reasoning-4b
+  scaffolded acme (blank) · targets: cli, desktop, web · model: qwen3.5-4b
   ...
-  Model      reasoning-4b                   ● resident
+  Model      qwen3.5-4b                   ● resident
   Inference  local · no provider endpoint   ● offline
   ready — type to begin, ctrl-c to stop
 ```
@@ -28,7 +28,7 @@ A harness is **one program**. `harness.yml` declares the surfaces it runs on and
 # harness.yml
 targets: [cli, desktop, web]                    # the surfaces this harness runs on
 model:
-  llm: { id: "reasoning-4b", context: 32768 }   # the resident model it thinks with
+  llm: { id: "qwen3.5-4b", context: 32768 }   # the resident model it thinks with
 ```
 
 You write the program once, under `harness/`; the CLI generates a binding per surface under `targets/`:

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "dist/cli.js"

--- a/packages/harness-cli/src/commands/new-wizard.tsx
+++ b/packages/harness-cli/src/commands/new-wizard.tsx
@@ -68,7 +68,7 @@ export function Wizard({
 }): ReactElement {
   const { exit } = useApp();
   const llms = modelsForRole('llm');
-  const defaultLlm = llms[0]?.id ?? 'reasoning-4b';
+  const defaultLlm = llms[0]?.id ?? 'qwen3.5-4b';
   const defaultLlmLabel = llms[0]?.label ?? defaultLlm;
 
   const [queue, setQueue] = useState<StepId[]>(() => initialQueue(prefill));

--- a/packages/harness-cli/src/commands/new.ts
+++ b/packages/harness-cli/src/commands/new.ts
@@ -167,7 +167,7 @@ function planFromFlags(
     name,
     template: flags.template ?? 'blank',
     targets: flags.targets ?? [...ALL_TARGETS],
-    llm: flags.llm ?? modelsForRole('llm')[0]?.id ?? 'reasoning-4b',
+    llm: flags.llm ?? modelsForRole('llm')[0]?.id ?? 'qwen3.5-4b',
   };
 }
 

--- a/packages/harness-cli/src/scaffold/apply-model.ts
+++ b/packages/harness-cli/src/scaffold/apply-model.ts
@@ -31,7 +31,7 @@ export interface ModelChoice {
 /**
  * A model value is a BYO **path** (not a catalog id) if it looks like a
  * filesystem path: it contains a slash, ends in `.gguf`, or starts with `~`.
- * Catalog ids are bare slugs (`reasoning-4b`) and stay ids even when unknown to
+ * Catalog ids are bare slugs (`qwen3.5-4b`) and stay ids even when unknown to
  * the vendored catalog, so the picker survives catalog drift. This is the fix
  * for the bug where a BYO `./x.gguf` was written as `id:` and rig then looked
  * for `models/llm/./x.gguf.gguf`.

--- a/packages/harness-cli/src/scaffold/model-catalog.ts
+++ b/packages/harness-cli/src/scaffold/model-catalog.ts
@@ -27,9 +27,9 @@ export interface CatalogModel {
 /** Mirrors `@lloyal-labs/rig`'s `MODEL_CATALOG`, minus urls/sha256/sizeBytes. */
 export const MODEL_CATALOG: readonly CatalogModel[] = [
   {
-    id: 'reasoning-4b',
+    id: 'qwen3.5-4b',
     role: 'llm',
-    label: 'Reasoning 4B · Q4_K_M',
+    label: 'Qwen3.5 4B · Q4_K_M',
     recommendedContext: 32768,
   },
   {

--- a/packages/harness-cli/templates/blank/harness.yml
+++ b/packages/harness-cli/templates/blank/harness.yml
@@ -11,7 +11,7 @@ targets: [cli, desktop, web]
 
 model:
   llm:
-    id: "reasoning-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity — add a line to override
+    id: "qwen3.5-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity — add a line to override
     context: 32768
   # An app that needs a reranker (e.g. corpus, web) auto-provisions the catalog
   # default when it's enabled. Pin a specific one here to override:

--- a/packages/harness-cli/templates/blank/harness/config-types.ts
+++ b/packages/harness-cli/templates/blank/harness/config-types.ts
@@ -37,7 +37,7 @@ export type ConfigApps = Record<string, Record<string, unknown>>;
 export type ConfigGpu = 'default' | 'cuda' | 'vulkan';
 
 export interface ConfigModel {
-  /** Filesystem path OR catalog id (e.g. `reasoning-4b`). Resolution is the
+  /** Filesystem path OR catalog id (e.g. `qwen3.5-4b`). Resolution is the
    *  caller's concern (`rig.resolveModel`) — config just stores whatever the
    *  boot resolved. */
   path?: string;

--- a/packages/harness-cli/templates/blank/models/llm/.gitkeep
+++ b/packages/harness-cli/templates/blank/models/llm/.gitkeep
@@ -1,1 +1,1 @@
-# reasoning-4b.gguf is fetched here on first run (verified), or drop your own .gguf.
+# qwen3.5-4b.gguf is fetched here on first run (verified), or drop your own .gguf.

--- a/packages/harness-cli/templates/blank/package.json
+++ b/packages/harness-cli/templates/blank/package.json
@@ -33,7 +33,7 @@
     "@lloyal-labs/host": "^0.1.0",
     "@lloyal-labs/lloyal-agents": "^3.4.0",
     "@lloyal-labs/lloyal.node": "^3.1.0",
-    "@lloyal-labs/rig": "^3.7.0",
+    "@lloyal-labs/rig": "^3.8.0",
     "@lloyal-labs/sdk": "^3.0.3",
     "@lloyal-labs/wikipedia-app": "https://apps.lloyal.ai/v1/bundles/lloyal__wikipedia-1.1.0.tgz",
     "effection": "^4.0.2",

--- a/packages/harness-cli/templates/research/harness.yml
+++ b/packages/harness-cli/templates/research/harness.yml
@@ -10,7 +10,7 @@ targets: [cli, desktop, web]
 
 model:
   llm:
-    id: "reasoning-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity
+    id: "qwen3.5-4b"          # kvCache: q4_0 · gpu: auto · branches: from capacity
     context: 32768
   # The corpus + web apps score retrievals with a reranker. It's resolved +
   # digest-verified into models/reranker/ on first run, then created per-boot.

--- a/packages/harness-cli/templates/research/package.json
+++ b/packages/harness-cli/templates/research/package.json
@@ -34,7 +34,7 @@
     "@lloyal-labs/host": "^0.1.0",
     "@lloyal-labs/lloyal-agents": "^3.4.0",
     "@lloyal-labs/lloyal.node": "^3.1.0",
-    "@lloyal-labs/rig": "^3.7.0",
+    "@lloyal-labs/rig": "^3.8.0",
     "@lloyal-labs/sdk": "^3.0.3",
     "@lloyal-labs/web-app": "https://apps.lloyal.ai/v1/bundles/lloyal__web-1.3.0.tgz",
     "effection": "^4.0.2",

--- a/packages/harness-cli/test/models-targets.test.ts
+++ b/packages/harness-cli/test/models-targets.test.ts
@@ -46,7 +46,7 @@ async function scaffold(name: string, targets: string, template = 'blank'): Prom
     '--targets',
     targets,
     '--model',
-    'reasoning-4b',
+    'qwen3.5-4b',
     '--yes',
   ]);
   expect(code).toBe(0);
@@ -159,8 +159,8 @@ describe('writeModelField / readModelField', () => {
 describe('models: verbs', () => {
   it('models:use writes id; rejects a path-shaped arg', async () => {
     const dir = await scaffold('u1', 'cli');
-    expect(await runIn(dir, () => modelsUseCommand.run(['reasoning-4b']))).toBe(0);
-    expect(readModelField(dir, 'llm')).toEqual({ id: 'reasoning-4b' });
+    expect(await runIn(dir, () => modelsUseCommand.run(['qwen3.5-4b']))).toBe(0);
+    expect(readModelField(dir, 'llm')).toEqual({ id: 'qwen3.5-4b' });
     // A path belongs to models:add, not models:use.
     expect(await runIn(dir, () => modelsUseCommand.run(['./x.gguf']))).toBe(1);
   });
@@ -177,8 +177,8 @@ describe('models: verbs', () => {
     vi.spyOn(process.stdout, 'write').mockImplementation((s) => (out.push(String(s)), true));
     expect(await runIn(dir, () => modelsListCommand.run([]))).toBe(0);
     const text = out.join('');
-    expect(text).toContain('reasoning-4b');
-    expect(text).toMatch(/llm\s+id: reasoning-4b/);
+    expect(text).toContain('qwen3.5-4b');
+    expect(text).toMatch(/llm\s+id: qwen3.5-4b/);
   });
 
   it('rejects an unknown --role', async () => {

--- a/packages/harness-cli/test/new-scaffold.test.ts
+++ b/packages/harness-cli/test/new-scaffold.test.ts
@@ -114,7 +114,7 @@ describe('pruneTargets — guards', () => {
 describe('isModelPath', () => {
   it('classifies catalog ids as ids and .gguf/paths as paths', () => {
     // Bare slugs stay ids — even unknown ones, so the picker survives catalog drift.
-    expect(isModelPath('reasoning-4b')).toBe(false);
+    expect(isModelPath('qwen3.5-4b')).toBe(false);
     expect(isModelPath('custom-model')).toBe(false);
     // Anything path-shaped is BYO.
     expect(isModelPath('./models/llm/x.gguf')).toBe(true);
@@ -158,7 +158,7 @@ describe('applyModelChoice', () => {
 
   it('leaves context untouched when not given', () => {
     const dir = freshBlankProject();
-    applyModelChoice(dir, { llm: 'reasoning-4b' });
+    applyModelChoice(dir, { llm: 'qwen3.5-4b' });
     expect(readFileSync(join(dir, 'harness.yml'), 'utf8')).toMatch(/context:\s*32768/);
   });
 
@@ -203,7 +203,7 @@ describe('newCommand.run — non-interactive flag path (end-to-end)', () => {
 
     expect(code).toBe(0);
     const yml = readFileSync(join(parent, 'dflt', 'harness.yml'), 'utf8');
-    expect(yml).toMatch(/id:\s*"reasoning-4b"/); // the catalog default, not an empty value
+    expect(yml).toMatch(/id:\s*"qwen3.5-4b"/); // the catalog default, not an empty value
     expect(yml).not.toMatch(/(id|path):\s*""/);
   });
 
@@ -225,7 +225,7 @@ describe('model-catalog (vendored)', () => {
   it('offers the default llm', () => {
     const llms = modelsForRole('llm');
     expect(llms.length).toBeGreaterThan(0);
-    expect(llms[0].id).toBe('reasoning-4b');
+    expect(llms[0].id).toBe('qwen3.5-4b');
     expect(llms[0].recommendedContext).toBe(32768);
   });
 

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/rig/src/models.ts
+++ b/packages/rig/src/models.ts
@@ -65,14 +65,14 @@ function assertSafeSegment(kind: 'role' | 'id', value: string): void {
 
 /**
  * The platform's default catalog. Extend by adding an entry — no plumbing
- * change. `id`s are the friendly, dx-facing names (`reasoning-4b`), decoupled
- * from the upstream filename.
+ * change. `id`s name the model (`qwen3.5-4b`), matching the on-disk slot
+ * `models/<role>/<id>.gguf`.
  */
 export const MODEL_CATALOG: readonly ModelCatalogEntry[] = [
   {
-    id: 'reasoning-4b',
+    id: 'qwen3.5-4b',
     role: 'llm',
-    label: 'Reasoning 4B · Q4_K_M',
+    label: 'Qwen3.5 4B · Q4_K_M',
     urls: [
       'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf',
       'https://models.lloyal.ai/Qwen3.5-4B-Q4_K_M.gguf',

--- a/packages/rig/test/models.test.ts
+++ b/packages/rig/test/models.test.ts
@@ -73,9 +73,9 @@ describe('resolveModel — filesystem walk', () => {
   });
 
   it('id with an existing slot → used without a fetch', async () => {
-    put('models/llm/reasoning-4b.gguf');
-    const out = await resolveModel({ projectRoot: root, role: 'llm', spec: { id: 'reasoning-4b' } });
-    expect(out).toBe(path.join(root, 'models/llm/reasoning-4b.gguf'));
+    put('models/llm/qwen3.5-4b.gguf');
+    const out = await resolveModel({ projectRoot: root, role: 'llm', spec: { id: 'qwen3.5-4b' } });
+    expect(out).toBe(path.join(root, 'models/llm/qwen3.5-4b.gguf'));
   });
 
   it('no spec + sole .gguf → adopted', async () => {


### PR DESCRIPTION
Renames the default trunk-LLM catalog id `reasoning-4b` → `qwen3.5-4b` for honest provenance (it *is* Qwen3.5-4B) and consistency with its reranker sibling (`qwen3-reranker-0.6b-q8`).

The weight file, `urls`, `sha256`, and `sizeBytes` are **unchanged** — only the provenance id string moves, so the `.gguf` is byte-identical and the slot layout still resolves (`models/llm/qwen3.5-4b.gguf`; `SAFE_SEGMENT` allows dots).

### rig (source catalog — publishes first)
- `models.ts`: `id: 'qwen3.5-4b'`, `label: 'Qwen3.5 4B · Q4_K_M'`
- version 3.7.0 → **3.8.0**; `models.test.ts` slot/spec assertions updated

### harness-cli
- Rename across the vendored `model-catalog.ts`, both templates' `harness.yml`, `new.ts` + `new-wizard.tsx` fallbacks, README, comments, blank's `models/llm/.gitkeep`, and the test suites
- version 0.6.2 → **0.6.3**; both template rig floors `^3.7.0` → `^3.8.0`

### Verification
- rig: build ✓ · 17/17 models tests ✓
- harness-cli: build ✓ · 101/101 tests ✓
- Comprehensive grep across all file types → zero `reasoning-4b`/`Reasoning 4B` residuals
- Lockfile diff is only the two internal version bumps

### Release
Ship as two ordered tags after merge: `v3.8.0-rig` first (rig is the source catalog; verify `@lloyal-labs/rig@3.8.0` live), **then** `v0.6.3-cli` (its templates now pin rig `^3.8.0`).

reasoning.run + Artifact are a separate repo, lockfile-pinned to the old rig, and default to their own id string — unaffected here.