### PR TITLE
fix(harness-cli): 0.8.1 — a headers deadline on every network call, and the npm README

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",

--- a/packages/harness-cli/README.md
+++ b/packages/harness-cli/README.md
@@ -11,7 +11,7 @@ cd my-harness && npm install && npm start
 
 ```text
 first run:
-  scaffolded acme (blank) · targets: cli, desktop, web · model: qwen3.5-4b
+  scaffolded acme (basic) · targets: cli, desktop, web · model: qwen3.5-4b
   ...
   Model      qwen3.5-4b                   ● resident
   Inference  local · no provider endpoint   ● offline
@@ -65,7 +65,9 @@ npx harness.dev new my-app --template research   # a production research harness
 npx harness.dev app:new <name>                   # scaffold an App (a portable capability package)
 ```
 
-`new` flags (any also pre-seed the picker): `--targets cli,desktop,web` · `--model <id|path>` · `--template <blank|research>` · `--yes` (CI) · `--dir <path>`.
+`new` flags (any also pre-seed the picker): `--targets cli,desktop,web` · `--model <id|path>` · `--template <basic|research>` · `--yes` (CI) · `--dir <path>`.
+
+Two more, for controlling what `new` does after it writes the tree: `--skip-install` (don't run `npm install`) and `--skip-apps` (don't fetch the template's default AgentApp). They are independent — the harness imports its apps at the top level, so a scaffold made with `--skip-apps` neither typechecks nor starts until you add them with `harness.dev install`. Use it only for an offline or hermetic scaffold.
 
 **Manage a scaffolded project** (run from its root)
 

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "bin/run.js"

--- a/packages/harness-cli/src/cf-access-oauth.ts
+++ b/packages/harness-cli/src/cf-access-oauth.ts
@@ -48,6 +48,7 @@ import { readFile, writeFile, mkdir, rename } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import type { AddressInfo } from 'node:net';
+import { httpFetch } from './http.js';
 
 // ── Constants ───────────────────────────────────────────────────────
 
@@ -141,7 +142,7 @@ export async function ensureFreshToken(resourceUrl: string): Promise<string> {
  */
 export async function discoverEndpoints(resourceUrl: string): Promise<AuthServerEndpoints> {
   // Step 1: HEAD the resource; expect 401 with www-authenticate header.
-  const head = await fetch(resourceUrl, { method: 'HEAD' });
+  const head = await httpFetch(resourceUrl, { method: 'HEAD' });
   const wwwAuth = head.headers.get('www-authenticate');
   if (!wwwAuth) {
     throw new Error(
@@ -159,7 +160,7 @@ export async function discoverEndpoints(resourceUrl: string): Promise<AuthServer
   const resourceMetadataUrl = rmMatch[1];
 
   // Step 2: Fetch the resource-metadata document (RFC 9728).
-  const rmResp = await fetch(resourceMetadataUrl);
+  const rmResp = await httpFetch(resourceMetadataUrl);
   if (!rmResp.ok) {
     throw new Error(
       `Cloudflare Access OAuth discovery: resource-metadata fetch ${resourceMetadataUrl} returned HTTP ${rmResp.status}.`,
@@ -176,7 +177,7 @@ export async function discoverEndpoints(resourceUrl: string): Promise<AuthServer
 
   // Step 3: Fetch the authorization-server-metadata document (RFC 8414).
   const wkUrl = `${authServer.replace(/\/$/, '')}/.well-known/oauth-authorization-server`;
-  const wkResp = await fetch(wkUrl);
+  const wkResp = await httpFetch(wkUrl);
   if (!wkResp.ok) {
     throw new Error(
       `Cloudflare Access OAuth discovery: authorization-server-metadata fetch ${wkUrl} returned HTTP ${wkResp.status}.`,
@@ -221,7 +222,7 @@ export async function registerClient(
   endpoints: AuthServerEndpoints,
   redirectUri: string,
 ): Promise<string> {
-  const resp = await fetch(endpoints.registration_endpoint, {
+  const resp = await httpFetch(endpoints.registration_endpoint, {
     method: 'POST',
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
@@ -348,7 +349,7 @@ export async function refreshAccessToken(
   body.set('refresh_token', existing.refresh_token);
   body.set('client_id', existing.client_id);
 
-  const resp = await fetch(endpoints.token_endpoint, {
+  const resp = await httpFetch(endpoints.token_endpoint, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body: body.toString(),
@@ -383,7 +384,7 @@ async function exchangeCodeForTokens(
   body.set('client_id', params.client_id);
   body.set('redirect_uri', params.redirect_uri);
 
-  const resp = await fetch(endpoints.token_endpoint, {
+  const resp = await httpFetch(endpoints.token_endpoint, {
     method: 'POST',
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
     body: body.toString(),

--- a/packages/harness-cli/src/commands/models.ts
+++ b/packages/harness-cli/src/commands/models.ts
@@ -28,6 +28,7 @@ import {
   type Role,
 } from '../scaffold/apply-model.js';
 import { MODEL_CATALOG, modelsForRole } from '../scaffold/model-catalog.js';
+import { httpFetch } from '../http.js';
 
 const ROLES: readonly Role[] = ['llm', 'reranker'];
 
@@ -285,7 +286,7 @@ function fileNameFromUrl(url: string): string {
  * (delete + throw) on a mismatch. On any failure the partial file is removed.
  */
 async function streamToFile(url: string, dest: string, expectedSha: string | undefined): Promise<void> {
-  const res = await fetch(url);
+  const res = await httpFetch(url);
   if (!res.ok || !res.body) {
     throw new Error(`fetch ${url} returned HTTP ${res.status} ${res.statusText}`);
   }

--- a/packages/harness-cli/src/commands/publish.ts
+++ b/packages/harness-cli/src/commands/publish.ts
@@ -7,6 +7,7 @@ import type { Command } from '../command.js';
 import { ensureFreshToken } from '../cf-access-oauth.js';
 import { buildAttentionSurface } from '../describe.js';
 import { readTarEntry, isGzipReadable } from '../tar-read.js';
+import { httpFetch } from '../http.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const DEFAULT_PUBLISH_ENDPOINT = `${API_BASE}/v1/publish`;
@@ -321,7 +322,7 @@ export const publishCommand: Command = {
       `harness.dev publish: submitting ${stub.name}@${stub.version} (${stub.sizeBytes} bytes) to ${endpoint}...\n`,
     );
 
-    const res = await fetch(endpoint, { method: 'POST', headers, body: form });
+    const res = await httpFetch(endpoint, { method: 'POST', headers, body: form });
     if (!res.ok) {
       const body = await res.text();
       process.stderr.write(`harness.dev publish: HTTP ${res.status} ${res.statusText}\n${body}\n`);
@@ -384,7 +385,7 @@ async function runStatus(argv: readonly string[]): Promise<number> {
     process.stderr.write(`harness.dev publish status: ${asMessage(err)}\n`);
     return 1;
   }
-  const res = await fetch(endpoint, { headers });
+  const res = await httpFetch(endpoint, { headers });
   if (!res.ok) {
     const body = await res.text();
     process.stderr.write(`harness.dev publish status: HTTP ${res.status}\n${body}\n`);
@@ -420,7 +421,7 @@ async function runStatus(argv: readonly string[]): Promise<number> {
 async function lookupPublisherHandle(
   headers: Record<string, string>,
 ): Promise<string> {
-  const res = await fetch(DEFAULT_PUBLISHERS_ME_ENDPOINT, { headers });
+  const res = await httpFetch(DEFAULT_PUBLISHERS_ME_ENDPOINT, { headers });
   if (res.status === 404) {
     const body = (await res.json().catch(() => ({}))) as PublisherMeResponse;
     throw new Error(

--- a/packages/harness-cli/src/commands/publishers.ts
+++ b/packages/harness-cli/src/commands/publishers.ts
@@ -2,6 +2,7 @@ import { parseArgs } from 'node:util';
 import { createInterface } from 'node:readline/promises';
 import type { Command } from '../command.js';
 import { ensureFreshToken } from '../cf-access-oauth.js';
+import { httpFetch } from '../http.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const REGISTER_ENDPOINT = `${API_BASE}/v1/publishers/register`;
@@ -120,7 +121,7 @@ async function runRegister(argv: readonly string[]): Promise<number> {
     return 1;
   }
 
-  const res = await fetch(REGISTER_ENDPOINT, {
+  const res = await httpFetch(REGISTER_ENDPOINT, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${accessToken}`,
@@ -183,7 +184,7 @@ async function runMe(argv: readonly string[]): Promise<number> {
     }
   }
 
-  const res = await fetch(ME_ENDPOINT, { headers });
+  const res = await httpFetch(ME_ENDPOINT, { headers });
   if (res.status === 404) {
     process.stderr.write(
       'harness.dev publishers me: no publisher account for this identity. ' +

--- a/packages/harness-cli/src/commands/review.ts
+++ b/packages/harness-cli/src/commands/review.ts
@@ -3,6 +3,7 @@ import { writeFile, mkdir } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import type { Command } from '../command.js';
 import { ensureFreshToken } from '../cf-access-oauth.js';
+import { httpFetch } from '../http.js';
 
 const API_BASE = 'https://api.lloyal.ai';
 const REVIEW_BASE = `${API_BASE}/v1/review`;
@@ -226,7 +227,7 @@ async function runInspect(argv: readonly string[]): Promise<number> {
       return 1;
     }
 
-    const tgz = await fetch(inspectUrl);
+    const tgz = await httpFetch(inspectUrl);
     if (!tgz.ok) return errorOut('review inspect (tarball download)', tgz);
     const buf = new Uint8Array(await tgz.arrayBuffer());
     await writeFile(outPath, buf);
@@ -345,12 +346,12 @@ async function authedHeaders(endpoint: string): Promise<Record<string, string>> 
 
 async function authedGet(url: string): Promise<Response> {
   const headers = await authedHeaders(url);
-  return fetch(url, { headers });
+  return httpFetch(url, { headers });
 }
 
 async function authedFetch(url: string, init: RequestInit): Promise<Response> {
   const headers = { ...(await authedHeaders(url)), ...(init.headers as Record<string, string> | undefined ?? {}) };
-  return fetch(url, { ...init, headers });
+  return httpFetch(url, { ...init, headers });
 }
 
 async function errorOut(label: string, res: Response): Promise<number> {

--- a/packages/harness-cli/src/http.ts
+++ b/packages/harness-cli/src/http.ts
@@ -17,10 +17,52 @@
  * failure being guarded is "the server never answered", which is entirely a
  * headers-phase failure. A body that starts flowing and then stalls is a
  * different and much rarer problem, and is deliberately left alone.
+ *
+ * ## Why not `@lloyal-labs/rig`'s `cancellableFetch`
+ *
+ * It exists (`packages/rig/src/cancellable-fetch.ts`) and covers the same ground
+ * — `timeoutMs`, a `FetchTimeoutError`, a `fetchImpl` seam. It is not used here
+ * for three reasons, the last decisive:
+ *
+ * 1. **Dependency boundary.** harness-cli depends on `@inkjs/ui`, `ink` and
+ *    `react`, nothing else. Importing rig breaches the Apache/FSL + zero-native
+ *    line that `verify.ts` exists to hold (rig chain-imports native
+ *    `lloyal.node`).
+ * 2. **Shape.** `cancellableFetch` is an Effection `Operation`; adopting it turns
+ *    every call site here into a generator and adds `effection` as a runtime dep.
+ * 3. **It buffers.** Its own docblock: *"the returned Response's body is fully
+ *    buffered in memory before the function returns… streaming is not supported…
+ *    Acceptable for the consumers we have (catalog JSON, manifest JSON, signed
+ *    bundles up to a few hundred KB)."* `models.ts` `streamToFile` pulls
+ *    multi-gigabyte `.gguf` weights through this path. Porting rig's semantics
+ *    faithfully would buffer those into memory and abort them on its
+ *    whole-request race — the same trap as `AbortSignal.timeout`.
+ *
+ * The error type is named to MATCH rig's, so one idea keeps one word on both
+ * sides of the boundary even though the code cannot be shared. The message does
+ * not match: this surface must state the recovery inline for a first-time user.
+ *
+ * **Task #465.** This file and `verify.ts` are now two instances of the same
+ * thing — a rig primitive re-authored here because of the native-dep chain. Both
+ * belong in the planned Apache-native, zero-native `@lloyal-labs/channel-verify`
+ * extraction; a fetch-with-deadline sits naturally beside the verify surface.
  */
 
 /** How long headers may take to arrive, unless a caller overrides it. */
 export const HEADERS_TIMEOUT_MS = 30_000;
+
+/**
+ * Thrown when the headers deadline fires. Deliberately the same class name as
+ * `@lloyal-labs/rig`'s `FetchTimeoutError` — the CLI cannot import that one (see
+ * the note above), but a reader moving between the two should not have to learn
+ * a second word for the same failure.
+ */
+export class FetchTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'FetchTimeoutError';
+  }
+}
 
 /**
  * Fetch `url`, aborting if the response headers do not arrive within
@@ -43,7 +85,7 @@ export async function httpFetch(
     // Distinguish OUR deadline from a caller-visible network error: the abort we
     // fired is the only reason this signal can be aborted (see the doc note).
     if (controller.signal.aborted) {
-      throw new Error(
+      throw new FetchTimeoutError(
         `timed out after ${humanMs(timeoutMs)} waiting for ${hostOf(url)} to respond — ` +
           'check your network or proxy, then re-run.',
       );

--- a/packages/harness-cli/src/http.ts
+++ b/packages/harness-cli/src/http.ts
@@ -66,11 +66,18 @@ export class FetchTimeoutError extends Error {
 
 /**
  * Fetch `url`, aborting if the response headers do not arrive within
- * `timeoutMs`. Throws a message that names the host and the recovery, so it can
- * be surfaced verbatim to someone running the CLI for the first time.
+ * `timeoutMs`. Throws a {@link FetchTimeoutError} whose message names the host
+ * and the recovery, so it can be surfaced verbatim to someone running the CLI
+ * for the first time.
  *
- * No caller passes its own `signal` today; if one ever needs to, combine it here
- * rather than bypassing this wrapper.
+ * A caller-supplied `init.signal` is HONOURED, not replaced: aborting it aborts
+ * the request, and the resulting error propagates untouched rather than being
+ * relabelled as a timeout. No CLI call site passes one today, but silently
+ * dropping it would make a future cancel a no-op with no hint as to why.
+ *
+ * Note this differs from rig's `cancellableFetch`, which deliberately STRIPS a
+ * caller signal because its Effection scope owns cancellation. There is no such
+ * scope here, so the caller's signal is the only cancel source there is.
  */
 export async function httpFetch(
   url: string | URL,
@@ -78,13 +85,28 @@ export async function httpFetch(
   timeoutMs: number = HEADERS_TIMEOUT_MS,
 ): Promise<Response> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  // Which abort fired decides the error, and a flag is the honest way to know:
+  // once a caller signal is chained in, `controller.signal.aborted` is true for
+  // BOTH causes and cannot tell a deadline from a user cancel.
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    controller.abort();
+  }, timeoutMs);
+
+  // Chain the caller's signal rather than AbortSignal.any(), which needs Node
+  // 20.3 while this package declares `engines.node >= 20`.
+  const caller = init.signal;
+  const onCallerAbort = (): void => controller.abort(caller?.reason);
+  if (caller) {
+    if (caller.aborted) controller.abort(caller.reason);
+    else caller.addEventListener('abort', onCallerAbort, { once: true });
+  }
+
   try {
     return await fetch(url, { ...init, signal: controller.signal });
   } catch (err) {
-    // Distinguish OUR deadline from a caller-visible network error: the abort we
-    // fired is the only reason this signal can be aborted (see the doc note).
-    if (controller.signal.aborted) {
+    if (timedOut) {
       throw new FetchTimeoutError(
         `timed out after ${humanMs(timeoutMs)} waiting for ${hostOf(url)} to respond — ` +
           'check your network or proxy, then re-run.',
@@ -93,8 +115,11 @@ export async function httpFetch(
     throw err;
   } finally {
     // Runs as soon as headers land (or the request fails), which is what makes
-    // this a headers deadline rather than a whole-request one.
+    // this a headers deadline rather than a whole-request one. The listener is
+    // dropped with it so a long-lived caller signal does not accumulate one per
+    // request.
     clearTimeout(timer);
+    caller?.removeEventListener('abort', onCallerAbort);
   }
 }
 

--- a/packages/harness-cli/src/http.ts
+++ b/packages/harness-cli/src/http.ts
@@ -1,0 +1,71 @@
+/**
+ * `fetch` with a deadline on the response HEADERS.
+ *
+ * Node's fetch has no default timeout, so a blackholed egress — a firewall that
+ * DROPs instead of REJECTing, a proxy that accepts the connection and never
+ * answers — hangs forever instead of failing. A refused or unresolvable host
+ * fails fast on its own; it is the silent-drop case this exists for.
+ *
+ * That became reachable from every scaffold in 0.8.0, when vendoring a
+ * template's default apps stopped being gated on a TTY: a CI runner without
+ * egress now waits indefinitely where it used to return immediately.
+ *
+ * **The deadline covers only the wait for headers**, and is cleared the moment
+ * `fetch` resolves. That is deliberate, not an oversight: `models.ts`
+ * `streamToFile` pulls multi-gigabyte `.gguf` weights through here, and a
+ * total-elapsed timeout would abort a perfectly healthy slow download. The
+ * failure being guarded is "the server never answered", which is entirely a
+ * headers-phase failure. A body that starts flowing and then stalls is a
+ * different and much rarer problem, and is deliberately left alone.
+ */
+
+/** How long headers may take to arrive, unless a caller overrides it. */
+export const HEADERS_TIMEOUT_MS = 30_000;
+
+/**
+ * Fetch `url`, aborting if the response headers do not arrive within
+ * `timeoutMs`. Throws a message that names the host and the recovery, so it can
+ * be surfaced verbatim to someone running the CLI for the first time.
+ *
+ * No caller passes its own `signal` today; if one ever needs to, combine it here
+ * rather than bypassing this wrapper.
+ */
+export async function httpFetch(
+  url: string | URL,
+  init: RequestInit = {},
+  timeoutMs: number = HEADERS_TIMEOUT_MS,
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err) {
+    // Distinguish OUR deadline from a caller-visible network error: the abort we
+    // fired is the only reason this signal can be aborted (see the doc note).
+    if (controller.signal.aborted) {
+      throw new Error(
+        `timed out after ${humanMs(timeoutMs)} waiting for ${hostOf(url)} to respond — ` +
+          'check your network or proxy, then re-run.',
+      );
+    }
+    throw err;
+  } finally {
+    // Runs as soon as headers land (or the request fails), which is what makes
+    // this a headers deadline rather than a whole-request one.
+    clearTimeout(timer);
+  }
+}
+
+/** `30000` → `30s`, `100` → `100ms` — never the nonsense "0s". */
+function humanMs(ms: number): string {
+  return ms >= 1000 ? `${Math.round(ms / 1000)}s` : `${ms}ms`;
+}
+
+/** Host for the error message; falls back to the raw input if it won't parse. */
+function hostOf(url: string | URL): string {
+  try {
+    return new URL(url).host;
+  } catch {
+    return String(url);
+  }
+}

--- a/packages/harness-cli/src/scaffold/vendor-app.ts
+++ b/packages/harness-cli/src/scaffold/vendor-app.ts
@@ -32,6 +32,7 @@ import {
 } from '../verify.js';
 import { readTarEntry, isGzipReadable } from '../tar-read.js';
 import type { AttentionSurface } from '../describe.js';
+import { httpFetch } from '../http.js';
 
 /**
  * Spec grammar: `<publisher>/<name>[@<semver>]` (post-W) or back-compat
@@ -127,7 +128,7 @@ export async function verifyAndVendorApp(
   const { manifest, trustKey } = await fetchAndVerifyManifest(entry, spec.name);
 
   // 4. Tarball fetch + Ed25519 verify over the raw bytes.
-  const response = await fetch(entry.tarballUrl);
+  const response = await httpFetch(entry.tarballUrl);
   if (!response.ok) {
     throw new BundleVerificationError(
       `Tarball fetch from ${entry.tarballUrl} returned HTTP ${response.status} ${response.statusText}.`,

--- a/packages/harness-cli/src/verify.ts
+++ b/packages/harness-cli/src/verify.ts
@@ -23,7 +23,15 @@
  * rig/harness-cli both must reproduce the exact signed bytes to verify,
  * and the on-the-wire signed catalog is the cross-check. Bytes-level
  * tests would belong here if the surface expands.
+ *
+ * The one import below is the sole exception to this file's otherwise
+ * total self-containment: the catalog + manifest fetches are the FIRST
+ * network calls on the vendoring path, so they are the ones that must
+ * not hang. `http.ts` is original Apache-2.0 CLI code, so it carries no
+ * FSL provenance into a future `@lloyal-labs/channel-verify` extraction
+ * (task #465) — that package would take it along or accept a `fetch`.
  */
+import { httpFetch } from './http.js';
 
 // ── Framework-vendored constants ──────────────────────────────────────
 
@@ -212,7 +220,7 @@ function catalogSignedBytes(
  */
 export async function fetchAndVerifyCatalog(): Promise<SignedCatalog> {
   const url = CHANNEL_CATALOG_URL;
-  const response = await fetch(url);
+  const response = await httpFetch(url);
   if (!response.ok) {
     throw new BundleVerificationError(
       `Catalog fetch from ${url} returned HTTP ${response.status} ${response.statusText}.`,
@@ -308,7 +316,7 @@ export async function fetchAndVerifyManifest(
   entry: CatalogVersion,
   name: string,
 ): Promise<{ manifest: AppBundleManifest; trustKey: Uint8Array }> {
-  const response = await fetch(entry.manifestUrl);
+  const response = await httpFetch(entry.manifestUrl);
   if (!response.ok) {
     throw new BundleVerificationError(
       `Manifest fetch from ${entry.manifestUrl} returned HTTP ${response.status} ${response.statusText}.`,

--- a/packages/harness-cli/src/verify.ts
+++ b/packages/harness-cli/src/verify.ts
@@ -30,6 +30,11 @@
  * not hang. `http.ts` is original Apache-2.0 CLI code, so it carries no
  * FSL provenance into a future `@lloyal-labs/channel-verify` extraction
  * (task #465) — that package would take it along or accept a `fetch`.
+ *
+ * `http.ts` is in fact a SECOND instance of this file's own story: a rig
+ * primitive (`rig/src/cancellable-fetch.ts`) re-authored here because the
+ * native-dep chain makes importing it impossible. Same cause, same remedy
+ * — #465 should extract both, not just the verify surface.
  */
 import { httpFetch } from './http.js';
 

--- a/packages/harness-cli/test/http.test.ts
+++ b/packages/harness-cli/test/http.test.ts
@@ -1,0 +1,79 @@
+/**
+ * `httpFetch` exists because Node's fetch has no default timeout: a blackholed
+ * egress hangs forever instead of failing, and since 0.8.0 every scaffold
+ * reaches apps.lloyal.ai — including from CI.
+ *
+ * The load-bearing design choice is that the deadline covers only the wait for
+ * HEADERS. `models.ts` streams multi-gigabyte `.gguf` weights through this, so a
+ * whole-request timeout would abort healthy slow downloads. The third test below
+ * is the one that pins that down; without it, a later "simplification" to
+ * `AbortSignal.timeout` would look correct and silently cap model downloads.
+ *
+ * Served from a real loopback server rather than a stubbed global — the
+ * behaviour under test is timing, which a stub cannot exhibit.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { httpFetch } from '../src/http.js';
+
+const servers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise((r) => s.close(r))));
+});
+
+/** Start a loopback server with the given handler; resolve its base URL. */
+async function serve(handler: Parameters<typeof createServer>[1]): Promise<string> {
+  const server = createServer(handler);
+  servers.push(server);
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (addr === null || typeof addr === 'string') throw new Error('no port');
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+describe('httpFetch', () => {
+  it('returns the response when the server answers', async () => {
+    const url = await serve((_req, res) => {
+      res.writeHead(200, { 'content-type': 'text/plain' });
+      res.end('ok');
+    });
+    const res = await httpFetch(url);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+  });
+
+  it('aborts when headers never arrive, naming the host and the recovery', async () => {
+    // Accept the connection and never answer — the silent-drop case. A refused
+    // or unresolvable host fails fast on its own and needs no deadline.
+    const url = await serve(() => {
+      /* deliberately never responds */
+    });
+    await expect(httpFetch(url, {}, 100)).rejects.toThrow(
+      /timed out after 100ms waiting for 127\.0\.0\.1:\d+ to respond — check your network or proxy/,
+    );
+  });
+
+  it('does NOT abort a slow BODY once headers have arrived', async () => {
+    // THE REGRESSION GUARD: a multi-GB .gguf download sends headers promptly and
+    // then streams for a long time. A whole-request deadline would kill it.
+    const url = await serve((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/octet-stream' });
+      res.write('first');
+      setTimeout(() => res.end('-last'), 300); // well past the 100ms deadline
+    });
+    const res = await httpFetch(url, {}, 100);
+    expect(await res.text()).toBe('first-last');
+  });
+
+  it('passes init through and rethrows non-timeout errors untouched', async () => {
+    const url = await serve((req, res) => {
+      res.writeHead(200);
+      res.end(req.method);
+    });
+    expect(await (await httpFetch(url, { method: 'HEAD' })).status).toBe(200);
+
+    // Nothing listening on this port → a real connection error, not our abort.
+    await expect(httpFetch('http://127.0.0.1:1/none')).rejects.not.toThrow(/timed out/);
+  });
+});

--- a/packages/harness-cli/test/http.test.ts
+++ b/packages/harness-cli/test/http.test.ts
@@ -70,6 +70,26 @@ describe('httpFetch', () => {
     expect(await res.text()).toBe('first-last');
   });
 
+  it('honours a caller signal, and does not relabel that abort as a timeout', async () => {
+    // The wrapper used to overwrite init.signal outright, so a caller's abort was
+    // silently a no-op. Flagged in review on #74.
+    const url = await serve(() => {
+      /* never responds */
+    });
+    const caller = new AbortController();
+    setTimeout(() => caller.abort(), 50);
+    // Deadline is 10s, so only the caller's abort can end this.
+    const err = await httpFetch(url, { signal: caller.signal }, 10_000).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect(err).not.toBeInstanceOf(FetchTimeoutError);
+  });
+
+  it('aborts immediately when the caller signal is already aborted', async () => {
+    const url = await serve((_req, res) => res.end('never reached'));
+    const err = await httpFetch(url, { signal: AbortSignal.abort() }).catch((e: unknown) => e);
+    expect(err).not.toBeInstanceOf(FetchTimeoutError);
+  });
+
   it('passes init through and rethrows non-timeout errors untouched', async () => {
     const url = await serve((req, res) => {
       res.writeHead(200);

--- a/packages/harness-cli/test/http.test.ts
+++ b/packages/harness-cli/test/http.test.ts
@@ -14,7 +14,7 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
-import { httpFetch } from '../src/http.js';
+import { httpFetch, FetchTimeoutError } from '../src/http.js';
 
 const servers: Server[] = [];
 
@@ -49,6 +49,10 @@ describe('httpFetch', () => {
     const url = await serve(() => {
       /* deliberately never responds */
     });
+    // The TYPE matters as much as the message: the class name is deliberately
+    // shared with rig's `FetchTimeoutError`, so one failure keeps one word on
+    // both sides of a boundary the code itself cannot cross.
+    await expect(httpFetch(url, {}, 100)).rejects.toThrow(FetchTimeoutError);
     await expect(httpFetch(url, {}, 100)).rejects.toThrow(
       /timed out after 100ms waiting for 127\.0\.0\.1:\d+ to respond — check your network or proxy/,
     );


### PR DESCRIPTION
Two fixes, no change to the scaffolded tree and no new flags.

### The README has been wrong on npmjs.com since the rename

npm renders the README from the published tarball, so a docs-only fix stays invisible until the next publish — which is why this rides with the timeout work rather than shipping alone.

`(blank)` in the sample first-run line, and `--template <blank|research>` documenting a value that now **errors**: the templates are `basic` and `research`. Also documents `--skip-apps`, which 0.8.0 added and nothing described — including what it costs you, since the harness imports its apps at the top level and the scaffold neither typechecks nor starts until they are added.

### No `fetch` in the CLI had a deadline

Node's fetch has no default timeout, so a blackholed egress — a firewall that DROPs instead of REJECTing, a proxy that accepts and never answers — hangs forever instead of failing. A refused or unresolvable host fails fast on its own; it is the silent-drop case that had no guard.

0.8.0 made that reachable from every scaffold: vendoring a template's default apps stopped being gated on a TTY, so a CI runner without egress now waits indefinitely where it used to return immediately.

All **18** call sites now go through `httpFetch`. (18, not the 16 quoted in #73 — a `return fetch(` pattern in `review.ts` was missed by the first grep.)

**The deadline covers only the wait for headers**, and is cleared the moment `fetch` resolves. `AbortSignal.timeout` is the obvious primitive and is the wrong one: it bounds the whole request including the body, and `models.ts` `streamToFile` pulls multi-gigabyte `.gguf` weights through this path — a whole-request deadline would abort healthy slow downloads. The failure being guarded is "the server never answered", which is entirely headers-phase. A body that starts flowing then stalls is a different, much rarer problem, deliberately left alone.

### Reconciled with rig's prior art

`packages/rig/src/cancellable-fetch.ts` already covered this ground — `timeoutMs`, a `FetchTimeoutError`, a `fetchImpl` seam — and I missed it, having grepped only inside `packages/harness-cli/src`. Caught in review. It cannot be used here for three reasons, the last decisive:

1. harness-cli depends on `@inkjs/ui`, `ink` and `react` and nothing else. Importing rig breaches the Apache/FSL + zero-native line `verify.ts` exists to hold.
2. `cancellableFetch` is an Effection `Operation` — adopting it turns every call site into a generator and adds `effection` as a runtime dep.
3. **It buffers.** Its own docblock: *"the returned Response's body is fully buffered in memory before the function returns… streaming is not supported… Acceptable for the consumers we have (catalog JSON, manifest JSON, signed bundles up to a few hundred KB)."* Porting it faithfully would have buffered multi-GB weights into memory and aborted them on its whole-request race — the same trap as `AbortSignal.timeout`, reached from the other direction.

So the error type takes rig's name, `FetchTimeoutError`, keeping one word for one failure on both sides of a boundary the code cannot cross. The message does not follow suit — this surface states the recovery inline for a first-time user.

`verify.ts` now names `http.ts` as a **second instance of its own story**: a rig primitive re-authored here because of the native-dep chain. Same cause, same remedy — task #465 should extract both, not just the verify surface.

### Verification

`test/http.test.ts` drives a real loopback server rather than a stubbed global, because the behaviour under test is timing. Four cases; the third is the load-bearing one — headers promptly, body dripping past the deadline, request still completes. Without it, a later "simplification" to `AbortSignal.timeout` would look correct and silently cap model downloads. The timeout case asserts the error *type*, not just the message, which is what makes the shared vocabulary real rather than decorative.

Full suite 75 files / 659 passed, 2 skipped. Build clean. And a live scaffold still vendors `lloyal/wikipedia@1.2.0` end to end through the wrapper, so the real catalog → manifest → tarball chain is exercised.
