### PR TITLE
fix(harness-cli): declare the Node floor, and state the hardware floor where the model is chosen

### DIFF
--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -28,7 +28,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=24"
   },
   "scripts": {
     "build": "tsc -b",

--- a/packages/harness-cli/src/commands/new-wizard.tsx
+++ b/packages/harness-cli/src/commands/new-wizard.tsx
@@ -18,7 +18,7 @@ import { createRequire } from 'node:module';
 import { useRef, useState, type ReactElement } from 'react';
 import { Box, Text, render, useApp, useInput } from 'ink';
 import { TextInput, Select, MultiSelect, ThemeProvider } from '@inkjs/ui';
-import { modelsForRole } from '../scaffold/model-catalog.js';
+import { modelsForRole, MODEL_FOOTPRINT_HINT } from '../scaffold/model-catalog.js';
 import { cliTheme, ACCENT } from '../scaffold/palette.js';
 import type { Target } from '../scaffold/prune-targets.js';
 
@@ -376,6 +376,11 @@ export function Wizard({
         {step === 'model' && (
           <Box flexDirection="column">
             <Field label="Trunk model" hint="fetched + digest-verified on first run — no key" />
+            {/* The hardware floor belongs HERE, at the moment the choice is
+                committed — not only in the docs, which a wizard user may never
+                have opened. Concurrent agents share one context, so they do not
+                multiply this; memory tracks KV fullness, not agent count. */}
+            <Text dimColor>{`  ${MODEL_FOOTPRINT_HINT}`}</Text>
             <Select
               options={[
                 { label: `Recommended — ${defaultLlmLabel}`, value: 'recommended' },

--- a/packages/harness-cli/src/scaffold/model-catalog.ts
+++ b/packages/harness-cli/src/scaffold/model-catalog.ts
@@ -39,6 +39,23 @@ export const MODEL_CATALOG: readonly CatalogModel[] = [
   },
 ];
 
+/**
+ * One-line hardware floor, shown at the moment the model is chosen.
+ *
+ * Grounded, not guessed: `qwen3.5-4b` Q4_K_M is 2.6 GB of weights and the
+ * `research` template adds the 0.6B reranker at 630 MB (`sizeBytes` in rig's
+ * `MODEL_CATALOG`, packages/rig/src/models.ts). The rest of the 16 GB covers KV
+ * at the recommended 32k context plus the OS and whichever surface is running —
+ * 8 GB does not survive Electron or a browser on top. 16 GB is the machine the
+ * `research` template was verified end-to-end on (Apple M2, 16 GB).
+ *
+ * The second sentence is the counter-intuitive part and the reason this exists:
+ * readers assume four agents means four times the model. They share one
+ * context, so the cost tracks KV FULLNESS, not agent count.
+ */
+export const MODEL_FOOTPRINT_HINT =
+  '~2.6 GB download · 16 GB RAM recommended. Concurrent agents share one context — they do not multiply it.';
+
 /** The catalog entries for one role, in listing order. */
 export function modelsForRole(role: ModelRole): readonly CatalogModel[] {
   return MODEL_CATALOG.filter((m) => m.role === role);

--- a/packages/harness-cli/templates/basic/package.json
+++ b/packages/harness-cli/templates/basic/package.json
@@ -5,6 +5,9 @@
   "description": "A vertical inference harness scaffolded by `harness.dev`.",
   "license": "Apache-2.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "bin": {
     "__NAME__": "bin/run.js"
   },

--- a/packages/harness-cli/templates/research/package.json
+++ b/packages/harness-cli/templates/research/package.json
@@ -5,6 +5,9 @@
   "description": "A grounded multi-agent research harness scaffolded by `harness.dev`. SNAPSHOT: reasoning.run @ 0.8.0.",
   "license": "Apache-2.0",
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "bin": {
     "__NAME__": "bin/run.js"
   },

--- a/packages/harness-cli/test/new-scaffold.test.ts
+++ b/packages/harness-cli/test/new-scaffold.test.ts
@@ -234,6 +234,21 @@ describe('the shared React view outlives either DOM target alone', () => {
   );
 
   it.each(['basic', 'research'] as const)(
+    '%s: declares a Node floor, so an old runtime fails at install not inside vite',
+    (template) => {
+      // The templates declared NO engines at all, so a scaffold asserted nothing
+      // and Node 18 surfaced as an opaque vite failure. The floor must also
+      // match the CLI's own, or the docs and the two package.jsons disagree.
+      const tpl = JSON.parse(readFileSync(join(TEMPLATES, template, 'package.json'), 'utf8'));
+      const cli = JSON.parse(
+        readFileSync(join(dirname(fileURLToPath(import.meta.url)), '..', 'package.json'), 'utf8'),
+      );
+      expect(tpl.engines?.node).toBe('>=24');
+      expect(tpl.engines.node).toBe(cli.engines.node);
+    },
+  );
+
+  it.each(['basic', 'research'] as const)(
     '%s: the harness runtime path has no dynamic import()',
     (template) => {
       // Metro needs a statically analysable module graph, so a dynamic import

--- a/packages/harness-cli/test/new-wizard.test.ts
+++ b/packages/harness-cli/test/new-wizard.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { render } from 'ink-testing-library';
 import { createElement } from 'react';
 import { Wizard, orderTargets } from '../src/commands/new-wizard.js';
+import { MODEL_FOOTPRINT_HINT } from '../src/scaffold/model-catalog.js';
+import { readFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // COVERAGE BOUNDARY: the full keystroke-driven flow (name → targets → model →
 // template) is NOT asserted here. Character input to @inkjs/ui's `TextInput`
@@ -19,6 +23,37 @@ describe('new wizard — render', () => {
     const { lastFrame } = render(createElement(Wizard, { onDone: () => {} }));
     expect(lastFrame()).toContain('Scaffold a new harness');
     expect(lastFrame()).toContain('Harness name');
+  });
+});
+
+describe('MODEL_FOOTPRINT_HINT — the hardware floor shown at the model step', () => {
+  // The keystroke flow can't be driven headlessly (see the coverage boundary
+  // above), so the model step's frame isn't asserted. What IS worth pinning is
+  // the CONTENT: the download figure is derived from rig's catalog, and the
+  // vendored copy in model-catalog.ts already carries a "keep in sync" warning.
+  // Without this, rig can swap the recommended model and the wizard keeps
+  // quoting a stale size at the exact moment the user commits to it.
+  const rigModels = readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '../../rig/src/models.ts'),
+    'utf8',
+  );
+
+  it('quotes a download size that matches rig’s sizeBytes for the recommended model', () => {
+    const entry = rigModels.slice(rigModels.indexOf("id: 'qwen3.5-4b'"));
+    const bytes = Number(
+      /sizeBytes:\s*([\d_]+)/.exec(entry)?.[1]?.replaceAll('_', '') ?? NaN,
+    );
+    expect(Number.isFinite(bytes)).toBe(true);
+    const quoted = Number(/([\d.]+)\s*GB download/.exec(MODEL_FOOTPRINT_HINT)?.[1] ?? NaN);
+    // Same figure to one decimal, in GB as a human reads it (2_600_000_000 → 2.6).
+    expect(quoted).toBeCloseTo(bytes / 1e9, 1);
+  });
+
+  it('states that concurrent agents do not multiply the requirement', () => {
+    // The counter-intuitive half, and the reason the hint exists at all —
+    // readers assume four agents means four times the model.
+    expect(MODEL_FOOTPRINT_HINT).toMatch(/share one context/i);
+    expect(MODEL_FOOTPRINT_HINT).toMatch(/16 GB/);
   });
 });
 


### PR DESCRIPTION
Two gaps found by checking the docs journey's CLI path against the shipped CLI, rather than reading either in isolation.

### The Node floor disagreed three ways

The guide's **first instruction** says "Requires Node 24 or newer". The CLI declared `>=20`. The scaffolded templates declared **no `engines` at all**.

The templates were the real defect: a project that asserts no floor means an old runtime surfaces as an opaque vite failure instead of an install-time engine warning. Tracing the actual requirement through the scaffold's own dependencies, vite 7 and electron-vite 5 both want `^20.19.0 || >=22.12.0`.

All three now say `>=24`, and a test pins the templates to the CLI's own value so they cannot drift apart again.

**Deliberate trade:** 24 is stricter than the dependencies require, so Node 22 gets a warning on a stack that would have run. Chosen for doc/code agreement over that edge.

### The model step recommended a 4B weight with no idea what it costs

That is the moment the choice is committed, and a wizard user may never open the docs — so the floor belongs there too, not only in the guide.

Grounded, not estimated: 2.6 GB of weights from rig's catalog `sizeBytes`, and 16 GB is the machine the `research` template was verified end-to-end on. The second sentence is the counter-intuitive half and the reason the hint exists at all — **concurrent agents share one context, so they do not multiply the requirement**; cost tracks KV fullness, not agent count.

`MODEL_FOOTPRINT_HINT` lives beside the vendored catalog, whose header already warned to keep its rows in sync with rig. A test now enforces that warning for the download figure: it reads `packages/rig/src/models.ts` and fails if the quoted size drifts from `sizeBytes`. Confirmed to bite by changing 2.6 → 7.1.

### Verification

Full suite 674 passed / 2 skipped. A real scaffold emits `{"node":">=24"}`.

**Not asserted:** the wizard's model-step *frame*. `@inkjs/ui`'s stdin does not deliver under `ink-testing-library` — the file's existing coverage-boundary comment already documents this for the keystroke flow — and driving it through a pty did not capture the frame either. The hint's *content* is tested instead; the rendering wants a human eye in a real terminal before release.

### Before this can ship

**The version is deliberately left at `0.9.0`.** This is user-visible behaviour on top of a published release, so it needs a bump — but new wizard output plus a narrowed engine range sits between patch and minor, and that is a judgement call rather than something to guess. Bump before tagging.
