### PR TITLE
feat(blank): 0.6.7 — atomic tool rows, side-by-side agents, real token count

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.6.6",
+      "version": "0.6.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.6.6",
+  "version": "0.6.7",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "bin/run.js"

--- a/packages/harness-cli/templates/blank/harness/state.ts
+++ b/packages/harness-cli/templates/blank/harness/state.ts
@@ -32,15 +32,30 @@ export function formatSize(bytes: number): string {
 
 export type AgentStatus = "active" | "tool" | "done" | "failed";
 
+/** One tool invocation, paired with its result — the atomic unit the view
+ *  renders as a chip (a call in flight has `result: null`). Built from the
+ *  structured `agent:tool_call` / `agent:tool_result` events, NOT by parsing the
+ *  model's `<tool_call>` XML out of the stream. `args` is the raw JSON string
+ *  the event carries; `toolArgSummary` formats it for display. */
+export interface ToolStep {
+  tool: string;
+  args: string;
+  result: string | null;
+}
+
 export interface AgentView {
   id: number;
   parentId: number;
   status: AgentStatus;
-  /** Accumulated streamed text (`agent:produce` deltas). */
+  /** Accumulated streamed text (`agent:produce` deltas). Includes the model's
+   *  `<think>` / `<tool_call>` markup verbatim — `cleanNarration` strips it for
+   *  display (tools render as chips from `tools`, not from this text). */
   body: string;
   tokens: number;
   currentTool: string | null;
   toolCalls: number;
+  /** Tool calls in order, each paired with its result — see `ToolStep`. */
+  tools: ToolStep[];
 }
 
 export interface AppState {
@@ -86,6 +101,7 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
         tokens: 0,
         currentTool: null,
         toolCalls: 0,
+        tools: [],
       });
       // A new query begins — clear the prior answer/error so it doesn't
       // linger while this run produces.
@@ -97,7 +113,9 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
         status: "active",
         currentTool: null,
         body: a.body + ev.text,
-        tokens: a.tokens + ev.tokenCount,
+        // `tokenCount` is the agent's running TOTAL, not a per-delta count —
+        // take the latest, don't sum (summing cumulatives is quadratic).
+        tokens: ev.tokenCount,
       }));
     case "agent:tool_call":
       return patch(s, ev.agentId, (a) => ({
@@ -105,9 +123,16 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
         status: "tool",
         currentTool: ev.tool,
         toolCalls: a.toolCalls + 1,
+        tools: [...a.tools, { tool: ev.tool, args: ev.args, result: null }],
       }));
     case "agent:tool_result":
-      return patch(s, ev.agentId, (a) => ({ ...a, status: "active", currentTool: null }));
+      return patch(s, ev.agentId, (a) => ({
+        ...a,
+        status: "active",
+        currentTool: null,
+        // Fill the most recent in-flight call for this tool with its result.
+        tools: fillResult(a.tools, ev.tool, ev.result),
+      }));
     case "agent:return":
     case "agent:recovered":
       return patch(s, ev.agentId, (a) => ({ ...a, status: "done", body: a.body || ev.result }));
