### PR TITLE
fix(harness-cli): 0.6.4 — bin shim so the CLI runs through a symlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 An inference endpoint makes a model **callable** — you send text, you get text, and the reasoning lives behind an HTTP boundary you can't reach. HDK makes it **programmable**: the model runs inside your Node process, and your application addresses its *live attention state* directly — forking lines of reasoning, admitting evidence mid-generation, deciding what becomes a durable result. Same process, same memory, same data structures as the rest of your code. No inference server, no vector DB, no embedding pipeline, no per-token bill.
 
-You write the reasoning once as an ordinary TypeScript program — a **harness** — and run it as a terminal app, a desktop app, or a served browser app off that one program. Every agent scaffold starts with `API_KEY=`. **A harness starts with a model.** Nothing on the reasoning path touches a third-party API; `grep API_KEY` in a scaffolded project finds nothing.
+You write the reasoning once as an ordinary TypeScript program — a **harness** — and run it as a terminal app, a desktop app, or a served browser app off that one program. Every agent scaffold starts with `API_KEY=`. **A harness starts with a model.**
 
 Free to use, embed, ship, and sell — commercial, private, internal, all of it. The one carve-out — forking the runtime to compete — is the [trust boundary](#why-fsl-instead-of-mit) that keeps capability-bearing apps installable safely. Converts to Apache 2.0 on a rolling two-year schedule.
 
@@ -27,7 +27,7 @@ Free to use, embed, ship, and sell — commercial, private, internal, all of it.
 
 ## Get started
 
-Scaffold your own harness — no API key, the model runs in-process:
+Scaffold your own harness — the model runs in your process:
 
 ```bash
 npx harness.dev new              # interactive: name → surfaces → model → template
@@ -64,17 +64,17 @@ Full command surface → [`harness.dev`](./packages/harness-cli/README.md).
 
 ## The shift
 
-The unit you build moves from *an inference endpoint your app calls* to *an application your app is*. When the model is remote, every agent is a fresh conversation you re-feed context to, and concurrency multiplies cost linearly. When the model is embedded, agents fork a shared line of reasoning for free, correct each other in real time, and synthesize — coordination patterns that simply aren't expressible over API calls.
+> **The unit you build moves from *an inference endpoint your app calls* to *an application your app is*.**
 
-That difference isn't faster inference. It's a different *kind* of capability, and it's a cross-product, not one API: your application composes **topology** (which lines of reasoning exist and how they relate) × **observation** (watching a generation as it runs) × **evidence** (what gets admitted into context, and when) × **lifecycle** (when output becomes an accepted result) × **authority** (which capabilities a step may use) × **continuity** (the same program, preserved across turns, models, surfaces, and deployments). The model runs inside the harness — governed, forkable, and yours.
+When the model is remote, every agent is a fresh conversation you re-feed and bill per token. When it's embedded, agents fork one shared line of reasoning for free, correct each other in real time, and synthesize — coordination that isn't expressible over API calls. It's not faster inference; it's a different *kind* of capability: your app composes **topology, live observation, evidence admission, lifecycle, and authority** over the model's reasoning, not just its output. [The full capability grammar →](https://hdk.lloyal.ai)
 
 ## What you get
 
 - **A programming model, not an SDK.** A harness is *a tree of owned lifetimes over a tree of live inference state.* Agents bind to parent scopes via [Effection](https://frontside.com/effection) structured concurrency — cancellation propagates, teardown runs in reverse, cleanup is inseparable from ownership. Loops, conditions, and lexical scope **are** your orchestration; there's no graph DSL to learn.
-- **Continuous-context agents.** Sub-agents fork the parent's full attention at zero tensor copy — one shared model context, N branches, **one GPU dispatch per tick regardless of branch count.** A fork is a bitset flip, not a recompute; cost tracks KV *fullness*, not agent count, so two vs. ten concurrent agents decode at the same per-tick speed. *(Code-confirmed against the vendored llama.cpp build — see [Why in-process](#why-in-process-is-a-different-capability).)* The result: **4.4× fewer tokens processed** than a prompt-rebuilding pipeline.
+- **Continuous-context agents.** Sub-agents fork the parent's full attention at zero copy — N branches, **one GPU dispatch per tick**, cost tracking KV *fullness* not agent count. **4.4× fewer tokens** than a prompt-rebuilding pipeline. [The code-confirmed receipts ↓](#why-in-process-is-a-different-capability)
 - **Retrieval-interleaved generation.** Agents assemble context _during_ generation — searching, reading, and reranking across your app's own data. One `Source` shape for files, SQL, the web, or user records. A cross-encoder focal lens admits only verbatim top-K chunks — never summarized.
 - **A signed App platform.** Capabilities — web search, browser automation, payment connectors, your company's data — install as **Apps** from a curated channel at [`apps.lloyal.ai`](https://apps.lloyal.ai). Every bundle is Ed25519-signed and verified against an embedded trust root *before it runs*; the CLI shows an App's *attention surface* — protocol, tools, config, skill lines — from the verified bytes first. What you install is what was reviewed.
-- **One harness, every surface, every tier.** Write the program once; each surface — terminal, desktop, browser — is a binding over the same events, all folding one `reduce`. The same contract runs it on a laptop, a shared GPU box, or a served fleet. *Where* it runs is a deployment decision, not an application one.
+- **One harness, every surface, every tier.** Write the program once; each surface — terminal, desktop, browser — is a binding over the same events, all folding one `reduce`. *Where* it runs — a laptop, a GPU box, a served fleet — is a deployment decision, not an application one. [You already know this architecture — it shipped in Rails in 2007.](https://lloyal.ai/blog/you-already-know-this-architecture/)
 
 Mechanics, receipts, and the case for the architecture at [hdk.lloyal.ai](https://hdk.lloyal.ai).
 
@@ -164,17 +164,33 @@ npx harness.dev publish                        # ship through the signed channel
 
 ## Why in-process is a different capability
 
-Most "AI for TypeScript" tools are a **client to an inference endpoint** — the Vercel AI SDK calls a provider's API; LangGraph orchestrates a graph of calls over one; even "local," through Ollama, the model is a separate daemon you POST to. The model is a service behind a boundary, so every agent, every turn, re-ships its context and pays per token.
+> **Most "AI for TypeScript" is a *client to an inference endpoint*. HDK *embeds the model* — like SQLite in your app, not a database over the network.**
 
-HDK isn't a client — it's a **runtime that embeds the model**, the way an app embeds SQLite instead of reaching a database over the network. The weights are resident in your process, and your harness governs the model's *live* reasoning state as it runs. That's the difference between renting behaviour request-by-request and owning it as code — and it's why concurrent agents are cheap. Endpoint tools coordinate agents like **VMs**: each a full, isolated context you stand up and re-feed. HDK runs them like **containers on one kernel**: every agent is a zero-copy *branch* of one resident model state.
+|                    | Endpoint SDK · Vercel AI / LangGraph / Ollama      | **HDK**                                                                   |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------- |
+| The model is       | a service behind an HTTP boundary                  | resident in the process you run — laptop or your own GPU host             |
+| Each sub-agent     | a fresh request that re-ships its context          | a zero-copy `fork()` of the parent's live attention                       |
+| Ten agents cost    | 10× context · 10× dispatches · per-token billing   | one GPU dispatch per tick — cost tracks KV *fullness*, not agent count    |
+| Prefix sharing     | a token-keyed KV cache, LRU-evicted, over an API   | a structural back-reference, pruned by *your* policy when the reasoning is done |
+| API key            | required, billed per token                         | none on the reasoning path                                                |
 
-The mechanism is verifiable, not marketing — the numbers below are **code-confirmed against the vendored llama.cpp build**, read from source, not reconstructed:
+Endpoint tools run agents like **VMs** — each a full context you stand up and re-feed. HDK runs them like **containers on one kernel**: every agent is a branch of one resident model state.
 
-- **N branches, one dispatch.** N branches that fit the micro-batch decode in **one `llama_decode`** — the batch splitter cuts on token rows and never reads `seq_id`. GPU dispatches per tick are **O(1) in branch count**.
-- **Forking is free.** A fork (`seq_cp`) allocates no cells and copies no buffer — it's a single `std::bitset<LLAMA_MAX_SEQ>` write, one cell now owned by two branches. Zero decode, zero attention compute. *This is* prefix sharing, by construction.
-- **Cost is KV fullness, not agent count.** Per-tick wall-time is `O(n_kv × token_rows)` — there is no `× n_seqs` multiplier. **Two vs. ten concurrent agents decode at the same per-tick speed;** concurrency is free on compute and priced only in KV *space*.
+The mechanism is verifiable, not marketing — **code-confirmed against the vendored llama.cpp build**, read from source:
 
-If you know the serving stack: vLLM and SGLang already reuse prefixes (RadixAttention) — but as a **server**, where the shared prefix is a token-keyed KV *cache* (radix-matched, LRU-evicted; a miss recomputes) reached over an API. HDK puts that tree *inside your application*: a branch is a structural **back-reference** into its parent's live cells (nothing to match, cache, or evict), pruned **semantically** when the reasoning is done — governed by policy, not evicted when a cache runs cold. A cloud per-token API structurally cannot replicate this economics.
+- **N branches, one dispatch.** N branches that fit the micro-batch decode in **one `llama_decode`** — the splitter cuts on token rows, never reads `seq_id`. GPU dispatches per tick are **O(1) in branch count**.
+- **Forking is free.** A fork (`seq_cp`) allocates no cells and copies no buffer — a single `std::bitset<LLAMA_MAX_SEQ>` write, one cell now owned by two branches. Zero decode, zero attention. *This is* prefix sharing, by construction.
+- **Cost is KV fullness, not agent count.** Per-tick wall-time is `O(n_kv × token_rows)` — no `× n_seqs` multiplier. **Two vs. ten concurrent agents decode at the same per-tick speed.**
+
+And the model is a **dial** — the *same* harness runs across compute tiers, key-free at each:
+
+| tier      | runs on                | model                                           | sessions                       |
+| --------- | ---------------------- | ----------------------------------------------- | ------------------------------ |
+| **Edge**  | a laptop               | a 4B, resident in-process                       | one, local                     |
+| **Host**  | your own GPU box       | a frontier model (GLM-5.2), sharded across GPUs | many, over wss — FIFO-admitted |
+| **Fleet** | a host per GPU cluster | frontier, per host                              | each host admits its own       |
+
+vLLM and SGLang share prefixes too (RadixAttention) — but as a **server**, over an API, LRU-evicted. HDK puts that tree *inside your app*, pruned by your policy, not a cache. A cloud per-token API can't replicate the economics.
 
 ## Stack vs. imports
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.6.3",
+      "version": "0.6.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/packages/harness-cli/README.md
+++ b/packages/harness-cli/README.md
@@ -2,7 +2,7 @@
 
 **`rails new` for agentic AI apps — the model lives inside, no API key.**
 
-`harness.dev` is the CLI for the [lloyal HDK](https://github.com/lloyal-ai/hdk). It scaffolds a **harness** — a runnable vertical-inference application in ordinary TypeScript — and runs it on a **resident** model: execution needs no network and no inference-provider service. Every agent scaffold starts with `API_KEY=`. A harness starts with a model.
+`harness.dev` is the CLI for the [lloyal HDK](https://github.com/lloyal-ai/hdk). It scaffolds a **harness** — a runnable vertical-inference app in ordinary TypeScript — and runs it on a model **you own**: resident in your process on a laptop, or served from your own GPU host. Every agent scaffold starts with `API_KEY=`; a harness starts with a model.
 
 ```bash
 npx harness.dev new              # interactive: name → surfaces → model → template
@@ -18,20 +18,26 @@ first run:
   ready — type to begin, ctrl-c to stop
 ```
 
-The recommended model is downloaded + digest-verified into `models/llm/` on first run (no key).
+The recommended model is downloaded + digest-verified into `models/llm/` on first run.
 
 ## One harness, many surfaces
 
-A harness is **one program**. `harness.yml` declares the surfaces it runs on and the model it thinks with — the one place "many surfaces" is spelled out:
+A harness is **one program** that ships as many apps. `harness.yml` lists its **targets** — each scaffolded into a full-stack app (a frontend *and* the deploy that runs it) — and the model it thinks with:
 
 ```yaml
 # harness.yml
-targets: [cli, desktop, web]                    # the surfaces this harness runs on
+targets: [cli, desktop, web]                    # each scaffolds a full-stack app
 model:
   llm: { id: "qwen3.5-4b", context: 32768 }   # the resident model it thinks with
 ```
 
-You write the program once, under `harness/`; the CLI generates a binding per surface under `targets/`:
+| target    | you get                    | run                                 |
+| --------- | -------------------------- | ----------------------------------- |
+| `cli`     | a terminal app             | `npm start`                         |
+| `desktop` | a native Mac / Windows app | `npm run dev:desktop`               |
+| `web`     | a browser app (served)     | `npm run serve` → `npm run dev:web` |
+
+You write the program once, under `harness/`; the CLI generates the full stack per target under `targets/` — each a thin wiring layer over your shared `harness.ts`:
 
 ```text
 my-harness/
@@ -41,10 +47,10 @@ my-harness/
 │   ├── protocol.ts        the commands (↑) and events (↓) it speaks
 │   └── state.ts           reduce(state, event) — the state every surface folds
 ├── models/              resident, digest-verified weights (gitignored)
-└── targets/             generated bindings — cli · desktop · web
+└── targets/             one full-stack app per target — cli · desktop · web
 ```
 
-The line that makes it click: `harness.dev targets:add web` adds a browser surface **without touching `harness.ts`**. Same program, one more transport. It's MVC with a live model as the Model — `harness.ts` is the Controller, your surfaces are the Views, the resident model holds the live generative state. The same contract is what lets that program scale from your laptop to a served GPU fleet: *where* it runs is a deployment decision, not an application one. [You already know this architecture — it shipped in Rails in 2007.](https://lloyal.ai/blog/you-already-know-this-architecture/)
+`harness.dev targets:add web` adds a browser app **without touching `harness.ts`** — it's MVC with a live model as the Model: your harness is the Controller, surfaces are Views. [You already know this architecture — it shipped in Rails in 2007.](https://lloyal.ai/blog/you-already-know-this-architecture/)
 
 ## Commands
 
@@ -104,17 +110,28 @@ npx harness.dev review                           # (reviewers) inspect + approve
 
 ## Where it sits
 
-Most "AI for TypeScript" tools are a **client to an inference endpoint**: the Vercel AI SDK calls a provider's API; LangGraph orchestrates a graph of calls over one — even "local," through Ollama, the model runs as a separate daemon you POST to. The model is a service behind a boundary, so every agent, every turn, re-ships its context and pays per token.
+> **Most "AI for TypeScript" is a *client to an inference endpoint*. Lloyal *embeds the model* — the way your app embeds SQLite, not a database server.**
 
-Lloyal isn't a client — it's a **runtime that embeds the model**, the way an app embeds SQLite instead of reaching a database over the network. The weights are resident in your process, and your harness — ordinary TypeScript — governs the model's *live* reasoning state as it runs. That's the difference between renting behaviour request-by-request and owning it as code.
+|                    | Endpoint SDK · Vercel AI / LangGraph / Ollama      | **Lloyal HDK**                                                            |
+| ------------------ | -------------------------------------------------- | ------------------------------------------------------------------------- |
+| The model is       | a service behind an HTTP boundary                  | resident in the process you run — laptop or your own GPU host             |
+| Each sub-agent     | a fresh request that re-ships its context          | a zero-copy `fork()` of the parent's live attention                       |
+| Ten agents cost    | 10× context · 10× dispatches · per-token billing   | one GPU dispatch per tick — cost tracks KV *fullness*, not agent count    |
+| Prefix sharing     | a token-keyed KV cache, LRU-evicted, over an API   | a structural back-reference, pruned by *your* policy when the reasoning is done |
+| API key            | required, billed per token                         | none on the reasoning path                                                |
 
-It's also why concurrent agents are cheap. Endpoint tools coordinate agents like **VMs** — each is a full, isolated context you stand up and re-feed. Lloyal runs them like **containers on one kernel**: every agent is a zero-copy *branch* of one resident model state, forked for free and decoded in the same pass. Cost tracks how much context is live, not how many agents run.
+Endpoint tools run agents like **VMs** — each a full context you stand up and re-feed. Lloyal runs them like **containers on one kernel**: every agent is a branch of one resident model state, forked for free and decoded in the same pass.
 
-If you know the serving stack: vLLM and SGLang already reuse prefixes (RadixAttention) and fork parallel decodes — but as a **server**, where the shared prefix is a token-keyed KV *cache* (radix-matched, LRU-evicted; a miss recomputes) reached over an API. Lloyal puts that tree *inside your application*. A branch is a `fork()` — a structural **back-reference** into its parent's live cells, shared by construction (nothing to match, cache, or evict) — and it's pruned **semantically and topologically**: your harness retires a branch when the *reasoning* is done or a subtree is a dead-end, governed by policy, not evicted when a cache runs cold. The KV math is the same; the tree is yours, in-process, and institutional — not a throughput optimization you rent from a server.
+And the model is a **dial** — the *same* harness runs across compute tiers, key-free at each:
 
-- **No key on the inference path.** Model execution never depends on a third-party API — `grep API_KEY` in a scaffolded project finds nothing. Apps use the network only when a capability calls for it (a search token, an OAuth grant); that never touches the reasoning path.
-- **Continuous context.** Agents are zero-copy KV branches over one live model state — fan-out, chains and DAGs without serialising or summarising context between them.
-- **Apps arrive signed.** First- and third-party ride the same Ed25519-verified path from a curated, reviewed catalog.
+| tier      | runs on                       | model                                           | sessions                       |
+| --------- | ----------------------------- | ----------------------------------------------- | ------------------------------ |
+| **Edge**  | a laptop / the user's machine | a 4B, resident in-process                       | one, local                     |
+| **Host**  | your own GPU box              | a frontier model (GLM-5.2), sharded across GPUs | many, over wss — FIFO-admitted |
+| **Fleet** | a host per GPU cluster        | frontier, per host                              | each host admits its own       |
+
+- **Apps reach the network only for their own capabilities** — a search token, an OAuth grant — never the reasoning path itself.
+- **Apps arrive signed.** First- and third-party ride the same Ed25519-verified path from a curated, reviewed catalog — an App's *attention surface* (protocol · tools · config · skills) shown from the verified bytes before install.
 
 **[Docs →](https://docs.lloyal.ai/cli)** · **[Build an App →](https://docs.lloyal.ai/build-an-app/what-is-an-app)** · **[The HDK →](https://github.com/lloyal-ai/hdk)**
 

--- a/packages/harness-cli/bin/run.js
+++ b/packages/harness-cli/bin/run.js
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+/**
+ * harness.dev — entrypoint for `npx harness.dev` and a global install.
+ *
+ * A dumb shim: load the built CLI library and run it. Keeping the bin separate
+ * from the library (`dist/cli.js`) is what makes it robust — the shim runs
+ * unconditionally, so there is no "am I the main module?" self-check to break
+ * when the bin is reached through a symlink (npx / `npm i -g` / `npm link`).
+ * This is the same shape every scaffolded harness ships (`bin/run.js`).
+ */
+import('../dist/cli.js')
+  .then((m) => m.run())
+  .catch((err) => {
+    process.stderr.write(`Error: ${err && err.stack ? err.stack : err}\n`);
+    process.exit(1);
+  });

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,9 +1,9 @@
 {
   "name": "harness.dev",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
-    "harness.dev": "dist/cli.js"
+    "harness.dev": "bin/run.js"
   },
   "publishConfig": {
     "access": "public"
@@ -44,6 +44,7 @@
     "ink-testing-library": "^4.0.0"
   },
   "files": [
+    "bin/run.js",
     "dist/**/*.js",
     "templates/**/*",
     "LICENSE"

--- a/packages/harness-cli/src/cli.ts
+++ b/packages/harness-cli/src/cli.ts
@@ -17,7 +17,7 @@
 
 import { readFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
 import { findCommand } from './commands/index.js';
 
 function version(): string {
@@ -94,16 +94,19 @@ export async function main(argv: readonly string[]): Promise<number> {
   return 1;
 }
 
-// Auto-run only when invoked as the CLI entrypoint — importing this module (e.g.
-// from a test) must NOT dispatch on the importer's argv.
-if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
-  void main(process.argv.slice(2)).then(
-    (code) => {
-      process.exitCode = code;
-    },
-    (err: unknown) => {
-      process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
-      process.exitCode = 1;
-    },
-  );
+/**
+ * Process entrypoint — turn argv into an exit code. Called by the `bin/run.js`
+ * shim, which is the CLI's only executable. Keeping this here (not in the shim)
+ * means all logic and its types live in one place and the shim stays a dumb
+ * loader; keeping it OFF module top-level means importing `cli.ts` (from a test,
+ * say) has no side effects. `main` stays pure — it returns a code — while `run`
+ * owns the process glue.
+ */
+export async function run(): Promise<void> {
+  try {
+    process.exitCode = await main(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
 }

--- a/packages/harness-cli/test/cli-entrypoint.test.ts
+++ b/packages/harness-cli/test/cli-entrypoint.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Regression: the CLI must dispatch when its bin is reached through a **symlink**
+ * — which is how every real install runs it (`npx`, global `npm i -g`, `npm link`).
+ *
+ * The bin is a dumb shim (`bin/run.js`) that loads the library (`dist/cli.js`)
+ * and calls its exported `run()`; the shim runs unconditionally, so there is no
+ * "am I the main module?" self-check to break under a symlink. (An earlier design
+ * fused the two into `dist/cli.js` and guarded on
+ * `import.meta.url === pathToFileURL(process.argv[1])`, which never matched
+ * through a symlink → the CLI silently exited 0 having done nothing.) Every other
+ * test imports command modules directly and so never exercises the bin — this one
+ * spawns it through a symlink, exactly as an installed bin does.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, symlinkSync, readdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const binRun = join(here, '..', 'bin', 'run.js'); // the published bin (a shim)
+const distCli = join(here, '..', 'dist', 'cli.js'); // the library the shim loads
+
+describe('bin/run.js entrypoint (invoked via a bin symlink)', () => {
+  beforeAll(() => {
+    expect(existsSync(binRun), `missing shim ${binRun}`).toBe(true);
+    expect(existsSync(distCli), `build first — missing ${distCli}`).toBe(true);
+  });
+
+  function symlinkedBin(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hd-bin-'));
+    const link = join(dir, 'harness.dev'); // basename differs from the target, like a real bin
+    symlinkSync(binRun, link);
+    return link;
+  }
+
+  it('--help dispatches through the symlink (does not silently no-op)', () => {
+    const out = execFileSync('node', [symlinkedBin(), '--help'], { encoding: 'utf8' });
+    expect(out).toContain('harness.dev');
+    expect(out).toMatch(/Scaffold/);
+  });
+
+  it('new <name> --yes scaffolds through the symlink', () => {
+    const bin = symlinkedBin();
+    const dest = mkdtempSync(join(tmpdir(), 'hd-scaffold-'));
+    const out = execFileSync('node', [bin, 'new', 'symapp', '--yes', '--dir', dest], {
+      encoding: 'utf8',
+    });
+    expect(out).toContain('scaffolded symapp');
+    expect(readdirSync(dest)).toContain('symapp');
+    expect(existsSync(join(dest, 'symapp', 'harness.yml'))).toBe(true);
+  });
+});


### PR DESCRIPTION
### The bug (ship-blocker across 0.6.0–0.6.3)
`harness.dev <anything>` was a **silent no-op** for every real install. `dist/cli.js` was both the library and the executable, gated by `import.meta.url === pathToFileURL(process.argv[1]).href`. Reached through a bin **symlink** (npx / `npm i -g` / `npm link`), `process.argv[1]` is the symlink path while `import.meta.url` is the realpath — the guard never matches, so the dispatcher never runs and the process exits 0 having done nothing. The unit tests import command modules directly and never execute `dist/cli.js`, so they stayed green while the shipped CLI was dead.

### The fix — separate entrypoint from library
- **`bin/run.js`** (new): a dumb shim — `import('../dist/cli.js').then(m => m.run())`. Runs unconditionally; no self-check to break under a symlink. Same shape every scaffolded harness ships.
- **`cli.ts`**: pure library — drops the self-guard, exports `run()` (process glue) + `main()` (pure, returns a code, for tests). Importing it now has zero side effects.
- **`package.json`**: `bin` → `bin/run.js`; ships it in `files`; `0.6.4`.
- **regression test**: spawns the bin **through a symlink** — the path the whole suite skipped.

Verified against the failing path: `node <symlink> new x --yes` now scaffolds; `--help` prints; direct `node dist/cli.js` is correctly inert. **103/103.**

### Also — README pass (root + package)
Restructure the positioning into **comparison + Edge/Host/Fleet tiers tables**, dedupe the "no key" theme (8→1 / 6→1), delete the model-range prose patch (the tiers table now *shows* frontier models — GLM-5.2 on a GPU host), restore the "You already know this architecture" Rails blog link. Less prose, more skimmable structure.

Ship: tag `v0.6.4-cli` on merge → `release.yml` publishes.