### PR TITLE
feat(harness-cli): 0.6.5 — branded wizard, auto-install, one-command web

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.6.4",
+      "version": "0.6.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -2670,7 +2670,7 @@
         "react": "^18.3.1"
       },
       "bin": {
-        "harness.dev": "dist/cli.js"
+        "harness.dev": "bin/run.js"
       },
       "devDependencies": {
         "@types/react": "^18.3.12",

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "bin/run.js"

--- a/packages/harness-cli/src/commands/new-wizard.tsx
+++ b/packages/harness-cli/src/commands/new-wizard.tsx
@@ -14,11 +14,15 @@
  * harnesses render in, so the tool eats its own dog food. It stays thin: no
  * scaffolding happens here, only data collection.
  */
+import { createRequire } from 'node:module';
 import { useRef, useState, type ReactElement } from 'react';
 import { Box, Text, render, useApp, useInput } from 'ink';
-import { TextInput, Select, MultiSelect, StatusMessage } from '@inkjs/ui';
+import { TextInput, Select, MultiSelect, ThemeProvider } from '@inkjs/ui';
 import { modelsForRole } from '../scaffold/model-catalog.js';
+import { cliTheme, ACCENT } from '../scaffold/palette.js';
 import type { Target } from '../scaffold/prune-targets.js';
+
+const VERSION = (createRequire(import.meta.url)('../../package.json') as { version: string }).version;
 
 export type TemplateKind = 'blank' | 'research';
 
@@ -42,6 +46,138 @@ const NAME_RE = /^[a-z][a-z0-9_-]{1,63}$/;
 const TARGET_ORDER: Target[] = ['cli', 'desktop', 'web'];
 const DEFAULT_TARGETS: Target[] = ['cli', 'desktop', 'web'];
 
+// Brand gradient — a horizontal sweep across the mark and wordmark. Truecolor
+// stops; terminals without 24-bit color downsample gracefully.
+type RGB = readonly [number, number, number];
+const STOPS: readonly RGB[] = [
+  [45, 212, 191], // #2DD4BF teal
+  [99, 102, 241], // #6366F1 indigo
+  [217, 70, 239], // #D946EF fuchsia
+];
+
+/** Sample the multi-stop gradient at t ∈ [0,1]. */
+function sample(t: number): RGB {
+  const span = STOPS.length - 1;
+  const seg = Math.min(Math.max(t, 0), 1) * span;
+  const i = Math.min(Math.floor(seg), span - 1);
+  const f = seg - i;
+  const a = STOPS[i];
+  const b = STOPS[i + 1];
+  return [a[0] + (b[0] - a[0]) * f, a[1] + (b[1] - a[1]) * f, a[2] + (b[2] - a[2]) * f];
+}
+const hex = (c: RGB): string =>
+  `#${c.map((n) => Math.round(n).toString(16).padStart(2, '0')).join('')}`;
+const dim = (c: RGB, k: number): RGB => [c[0] * k, c[1] * k, c[2] * k];
+
+/** A word painted with the brand gradient, one hue step per character. */
+function GradientWord({ text, bold }: { text: string; bold?: boolean }): ReactElement {
+  const chars = [...text];
+  const last = Math.max(chars.length - 1, 1);
+  return (
+    <Text bold={bold}>
+      {chars.map((ch, i) => (
+        <Text key={i} color={hex(sample(i / last))}>
+          {ch}
+        </Text>
+      ))}
+    </Text>
+  );
+}
+
+// The lloyal [LL] mark as block art (matches src/assets/logo-white.png):
+// an open bracket, two Ls, a close bracket.
+const MARK_ROWS: readonly string[] = [
+  '███ █   █   ███',
+  '█   █   █     █',
+  '█   █   █     █',
+  '█   █   █     █',
+  '█   █   █     █',
+  '█   █   █     █',
+  '███ ███ ███ ███',
+];
+const MARK_W = Math.max(...MARK_ROWS.map((r) => r.length));
+
+// Horizontal extent of solids per row — used to keep the shadow on the mark's
+// outer silhouette (baseline + right edge) rather than filling the interior
+// negative space (bracket mouths, letter gaps), which reads as noise.
+const MARK_BOUNDS = MARK_ROWS.map((row) => {
+  let min = Infinity;
+  let max = -Infinity;
+  for (let c = 0; c < row.length; c++)
+    if (row[c] === '█') {
+      min = Math.min(min, c);
+      max = Math.max(max, c);
+    }
+  return { min, max };
+});
+
+type Cell = 'solid' | 'shadow' | 'empty';
+const markSolid = (r: number, c: number): boolean =>
+  r >= 0 && r < MARK_ROWS.length && c >= 0 && c < MARK_ROWS[r].length && MARK_ROWS[r][c] === '█';
+
+/** True when (r,c) is interior negative space (enclosed left and right by solids). */
+const enclosed = (r: number, c: number): boolean => {
+  const b: { min: number; max: number } | undefined = MARK_BOUNDS[r];
+  return b !== undefined && c > b.min && c < b.max;
+};
+
+/** Solid glyph, or a drop-shadow offset down-right on the outer silhouette — the "trail". */
+function markCell(r: number, c: number): Cell {
+  if (markSolid(r, c)) return 'solid';
+  if (markSolid(r - 1, c - 1) && !enclosed(r, c)) return 'shadow';
+  return 'empty';
+}
+
+/** The big [LL] emblem: block glyphs, a horizontal gradient, a stippled shadow. */
+function BigMark(): ReactElement {
+  const rows: ReactElement[] = [];
+  for (let r = 0; r <= MARK_ROWS.length; r++) {
+    const cells: ReactElement[] = [];
+    for (let c = 0; c <= MARK_W; c++) {
+      const kind = markCell(r, c);
+      const tint = sample(c / MARK_W);
+      if (kind === 'solid') {
+        cells.push(
+          <Text key={c} color={hex(tint)}>
+            █
+          </Text>,
+        );
+      } else if (kind === 'shadow') {
+        cells.push(
+          <Text key={c} color={hex(dim(tint, 0.5))}>
+            ░
+          </Text>,
+        );
+      } else {
+        cells.push(<Text key={c}> </Text>);
+      }
+    }
+    rows.push(<Text key={r}>{cells}</Text>);
+  }
+  return <Box flexDirection="column">{rows}</Box>;
+}
+
+/**
+ * The boot banner: the big [LL] mark (block art + gradient + dithered shadow)
+ * over the wordmark, a one-line pitch, and the version. The tool's front door —
+ * brand-forward like a real CLI splash, sized to a mark, not a figlet wall.
+ */
+function Banner(): ReactElement {
+  return (
+    <Box flexDirection="column">
+      <BigMark />
+      <Box width="100%" justifyContent="space-between" marginTop={1}>
+        <Box gap={2}>
+          <GradientWord text="harness.dev" bold />
+          <Text dimColor>rails new for agentic AI apps</Text>
+        </Box>
+        <Text dimColor>v{VERSION}</Text>
+      </Box>
+      <Text dimColor>the model lives inside your app — no API key</Text>
+    </Box>
+  );
+}
+
 export function orderTargets(values: string[]): Target[] {
   const set = new Set(values);
   set.add('cli'); // cli carries the engine bin — always kept
@@ -57,6 +193,36 @@ function initialQueue(prefill: WizardPrefill): StepId[] {
   if (!prefill.llm) q.push('model');
   if (!prefill.template) q.push('template');
   return q;
+}
+
+/** A one-line question header: a bold amber label + a dim inline hint. */
+function Field({ label, hint }: { label: string; hint: string }): ReactElement {
+  return (
+    <Text>
+      <Text color={ACCENT} bold>
+        {label}
+      </Text>
+      <Text dimColor>{`   ${hint}`}</Text>
+    </Text>
+  );
+}
+
+/** A text-entry row: a `❯` prompt marker + the input on one line. */
+function Prompt({
+  placeholder,
+  onChange,
+  onSubmit,
+}: {
+  placeholder: string;
+  onChange: () => void;
+  onSubmit: (value: string) => void;
+}): ReactElement {
+  return (
+    <Box>
+      <Text color={ACCENT}>❯ </Text>
+      <TextInput placeholder={placeholder} onChange={onChange} onSubmit={onSubmit} />
+    </Box>
+  );
 }
 
 export function Wizard({
@@ -108,8 +274,12 @@ export function Wizard({
 
   const submitName = (value: string): void => {
     const trimmed = value.trim();
+    if (!trimmed) {
+      setNameError('Type a name, then press enter.');
+      return;
+    }
     if (!NAME_RE.test(trimmed)) {
-      setNameError(`"${trimmed}" — expected [a-z][a-z0-9_-]{1,63} (lowercase, starts with a letter).`);
+      setNameError('Use lowercase letters, digits, - and _ — starting with a letter.');
       return;
     }
     setName(trimmed);
@@ -138,7 +308,7 @@ export function Wizard({
   const submitByo = (value: string): void => {
     const trimmed = value.trim();
     if (!trimmed) {
-      setByoError('Enter a path to a local .gguf, or press Ctrl-C to cancel.');
+      setByoError('Enter a path to a local .gguf, or press ctrl-c to cancel.');
       return;
     }
     setLlm(trimmed);
@@ -150,80 +320,100 @@ export function Wizard({
     advance(queue.slice(1), { template: value as TemplateKind });
   };
 
+  const hasAnswers = Boolean(
+    collected.current.name || collected.current.targets || collected.current.llm,
+  );
+
   return (
-    <Box flexDirection="column" gap={1}>
-      <Text bold>Scaffold a new harness</Text>
+    <Box flexDirection="column">
+      <Banner />
 
-      {collected.current.name && <Text dimColor>{`  name      ${collected.current.name}`}</Text>}
-      {collected.current.targets && (
-        <Text dimColor>{`  targets   ${collected.current.targets.join(', ')}`}</Text>
-      )}
-      {collected.current.llm && <Text dimColor>{`  model     ${collected.current.llm}`}</Text>}
+      <Box marginTop={1}>
+        <Text dimColor>Scaffold a new harness</Text>
+      </Box>
 
-      {step === 'name' && (
-        <Box flexDirection="column">
-          <Text>Harness name:</Text>
-          <Text dimColor>lowercase letters, digits, - and _ — becomes the folder and npm name.</Text>
-          <TextInput placeholder="my-harness" onSubmit={submitName} />
-          {nameError && <StatusMessage variant="error">{nameError}</StatusMessage>}
+      {hasAnswers && (
+        <Box flexDirection="column" marginTop={1}>
+          {collected.current.name && <Text dimColor>{`  name      ${collected.current.name}`}</Text>}
+          {collected.current.targets && (
+            <Text dimColor>{`  targets   ${collected.current.targets.join(', ')}`}</Text>
+          )}
+          {collected.current.llm && <Text dimColor>{`  model     ${collected.current.llm}`}</Text>}
         </Box>
       )}
 
-      {step === 'targets' && (
-        <Box flexDirection="column">
-          <Text>Targets (space to toggle, enter to confirm — cli is always included):</Text>
-          <Text dimColor>
-            cli = terminal · desktop = native window · web = browser app + host, one reduce.
-          </Text>
-          <MultiSelect
-            options={[
-              { label: 'cli (required)', value: 'cli' },
-              { label: 'desktop', value: 'desktop' },
-              { label: 'web', value: 'web' },
-            ]}
-            defaultValue={targets}
-            onSubmit={submitTargets}
-          />
-        </Box>
-      )}
+      <Box flexDirection="column" marginTop={1}>
+        {step === 'name' && (
+          <Box flexDirection="column">
+            <Field label="Harness name" hint="lowercase — becomes the folder + npm name" />
+            <Prompt
+              placeholder="my-harness"
+              onChange={() => {
+                if (nameError) setNameError(null);
+              }}
+              onSubmit={submitName}
+            />
+            {nameError && <Text color="red">{`  ${nameError}`}</Text>}
+          </Box>
+        )}
 
-      {step === 'model' && (
-        <Box flexDirection="column">
-          <Text>Trunk model:</Text>
-          <Text dimColor>catalog models are fetched + digest-verified on first run — no API key.</Text>
-          <Select
-            options={[
-              { label: `Recommended — ${defaultLlmLabel}`, value: 'recommended' },
-              { label: 'Bring your own — a local .gguf you already have', value: 'byo' },
-              { label: 'Decide later — keep the default, edit harness.yml', value: 'later' },
-            ]}
-            onChange={submitModel}
-          />
-        </Box>
-      )}
+        {step === 'targets' && (
+          <Box flexDirection="column">
+            <Field label="Targets" hint="cli terminal · desktop window · web browser — one reduce" />
+            <Text dimColor>space toggles, enter confirms — cli is always included.</Text>
+            <MultiSelect
+              options={[
+                { label: 'cli (required)', value: 'cli' },
+                { label: 'desktop', value: 'desktop' },
+                { label: 'web', value: 'web' },
+              ]}
+              defaultValue={targets}
+              onSubmit={submitTargets}
+            />
+          </Box>
+        )}
 
-      {step === 'byo' && (
-        <Box flexDirection="column">
-          <Text>Path to your .gguf:</Text>
-          <Text dimColor>absolute, or relative to the project — trusted as-is, not digest-verified.</Text>
-          <TextInput placeholder="./models/llm/my-model.gguf" onSubmit={submitByo} />
-          {byoError && <StatusMessage variant="error">{byoError}</StatusMessage>}
-        </Box>
-      )}
+        {step === 'model' && (
+          <Box flexDirection="column">
+            <Field label="Trunk model" hint="fetched + digest-verified on first run — no key" />
+            <Select
+              options={[
+                { label: `Recommended — ${defaultLlmLabel}`, value: 'recommended' },
+                { label: 'Bring your own — a local .gguf you already have', value: 'byo' },
+                { label: 'Decide later — keep the default, edit harness.yml', value: 'later' },
+              ]}
+              onChange={submitModel}
+            />
+          </Box>
+        )}
 
-      {step === 'template' && (
-        <Box flexDirection="column">
-          <Text>Template:</Text>
-          <Text dimColor>the starting point — you own the code either way.</Text>
-          <Select
-            options={[
-              { label: 'blank — minimal 2-agent pipeline', value: 'blank' },
-              { label: 'research — tuned recon → plan → agents → synth', value: 'research' },
-            ]}
-            onChange={submitTemplate}
-          />
-        </Box>
-      )}
+        {step === 'byo' && (
+          <Box flexDirection="column">
+            <Field label="Path to your .gguf" hint="absolute or project-relative — trusted as-is" />
+            <Prompt
+              placeholder="./models/llm/my-model.gguf"
+              onChange={() => {
+                if (byoError) setByoError(null);
+              }}
+              onSubmit={submitByo}
+            />
+            {byoError && <Text color="red">{`  ${byoError}`}</Text>}
+          </Box>
+        )}
+
+        {step === 'template' && (
+          <Box flexDirection="column">
+            <Field label="Template" hint="the starting point — you own the code either way" />
+            <Select
+              options={[
+                { label: 'blank — minimal 2-agent pipeline', value: 'blank' },
+                { label: 'research — tuned recon → plan → agents → synth', value: 'research' },
+              ]}
+              onChange={submitTemplate}
+            />
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }
@@ -242,7 +432,11 @@ export function runNewWizard(prefill: WizardPrefill = {}): Promise<WizardResult 
         resolve(result);
       }
     };
-    const { waitUntilExit } = render(<Wizard onDone={done} prefill={prefill} />);
+    const { waitUntilExit } = render(
+      <ThemeProvider theme={cliTheme}>
+        <Wizard onDone={done} prefill={prefill} />
+      </ThemeProvider>,
+    );
     void waitUntilExit().then(() => done(null));
   });
 }

--- a/packages/harness-cli/src/commands/new.ts
+++ b/packages/harness-cli/src/commands/new.ts
@@ -11,6 +11,7 @@ import {
   buildSubstitutions,
 } from '../scaffold/copy-tree.js';
 import { writeProjectMarker } from '../scaffold/write-marker.js';
+import { runInstall, printNextSteps, writeReadmeRunSteps } from '../scaffold/post-scaffold.js';
 import { runNewWizard, type TemplateKind, type WizardPrefill } from './new-wizard.js';
 
 const USAGE = [
@@ -36,12 +37,15 @@ const USAGE = [
   '                Trunk model — a catalog id (fetched + digest-verified) or a path',
   '                to a local .gguf you already have. Default: the catalog default.',
   '  --dir <path>  Parent directory to create the harness in (default: cwd)',
+  '  --skip-install',
+  '                Do not run `npm install` after scaffolding (it runs by',
+  '                default in an interactive terminal).',
   '  -y, --yes     Skip the picker; accept defaults for anything not given a flag.',
   '  -h, --help    Show this help',
   '',
   'Any flags you pass also pre-seed the picker, so it prompts only for what is',
   'missing. Emits a runnable harness on the selected surfaces, on a resident model',
-  '(fetched + verified on first run — no API key). Run `npm install && npm start`.',
+  '(fetched + verified on first run — no API key), then prints how to run each one.',
 ].join('\n');
 
 // Same grammar as `harness.dev app:new`: identifier-safe lowercase that
@@ -73,6 +77,7 @@ export const newCommand: Command = {
         template: { type: 'string' },
         targets: { type: 'string' },
         model: { type: 'string' },
+        'skip-install': { type: 'boolean' },
         yes: { type: 'boolean', short: 'y' },
       },
       allowPositionals: true,
@@ -119,7 +124,11 @@ export const newCommand: Command = {
       plan = built;
     }
 
-    return performScaffold(plan, parentDir);
+    // Auto-install by default in a real terminal (the batteries-included flow):
+    // scaffolding a project the user can't run yet is a dead-end. Skipped in
+    // non-TTY (CI installs itself) or with --skip-install.
+    const install = Boolean(process.stdout.isTTY) && !values['skip-install'];
+    return performScaffold(plan, parentDir, { install });
   },
 };
 
@@ -184,8 +193,12 @@ function parseTargets(csv: string | undefined): { targets: Target[] } | { error:
   return { targets: ALL_TARGETS.filter((t) => set.has(t)) };
 }
 
-/** Copy the template, prune to the selected targets, write the model. */
-function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
+/** Copy the template, prune to the selected targets, write the model, then install + report. */
+async function performScaffold(
+  plan: ScaffoldPlan,
+  parentDir: string,
+  opts: { install: boolean },
+): Promise<number> {
   const dest = join(parentDir, plan.name);
 
   // Refuse to clobber ANY existing path (dir, file, or symlink) — falling
@@ -220,6 +233,8 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
     // Provenance: record which template + surfaces this project came from so
     // `targets:add` knows which template's target subtree to copy back.
     writeProjectMarker(dest, { template: plan.template, targets: plan.targets });
+    // Fill the README's run instructions for exactly the surfaces we kept.
+    writeReadmeRunSteps(dest, plan.targets);
   } catch (err) {
     process.stderr.write(
       `harness.dev: scaffold failed: ${err instanceof Error ? err.message : String(err)}\n`,
@@ -227,24 +242,14 @@ function performScaffold(plan: ScaffoldPlan, parentDir: string): number {
     return 1;
   }
 
-  const appsNote =
-    plan.template === 'research'
-      ? '  it runs inside your app. The lloyal/corpus + lloyal/web apps are\n' +
-        '  preinstalled (grounded multi-agent research);\n'
-      : '  it runs inside your app. The lloyal/wikipedia app is preinstalled;\n';
-
   process.stdout.write(
-    `scaffolded ${plan.name} (${plan.template}) at ${dest}\n` +
-      `  targets: ${plan.targets.join(', ')} · model: ${plan.llm}\n` +
-      '  next steps:\n' +
-      `    cd ${plan.name}\n` +
-      '    npm install\n' +
-      '    npm start\n' +
-      '\n' +
-      '  No API key needed — the model is fetched + digest-verified on first run;\n' +
-      appsNote +
-      '  add more via: npx harness.dev install <publisher>/<name>\n',
+    `scaffolded ${plan.name} (${plan.template}) · targets: ${plan.targets.join(', ')} · model: ${plan.llm}\n`,
   );
+
+  // Batteries-included: install now (behind a spinner) so the project is
+  // runnable, then print how to run each surface. Skipped in non-TTY/CI.
+  const installed = opts.install ? await runInstall(dest) : false;
+  printNextSteps({ name: plan.name, targets: plan.targets, installed });
   return 0;
 }
 

--- a/packages/harness-cli/src/scaffold/palette.ts
+++ b/packages/harness-cli/src/scaffold/palette.ts
@@ -1,0 +1,55 @@
+/**
+ * The CLI's shared color language — one place so the wizard, the install
+ * spinner, and the next-steps panel stay coherent (and don't drift into an
+ * all-teal surface). Warm amber for labels / prompts / work-in-progress; cool
+ * cyan reserved for LIVE selection only; green for success.
+ */
+import { extendTheme, defaultTheme } from '@inkjs/ui';
+
+/** Warm accent — question labels, the `❯` prompt, the install spinner. */
+export const ACCENT = '#f5a623';
+/** The same accent as a raw SGR foreground code, for plain-ANSI output (the
+ *  next-steps panel) — derived from ACCENT so the two can never drift. */
+export const ACCENT_SGR = `38;2;${parseInt(ACCENT.slice(1, 3), 16)};${parseInt(
+  ACCENT.slice(3, 5),
+  16,
+)};${parseInt(ACCENT.slice(5, 7), 16)}`;
+/** The focused/selected row (the one cool accent — kept scarce on purpose). */
+const FOCUS = 'cyan';
+/** Success / checked. */
+const SUCCESS = 'green';
+
+const focusHighlight = (p?: { isFocused?: boolean; isSelected?: boolean }): Record<string, unknown> => {
+  if (p?.isFocused) return { color: FOCUS, bold: true };
+  if (p?.isSelected) return { color: SUCCESS };
+  return {};
+};
+
+/**
+ * `@inkjs/ui` theme override. Its defaults paint both the focused option AND
+ * the spinner frame `blue` — low-contrast on a dark terminal. This recolors
+ * selection to cyan+bold, the multi-select check to green, and the spinner to
+ * the warm accent so "working" reads clearly.
+ */
+export const cliTheme = extendTheme(defaultTheme, {
+  components: {
+    Select: {
+      styles: {
+        focusIndicator: () => ({ color: FOCUS }),
+        label: focusHighlight,
+      },
+    },
+    MultiSelect: {
+      styles: {
+        focusIndicator: () => ({ color: FOCUS }),
+        selectedIndicator: () => ({ color: SUCCESS }),
+        label: focusHighlight,
+      },
+    },
+    Spinner: {
+      styles: {
+        frame: () => ({ color: ACCENT }),
+      },
+    },
+  },
+});

--- a/packages/harness-cli/src/scaffold/post-scaffold.tsx
+++ b/packages/harness-cli/src/scaffold/post-scaffold.tsx
@@ -1,0 +1,132 @@
+/**
+ * After a scaffold completes: optionally run `npm install` behind a spinner,
+ * then print a per-target "how to run it" panel. Without this the flow
+ * dead-ends — the user lands in a shell with no `node_modules` and only a guess
+ * at the script name (`npm run dev:web` → `vite: command not found`).
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { Box, Text, render, useApp } from 'ink';
+import { Spinner, ThemeProvider } from '@inkjs/ui';
+import { spawn } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { cliTheme, ACCENT, ACCENT_SGR } from './palette.js';
+import type { Target } from './prune-targets.js';
+
+const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+function InstallScreen({ dir, onDone }: { dir: string; onDone: (ok: boolean) => void }): ReactElement {
+  const { exit } = useApp();
+  const [phase, setPhase] = useState<'installing' | 'ok' | 'fail'>('installing');
+
+  useEffect(() => {
+    const child = spawn(NPM, ['install'], { cwd: dir, stdio: 'ignore' });
+    let settled = false;
+    const finish = (ok: boolean): void => {
+      if (settled) return;
+      settled = true;
+      setPhase(ok ? 'ok' : 'fail');
+      onDone(ok);
+    };
+    child.on('close', (code) => finish(code === 0));
+    child.on('error', () => finish(false));
+    return () => {
+      if (!settled) child.kill();
+    };
+  }, [dir, onDone]);
+
+  // Once resolved, let the final (✓ / !) frame paint, then unmount — so the
+  // terminal is left showing the result, not a frozen spinner glyph.
+  useEffect(() => {
+    if (phase === 'installing') return undefined;
+    const id = setTimeout(() => exit(), 24);
+    return () => clearTimeout(id);
+  }, [phase, exit]);
+
+  if (phase === 'installing') {
+    return (
+      <Box gap={1}>
+        <Spinner />
+        <Text color={ACCENT}>
+          Installing dependencies <Text dimColor>— vite · ink · electron, ~a minute</Text>
+        </Text>
+      </Box>
+    );
+  }
+  if (phase === 'ok') {
+    return (
+      <Text>
+        <Text color="green">✓</Text> Dependencies installed
+      </Text>
+    );
+  }
+  return (
+    <Text>
+      <Text color="yellow">!</Text> Couldn&apos;t install automatically — run{' '}
+      <Text bold>npm install</Text> in the project.
+    </Text>
+  );
+}
+
+/** Run `npm install` in `dir` behind a spinner. Resolves true on success. */
+export function runInstall(dir: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let ok = false;
+    const { waitUntilExit } = render(<InstallScreen dir={dir} onDone={(v) => (ok = v)} />);
+    void waitUntilExit().then(() => resolve(ok));
+  });
+}
+
+/** Per-target run command + a one-word label for the surface. */
+const RUN: Record<Target, { cmd: string; label: string; note?: string }> = {
+  cli: { cmd: 'npm start', label: 'Terminal' },
+  desktop: { cmd: 'npm run dev:desktop', label: 'Desktop window' },
+  web: { cmd: 'npm run dev:web', label: 'Browser', note: 'boots the host + browser' },
+};
+
+/** Markdown "how to run each surface" block for the scaffolded README. */
+export function runStepsMarkdown(targets: Target[]): string {
+  return targets
+    .map((t) => {
+      const { cmd, label, note } = RUN[t];
+      return `- **${label}** — \`${cmd}\`${note ? ` — ${note}` : ''}`;
+    })
+    .join('\n');
+}
+
+/** Replace the README's `__RUN_STEPS__` marker with the kept targets' commands. */
+export function writeReadmeRunSteps(dir: string, targets: Target[]): void {
+  const readme = join(dir, 'README.md');
+  try {
+    const src = readFileSync(readme, 'utf8');
+    if (src.includes('__RUN_STEPS__')) {
+      writeFileSync(readme, src.replace('__RUN_STEPS__', runStepsMarkdown(targets)));
+    }
+  } catch {
+    // A template without a README (or an unreadable one) is not fatal to the scaffold.
+  }
+}
+
+/** Print the "you're set — here's how to run it" panel (ANSI-colored on a TTY). */
+export function printNextSteps(opts: { name: string; targets: Target[]; installed: boolean }): void {
+  const tty = Boolean(process.stdout.isTTY);
+  const c = (code: string, s: string): string => (tty ? `\x1b[${code}m${s}\x1b[0m` : s);
+  const amber = (s: string): string => c(ACCENT_SGR, s); // matches ACCENT everywhere else
+  const dim = (s: string): string => c('2', s);
+  const bold = (s: string): string => c('1', s);
+
+  const lines: string[] = ['', `${bold(opts.name)} is ready.`, ''];
+  lines.push(`  ${dim(`cd ${opts.name}`)}`);
+  if (!opts.installed) lines.push(`  ${dim('npm install')}`);
+  lines.push('', `  ${c(`${ACCENT_SGR};1`, 'Run it')}`);
+  for (const t of opts.targets) {
+    const step = RUN[t];
+    const note = step.note ? `  ${dim(`(${step.note})`)}` : '';
+    lines.push(`    ${amber(t.padEnd(9))}${step.cmd}${note}`);
+  }
+  lines.push('');
+  lines.push(`  ${dim('First run fetches + digest-verifies the model — no API key.')}`);
+  lines.push(`  ${dim('Add apps:  npx harness.dev install <publisher>/<name>')}`);
+  lines.push('');
+  process.stdout.write(`${lines.join('\n')}\n`);
+}

--- a/packages/harness-cli/src/scaffold/prune-targets.ts
+++ b/packages/harness-cli/src/scaffold/prune-targets.ts
@@ -29,7 +29,7 @@ export type PrunableTarget = Exclude<Target, 'cli'>;
 /** Per-target npm scripts. */
 export const TARGET_SCRIPTS: Record<PrunableTarget, string[]> = {
   desktop: ['dev:desktop', 'build:desktop'],
-  web: ['serve', 'dev:web', 'build:web'],
+  web: ['serve', 'dev:web', 'dev:web:client', 'build:web'],
 };
 /** Per-target runtime deps. */
 export const TARGET_DEPS: Record<PrunableTarget, string[]> = {
@@ -39,7 +39,7 @@ export const TARGET_DEPS: Record<PrunableTarget, string[]> = {
 /** Per-target devDeps. */
 export const TARGET_DEV_DEPS: Record<PrunableTarget, string[]> = {
   desktop: ['electron', 'electron-vite'],
-  web: ['@types/ws'],
+  web: ['@types/ws', 'concurrently'],
 };
 /**
  * Top-level files (besides `targets/<t>/`) that belong ONLY to a target: its

--- a/packages/harness-cli/templates/blank/README.md
+++ b/packages/harness-cli/templates/blank/README.md
@@ -6,10 +6,15 @@ A vertical inference harness. The model lives *inside* the app — no API key, a
 
 ```sh
 npm install
-npm start
 ```
 
-The recommended model is fetched and **digest-verified** into `models/llm/` on first run — no key. (Prefer your own weight? Drop a `.gguf` in `models/llm/`, or point `model.llm.path` in `harness.yml` at one.) `npm start` opens a terminal UI; type a question and watch two agents research it in parallel while a synth combines their notes. For a fast inner loop without a build step, use `npm run dev`.
+Then start a surface — each folds the same harness:
+
+__RUN_STEPS__
+
+The recommended model is fetched and **digest-verified** into `models/llm/` on first run — no key. (Prefer your own weight? Drop a `.gguf` in `models/llm/`, or point `model.llm.path` in `harness.yml` at one.) Type a question and watch two agents research it in parallel while a synth combines their notes.
+
+The **web** surface is two processes — a resident-model **host** and a browser client; `npm run dev:web` starts both (the browser reconnects until the host is up). To run the host on its own (a remote box, or the browser elsewhere), use `npm run serve` + `npm run dev:web:client`. For a fast cli loop without a build step, use `npm run dev`.
 
 ## The shape
 
@@ -19,9 +24,9 @@ harness/
   protocol.ts    the events (↓) and commands (↑) your harness speaks
   state.ts       node-free reduce(events) → AppState (every view folds it)
 targets/
-  cli/
+  <surface>/     one dir per surface — cli · desktop · web
     index.ts     boot: resolve the model, mount a view, run your harness
-    view.tsx     the terminal view (Ink) — swap it, or bring a whole app
+    view.tsx     the view (Ink for cli, React for desktop/web) — or bring a whole app
 models/
   llm/           the resident model (fetched on first run; gitignored)
 harness.yml      targets + model

--- a/packages/harness-cli/templates/blank/package.json
+++ b/packages/harness-cli/templates/blank/package.json
@@ -24,7 +24,8 @@
     "dev:desktop": "tsc && electron-vite dev",
     "build:desktop": "tsc && electron-vite build",
     "serve": "tsc && node bin/serve.js",
-    "dev:web": "vite --config targets/web/vite.web.config.ts",
+    "dev:web": "concurrently -k -n serve,web -c blue,magenta \"npm run serve\" \"vite --config targets/web/vite.web.config.ts\"",
+    "dev:web:client": "vite --config targets/web/vite.web.config.ts",
     "build:web": "vite build --config targets/web/vite.web.config.ts"
   },
   "dependencies": {
@@ -49,6 +50,7 @@
     "@types/react-dom": "^18.3.1",
     "@types/ws": "^8.5.13",
     "@vitejs/plugin-react": "^5.0.0",
+    "concurrently": "^10.0.0",
     "electron": "^42.0.0",
     "electron-vite": "^5.0.0",
     "tsx": "^4.21.0",

--- a/packages/harness-cli/templates/blank/targets/web/web-bridge.ts
+++ b/packages/harness-cli/templates/blank/targets/web/web-bridge.ts
@@ -21,25 +21,54 @@ function resolveWssUrl(): string {
 export function installWebBridge(): void {
   let client: WssClient<Command> | null = null;
   let seq = 0;
+  let active = false; // at least one subscriber wants the stream
+  let retry: ReturnType<typeof setTimeout> | null = null;
   const listeners = new Set<(f: { seq: number; ev: WorkflowEvent }) => void>();
+
+  const clearRetry = (): void => {
+    if (retry !== null) {
+      clearTimeout(retry);
+      retry = null;
+    }
+  };
+
+  // (Re)connect to the host. The browser is a CLIENT — the resident-model host
+  // is `npm run serve`. If it isn't up yet (a fresh `npm run dev:web` boots both
+  // and Vite wins the race, or you start `serve` in another shell after) the
+  // socket closes; retry until it answers, so the view isn't stuck forever.
+  const connect = (): void => {
+    client = connectWss<WorkflowEvent, Command>(resolveWssUrl(), {
+      onEvent: (ev) => {
+        const frame = { seq: ++seq, ev }; // synthesize a monotonic seq the wire doesn't carry
+        for (const l of listeners) l(frame);
+      },
+      onClose: () => {
+        client = null;
+        if (active) {
+          clearRetry();
+          retry = setTimeout(connect, 1000);
+        }
+      },
+    });
+  };
 
   const api = {
     onEvent(cb: (f: { seq: number; ev: WorkflowEvent }) => void): () => void {
       listeners.add(cb);
       // Lazy-connect on first subscription (the view subscribes in its effect).
-      // Synthesize a monotonic seq the wire doesn't carry.
-      client ??= connectWss<WorkflowEvent, Command>(resolveWssUrl(), {
-        onEvent: (ev) => {
-          const frame = { seq: ++seq, ev };
-          for (const l of listeners) l(frame);
-        },
-      });
+      if (!active) {
+        active = true;
+        connect();
+      }
       return () => {
         listeners.delete(cb);
-        // Last listener gone (view unmount / HMR): close the socket so it isn't
-        // leaked, and reset — a later subscription reconnects a fresh session
-        // (which re-seeds from initialState @ 0, matching requestSnapshot).
+        // Last listener gone (view unmount / HMR): stop retrying, close the
+        // socket so it isn't leaked, and reset — a later subscription reconnects
+        // a fresh session (which re-seeds from initialState @ 0, matching
+        // requestSnapshot).
         if (listeners.size === 0) {
+          active = false;
+          clearRetry();
           client?.close();
           client = null;
           seq = 0;

--- a/packages/harness-cli/test/new-wizard.test.ts
+++ b/packages/harness-cli/test/new-wizard.test.ts
@@ -18,7 +18,7 @@ describe('new wizard — render', () => {
   it('mounts and renders the name prompt first (no crash)', () => {
     const { lastFrame } = render(createElement(Wizard, { onDone: () => {} }));
     expect(lastFrame()).toContain('Scaffold a new harness');
-    expect(lastFrame()).toContain('Harness name:');
+    expect(lastFrame()).toContain('Harness name');
   });
 });
 


### PR DESCRIPTION
The `new` flow dead-ended: low-contrast prompts, a raw-regex error, no install, and only `npm start` in the closing text — so a web/desktop user was left guessing (`npm run web:dev` → not found; `npm run dev:web` → `vite: command not found`, because nothing was installed).

### Wizard
- A branded boot banner — the **`[LL]` block mark** (teal→indigo→fuchsia gradient + dithered drop-shadow) + wordmark + version.
- One-line question headers, a `❯` prompt, and **human errors that clear as you type** (no raw regex; empty vs invalid distinguished).
- A shared **palette** (`palette.ts`): amber for labels/prompts/spinner, cyan reserved for **live selection only**, green for success — fixes the low-contrast focus + the blue spinner and pulls teal out of the chrome.

### After scaffold
- Run **`npm install` behind a spinner**, then print a per-target **"Run it" panel** with the exact commands. TTY-gated (CI/non-TTY skip); `--skip-install` to opt out.
- The scaffolded **README is now target-aware** — documents only the surfaces you kept (was cli-only, so a web scaffold never told you how to run web).

### Web target
- **`npm run dev:web` boots the host + Vite together** (via `concurrently`) — web is one command. `serve` + `dev:web:client` stay as the primitives for a remote host.
- The browser bridge **reconnects** until the host answers, so it no longer hangs at "booting" when the host starts after the page (or loses the race).

### Verified
Build clean · **103/103** · default `cli·desktop·web` scaffold **typechecks clean** · install spinner + panel + wss reconnect all exercised on a real scaffold.

Note: a **pre-existing** coupling (unchanged here) — a `web`-without-`desktop` scaffold has a broken browser build because the shared React view lives in `targets/desktop/`. Tracked as a follow-up (needs a shared-view relocation); the default all-3 scaffold is unaffected.

Ship: tag `v0.6.5-cli` on merge → `release.yml` publishes.