@@ -137,4 +162,62 @@ function patch(
   const agents = new Map(s.agents);
   agents.set(id, fn(cur));
   return { ...s, agents };
+}
+
+/** Fill the last in-flight (`result === null`) call of `tool` with `result`. */
+function fillResult(tools: ToolStep[], tool: string, result: string): ToolStep[] {
+  for (let i = tools.length - 1; i >= 0; i--) {
+    if (tools[i].tool === tool && tools[i].result === null) {
+      const next = tools.slice();
+      next[i] = { ...tools[i], result };
+      return next;
+    }
+  }
+  return tools;
+}
+
+// ── display helpers (pure; the cli + desktop/web views share them) ──
+
+const truncate = (s: string, max: number): string =>
+  s.length > max ? `${s.slice(0, max - 1)}…` : s;
+
+/**
+ * The narration to *show* — the model's prose with its `<tool_call>` blocks and
+ * `<think>` tags stripped. Tool calls render as chips (from `tools`), so their
+ * raw XML is noise here; a trailing unterminated `<tool_call>` (mid-stream) is
+ * dropped too. `<think>` bodies are kept (they're the reasoning) minus the tags.
+ */
+export function cleanNarration(body: string): string {
+  return body
+    .replace(/<tool_call>[\s\S]*?<\/tool_call>/g, "")
+    .replace(/<tool_call>[\s\S]*$/g, "")
+    .replace(/<\/?think>/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+/** A one-line `key: value · key: value` summary of a tool call's JSON args. */
+export function toolArgSummary(args: string): string {
+  try {
+    const obj = JSON.parse(args) as Record<string, unknown>;
+    return Object.entries(obj)
+      .map(([k, v]) => `${k}: ${truncate(String(v), 40)}`)
+      .join(" · ");
+  } catch {
+    return truncate(args.trim(), 60);
+  }
+}
+
+/** Compact result meta: "…" while in flight, "N results" for a JSON array,
+ *  else an approximate size — the same idea as Artifact's row meta. */
+export function resultMeta(result: string | null): string {
+  if (result === null) return "…";
+  try {
+    const parsed = JSON.parse(result) as unknown;
+    if (Array.isArray(parsed)) return `${parsed.length} result${parsed.length === 1 ? "" : "s"}`;
+  } catch {
+    // not JSON — fall through to a size estimate
+  }
+  const kb = result.length / 1000;
+  return kb >= 1 ? `${kb.toFixed(1)} kb` : `${result.length} chars`;
 }

--- a/packages/harness-cli/templates/blank/targets/cli/view.tsx
+++ b/packages/harness-cli/templates/blank/targets/cli/view.tsx
@@ -13,8 +13,15 @@ import React, { useEffect, useReducer } from "react";
 import { Box, Text, render, useApp, useInput } from "ink";
 import { TextInput } from "@inkjs/ui";
 import type { EventBus } from "@lloyal-labs/binding";
-import { initialState, reduce, formatSize } from "../../harness/state.js";
-import type { AgentView, AppState } from "../../harness/state.js";
+import {
+  initialState,
+  reduce,
+  formatSize,
+  cleanNarration,
+  toolArgSummary,
+  resultMeta,
+} from "../../harness/state.js";
+import type { AgentView, AppState, ToolStep } from "../../harness/state.js";
 import type { Command, WorkflowEvent } from "../../harness/protocol.js";
 
 const seed = (bootstrap: WorkflowEvent[]): AppState =>
@@ -22,6 +29,44 @@ const seed = (bootstrap: WorkflowEvent[]): AppState =>
 
 const glyph = (s: AgentView["status"]): string =>
   s === "active" ? "●" : s === "tool" ? "◍" : s === "done" ? "✓" : "✗";
+
+const statusColor = (s: AgentView["status"]): string =>
+  s === "active" ? "yellow" : s === "tool" ? "cyan" : s === "done" ? "green" : "red";
+
+/** One tool invocation as an atomic chip: `⚒ tool · args → result-meta`. */
+function ToolChip({ step }: { step: ToolStep }): React.ReactElement {
+  const args = toolArgSummary(step.args);
+  return (
+    <Text wrap="truncate-end">
+      <Text color="magenta">⚒ {step.tool}</Text>
+      {args ? <Text dimColor>{`  ${args}`}</Text> : null}
+      <Text color={step.result === null ? "gray" : "green"}>{`  → ${resultMeta(step.result)}`}</Text>
+    </Text>
+  );
+}
+
+/** One agent, as a fixed-width column: header · recent tool chips · a short
+ *  narration preview (the last line of the model's prose, XML stripped). */
+function AgentColumn({ a, width }: { a: AgentView; width: number }): React.ReactElement {
+  const preview = cleanNarration(a.body).split("\n").filter(Boolean).slice(-1)[0] ?? "";
+  return (
+    <Box flexDirection="column" width={width} marginRight={2}>
+      <Text wrap="truncate-end">
+        <Text color={statusColor(a.status)}>{glyph(a.status)}</Text>
+        {` agent ${a.id}`}
+        <Text dimColor>{` · ${a.tokens} tok`}</Text>
+      </Text>
+      {a.tools.slice(-4).map((t, i) => (
+        <ToolChip key={i} step={t} />
+      ))}
+      {preview ? (
+        <Text dimColor wrap="truncate-end">
+          {preview}
+        </Text>
+      ) : null}
+    </Box>
+  );
+}
 
 function Gauge({ used, total }: { used: number; total: number }): React.ReactElement | null {
   if (!total) return null;
@@ -59,13 +104,10 @@ function View({
 
   const working = state.phase === "working";
   const agents = [...state.agents.values()];
-  const streaming =
-    state.answer ||
-    agents
-      .filter((a) => a.status !== "failed")
-      .map((a) => a.body)
-      .join("")
-      .trim();
+  // Lay parallel agents side by side — one column each, sized to the terminal
+  // (falls back to 80 cols when stdout isn't a TTY, e.g. the desktop fork).
+  const cols = process.stdout.columns ?? 80;
+  const colWidth = Math.max(30, Math.min(56, Math.floor((cols - 2) / Math.max(1, agents.length)) - 2));
 
   return (
     <Box flexDirection="column" gap={1}>
@@ -87,17 +129,16 @@ function View({
 
       {agents.length > 0 && (
         <Box flexDirection="column">
-          {agents.map((a) => (
-            <Text key={a.id}>
-              {glyph(a.status)} agent {a.id}
-              {a.currentTool ? ` · ${a.currentTool}` : ""} · {a.tokens} tok
-            </Text>
-          ))}
+          <Box flexWrap="wrap">
+            {agents.map((a) => (
+              <AgentColumn key={a.id} a={a} width={colWidth} />
+            ))}
+          </Box>
           <Gauge used={state.kv.used} total={state.kv.total} />
         </Box>
       )}
 
-      {streaming && <Text color="cyan">{streaming}</Text>}
+      {state.answer && <Text color="cyan">{state.answer}</Text>}
       {state.error && <Text color="red">error: {state.error}</Text>}
 
       {!working && (

--- a/packages/harness-cli/templates/blank/targets/desktop/App.tsx
+++ b/packages/harness-cli/templates/blank/targets/desktop/App.tsx
@@ -10,7 +10,16 @@
  * is the floor — grow it into your product's UI (or bring your own app).
  */
 import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { reduce, initialState, formatSize, type AppState, type AgentView } from "../../harness/state.js";
+import {
+  reduce,
+  initialState,
+  formatSize,
+  cleanNarration,
+  toolArgSummary,
+  resultMeta,
+  type AppState,
+  type AgentView,
+} from "../../harness/state.js";
 import type { WorkflowEvent, Command } from "../../harness/protocol.js";
 
 declare global {
@@ -91,14 +100,34 @@ export function HarnessApp() {
           : ` · ${state.phase}`}
         {state.kv.total > 0 && ` · kv ${Math.round((100 * state.kv.used) / state.kv.total)}%`}
       </div>
-      {agents.map((a) => (
-        <div key={a.id} style={{ ...S.agent, opacity: a.status === "done" ? 0.65 : 1 }}>
-          <div style={S.meta}>
-            agent {a.id} · {a.currentTool ? `⚙ ${a.currentTool}` : a.status} · {a.tokens} tok
-          </div>
-          <div style={S.body}>{a.body}</div>
-        </div>
-      ))}
+      <div style={S.agentRow}>
+        {agents.map((a) => {
+          const narration = cleanNarration(a.body);
+          return (
+            <div key={a.id} style={{ ...S.agent, opacity: a.status === "done" ? 0.72 : 1 }}>
+              <div style={S.meta}>
+                agent {a.id} · {a.status} · {a.tokens.toLocaleString()} tok
+              </div>
+              {/* Atomic tool rows — one per call, paired with its result. Built
+                  from the structured tool events, not by parsing the stream. */}
+              {a.tools.map((t, i) => {
+                const args = toolArgSummary(t.args);
+                return (
+                  <div key={i} style={S.tool}>
+                    <span style={S.toolName}>⚒ {t.tool}</span>
+                    {args && <span style={S.toolArgs}> {args}</span>}
+                    <span style={{ ...S.toolMeta, color: t.result === null ? "#8a90a0" : "#7ee0a6" }}>
+                      {" → "}
+                      {resultMeta(t.result)}
+                    </span>
+                  </div>
+                );
+              })}
+              {narration && <div style={S.body}>{narration}</div>}
+            </div>
+          );
+        })}
+      </div>
       {state.answer && <div style={S.answer}>{state.answer}</div>}
       {state.error && <div style={S.error}>{state.error}</div>}
       <div style={S.composer}>
@@ -120,11 +149,17 @@ export function HarnessApp() {
 }
 
 const S: Record<string, CSSProperties> = {
-  page: { font: "14px/1.55 ui-sans-serif, system-ui, sans-serif", color: "#e6e9ef", padding: 20, maxWidth: 820, margin: "0 auto" },
+  page: { font: "14px/1.55 ui-sans-serif, system-ui, sans-serif", color: "#e6e9ef", padding: 20, maxWidth: 1100, margin: "0 auto" },
   head: { opacity: 0.55, fontSize: 12, marginBottom: 14, letterSpacing: 0.3 },
-  agent: { borderLeft: "2px solid #2b3140", paddingLeft: 12, margin: "10px 0" },
-  meta: { fontSize: 12, opacity: 0.55 },
-  body: { whiteSpace: "pre-wrap" },
+  // Parallel agents side by side; each card wraps to the next row when narrow.
+  agentRow: { display: "flex", flexWrap: "wrap", gap: 14, alignItems: "flex-start" },
+  agent: { flex: "1 1 320px", minWidth: 280, maxWidth: 520, borderLeft: "2px solid #2b3140", paddingLeft: 12 },
+  meta: { fontSize: 12, opacity: 0.55, marginBottom: 6 },
+  tool: { fontSize: 13, margin: "3px 0", whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" },
+  toolName: { color: "#c9a2ff", fontWeight: 600 },
+  toolArgs: { opacity: 0.6 },
+  toolMeta: {},
+  body: { whiteSpace: "pre-wrap", maxHeight: 220, overflowY: "auto", opacity: 0.8, marginTop: 6 },
   answer: { marginTop: 16, whiteSpace: "pre-wrap", lineHeight: 1.6 },
   error: { marginTop: 16, color: "#ff7a7a" },
   composer: { display: "flex", gap: 8, marginTop: 22 },


### PR DESCRIPTION
The blank template's austere view dumped each agent's raw stream — the model's `<think>` / `<tool_call>` grammar XML — **stacked vertically**, with a runaway token count (**1.3M** for a 32K-context agent).

### Token count
`agent:produce.tokenCount` is the agent's **running total**, not a per-delta count. The reduce did `tokens: a.tokens + ev.tokenCount` — summing cumulatives (1+2+…+n ≈ n²/2 → ~1.3M). Now `tokens: ev.tokenCount` (take the latest).

### Atomic tool rows (Artifact's approach)
Add a structured `tools: ToolStep[]` to `AgentView`, built from the **structured** `agent:tool_call { tool, args }` / `agent:tool_result { tool, result }` events — **not by parsing the model's XML**. Each call is paired with its result and renders as one chip:

```
⚒ wikipedia_search · query: "eczema infants" · limit: 10  → 3 results
```

`cleanNarration` strips the residual `<tool_call>` blocks + `<think>` tags from the shown prose (tools are chips now).

### Side-by-side agents
- **cli**: parallel agents laid out in terminal-sized columns (was a vertical stack).
- **desktop/web** (shared `App.tsx`): agent cards wrap in a flex row; tool rows + a capped, scrollable body.

Pure helpers (`cleanNarration` / `toolArgSummary` / `resultMeta`) live in the node-free `state.ts`, shared by all three views.

### Verified
Default `cli·desktop·web` scaffold **typechecks clean** (3 tsconfigs); reduce logic asserted on a scaffold — **tokens 12 not 17**, tool `→ 3 results` paired, XML stripped. harness-cli suite 103/103.

Ship: tag `v0.6.7-cli` on merge.