### PR TITLE
fix(harness-cli): 0.6.6 — amber install spinner glyph, plain label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.6.5",
+      "version": "0.6.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "bin/run.js"

--- a/packages/harness-cli/src/scaffold/post-scaffold.tsx
+++ b/packages/harness-cli/src/scaffold/post-scaffold.tsx
@@ -10,7 +10,7 @@ import { Spinner, ThemeProvider } from '@inkjs/ui';
 import { spawn } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { cliTheme, ACCENT, ACCENT_SGR } from './palette.js';
+import { cliTheme, ACCENT_SGR } from './palette.js';
 import type { Target } from './prune-targets.js';
 
 const NPM = process.platform === 'win32' ? 'npm.cmd' : 'npm';
@@ -47,7 +47,7 @@ function InstallScreen({ dir, onDone }: { dir: string; onDone: (ok: boolean) => 
     return (
       <Box gap={1}>
         <Spinner />
-        <Text color={ACCENT}>
+        <Text>
           Installing dependencies <Text dimColor>— vite · ink · electron, ~a minute</Text>
         </Text>
       </Box>
@@ -72,7 +72,11 @@ function InstallScreen({ dir, onDone }: { dir: string; onDone: (ok: boolean) => 
 export function runInstall(dir: string): Promise<boolean> {
   return new Promise((resolve) => {
     let ok = false;
-    const { waitUntilExit } = render(<InstallScreen dir={dir} onDone={(v) => (ok = v)} />);
+    const { waitUntilExit } = render(
+      <ThemeProvider theme={cliTheme}>
+        <InstallScreen dir={dir} onDone={(v) => (ok = v)} />
+      </ThemeProvider>,
+    );
     void waitUntilExit().then(() => resolve(ok));
   });
 }


### PR DESCRIPTION
The install spinner was backwards: `runInstall` never wrapped `InstallScreen` in the ThemeProvider, so the spinner **glyph** fell back to `@inkjs/ui`'s default **blue**, while the **"Installing" text** was explicitly colored amber. Now the glyph is amber (via `cliTheme`) and the label is plain — the accent is on the spinner, not the words.

One-line-ish visual fix on top of 0.6.5. Build clean · 103/103.

Ship: tag `v0.6.6-cli` on merge → `release.yml` publishes.