### PR TITLE
feat(harness-cli): a follow-up question deepens the article, not replaces it

### DIFF
--- a/packages/harness-cli/templates/basic/harness/harness.ts
+++ b/packages/harness-cli/templates/basic/harness/harness.ts
@@ -326,7 +326,17 @@ function* runQuery(
   // trunk, `commitTurn` takes its cold path — fresh branch, prefill, promote —
   // and promote's `retainOnly` reclaims the old one. Append instead and the
   // trunk ends up holding every revision of the page.
+  //
+  // Restore on failure: until `promote` lands there is no new trunk, so leaving
+  // it null would silently drop the article and open the NEXT question on a
+  // blank page. Better to lose the turn than the page.
+  const superseded = session.trunk;
   session.trunk = null;
-  yield* call(() => session.commitTurn(query, answer));
+  try {
+    yield* call(() => session.commitTurn(query, answer));
+  } catch (err) {
+    session.trunk = superseded;
+    throw err;
+  }
   return answer;
 }

--- a/packages/harness-cli/templates/basic/harness/harness.ts
+++ b/packages/harness-cli/templates/basic/harness/harness.ts
@@ -94,6 +94,48 @@ const SYNTH_USER = [
   "Write the grounded markdown report.",
 ].join("\n");
 
+// The follow-up variants. A second question DEEPENS the same article rather than
+// starting a new one — each turn is another pass over one accreting page.
+//
+// Nothing re-sends the article: synth forks `session.trunk`, and `commitTurn`
+// put the previous turn there, so the current article is already in this agent's
+// KV prefix. These prompts only point at it. Re-injecting it as text would pay
+// for the same tokens twice and grow with every turn.
+const SYNTH_EXTEND_SYSTEM = [
+  "You are extending an existing research article. The current article is above this",
+  "message — it is the assistant side of the previous exchange. New research notes",
+  "for a follow-up question are below. Rules:",
+  "",
+  "- Output the COMPLETE updated article, not a diff and not just the new part.",
+  "- Preserve the existing sections and their inline citations. Change a claim only",
+  "  where the new notes actually correct it.",
+  "- Fold the new material into the section where it belongs. Add a new `##` section",
+  "  only for genuinely new ground the article does not yet cover.",
+  "- The result is ONE article about the whole subject, not two reports stitched",
+  "  together. A reader arriving fresh should not be able to tell where one turn",
+  "  ended and the next began.",
+  "- Keep the opening thesis accurate for the article as it now stands, and update",
+  "  `## Bottom line` to cover the whole page rather than only the latest question.",
+  "- Same grounding rules as before: cite inline as [short title](url) using exact",
+  "  URLs from the notes, and never invent a source, URL, or fact.",
+  "",
+  "Output the markdown article directly — no preamble, no tool call.",
+].join("\n");
+const SYNTH_EXTEND_USER = [
+  "Follow-up question: <%= it.query %>",
+  "",
+  "New research notes (cite by the URLs inside them):",
+  "<%= it.notes %>",
+  "",
+  "Extend the article above to cover this as well, and output the complete article.",
+].join("\n");
+
+/** Synthesis has two modes: open a page, or deepen the one already written. */
+const SYNTH = {
+  fresh: { system: SYNTH_SYSTEM, user: SYNTH_USER },
+  deepen: { system: SYNTH_EXTEND_SYSTEM, user: SYNTH_EXTEND_USER },
+} as const;
+
 /**
  * The one place basic subclasses `AgentPolicy`. A pool consults ONE policy per
  * role; the synth agent has no tools, so its free text IS the result — but the
@@ -178,6 +220,9 @@ export function* harness(
     if (cmd.type === "quit") return;
     if (cmd.type === "submit_query") {
       try {
+        // Announce the turn before any work. A warm trunk means this turn
+        // deepens the article already on the page rather than starting one.
+        events.send({ type: "query", text: cmd.query, warm: !!session.trunk });
         const answer = yield* runQuery(cmd.query, session, events);
         events.send({ type: "answer", text: answer });
       } catch (err) {
@@ -214,6 +259,9 @@ function* runQuery(
       "No AgentApp is enabled — enable one in harness.ts (e.g. `yield* registry.enable(createWikipediaApp)`).",
     );
   }
+  // Read BEFORE the turn is committed: a trunk here means an article already
+  // exists, so this run deepens it instead of opening a new one.
+  const mode = session.trunk ? "deepen" : "fresh";
   const tools = [...apps.flatMap((a) => [...a.tools]), reportTool];
   const spinePrompt = renderSpine({ apps });
 
@@ -253,11 +301,12 @@ function* runQuery(
     return "No findings — the research agents returned nothing.";
   }
 
-  // Synth: one agent, no tools, combines the notes. Committed to the session
-  // trunk so a follow-up query can build on it.
+  // Synth: one agent, no tools, combines the notes. It forks the trunk, which
+  // already holds the article, so `deepen` can point at it rather than restate
+  // it — the page grows turn by turn instead of being replaced by a new one.
   const synth = yield* useAgent({
-    systemPrompt: SYNTH_SYSTEM,
-    task: renderTemplate(SYNTH_USER, {
+    systemPrompt: SYNTH[mode].system,
+    task: renderTemplate(SYNTH[mode].user, {
       query,
       notes: notes.map((n, i) => `[${i + 1}] ${n}`).join("\n\n"),
     }),
@@ -271,6 +320,13 @@ function* runQuery(
   // raw stream. (The live agent cards keep `<think>` via `cleanNarration`; the final
   // answer does not.)
   const answer = reportBody(synth.result ?? "") || notes.join("\n\n");
+
+  // The page IS the state, so re-base the trunk on the article as it now stands
+  // rather than appending another copy beside the drafts it supersedes. With no
+  // trunk, `commitTurn` takes its cold path — fresh branch, prefill, promote —
+  // and promote's `retainOnly` reclaims the old one. Append instead and the
+  // trunk ends up holding every revision of the page.
+  session.trunk = null;
   yield* call(() => session.commitTurn(query, answer));
   return answer;
 }

--- a/packages/harness-cli/templates/basic/harness/protocol.ts
+++ b/packages/harness-cli/templates/basic/harness/protocol.ts
@@ -32,6 +32,13 @@ export type WorkflowEvent =
   | AgentEvent
   // Boot finished — the surface may accept a query. Carries the measured facts.
   | { type: "ready"; facts: BootFacts }
+  // A turn began. Emitted BEFORE any work, so the surface knows a new turn
+  // started without having to infer it from the first `agent:spawn` — which is
+  // both late and unable to tell a new turn's first agent from an extra agent
+  // spawned inside the current one. `warm` is true when the session already has
+  // a trunk, i.e. this turn DEEPENS the existing article rather than starting a
+  // fresh one; the view uses it to decide between replacing and extending.
+  | { type: "query"; text: string; warm: boolean }
   // The answer for the last query.
   | { type: "answer"; text: string }
   // A recoverable error to show; the surface returns to accepting input.

--- a/packages/harness-cli/templates/basic/harness/state.ts
+++ b/packages/harness-cli/templates/basic/harness/state.ts
@@ -46,6 +46,11 @@ export interface ToolStep {
 export interface AgentView {
   id: number;
   parentId: number;
+  /** Which turn spawned this agent. Agents accumulate across turns as the
+   *  composition history of the page, so "which agents are working NOW" and
+   *  "which agent is THIS turn's synth" both need the turn, not insertion
+   *  order — ids are not comparable across pools. */
+  turn: number;
   status: AgentStatus;
   /** Accumulated streamed text (`agent:produce` deltas). Includes the model's
    *  `<think>` / `<tool_call>` markup verbatim — `cleanNarration` strips it for
@@ -62,12 +67,18 @@ export interface AppState {
   phase: Phase;
   /** Measured boot facts for the header — null until `ready` lands. */
   boot: BootFacts | null;
-  /** Insertion-ordered by spawn — the auto-view renders the tree from `parentId`. */
+  /** Insertion-ordered by spawn — the auto-view renders the tree from `parentId`.
+   *  Agents from earlier turns are KEPT on purpose: they are the record of how
+   *  the article was composed. Use `turn` to tell history from live work. */
   agents: Map<number, AgentView>;
   answer: string;
   error: string | null;
   /** KV pressure for the gauge (from `agent:tick`). */
   kv: { used: number; total: number };
+  /** Turn counter, incremented by `query`. Agents carry the turn they belong to. */
+  turn: number;
+  /** The question being answered right now. */
+  topic: string;
 }
 
 export const initialState: AppState = {
@@ -77,6 +88,8 @@ export const initialState: AppState = {
   answer: "",
   error: null,
   kv: { used: 0, total: 0 },
+  turn: 0,
+  topic: "",
 };
 
 export function reduce(s: AppState, ev: WorkflowEvent): AppState {
@@ -85,6 +98,25 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
     case "ready":
       // Boot facts land here — the view renders the header from `s.boot`.
       return { ...s, phase: s.phase === "booting" ? "ready" : s.phase, boot: ev.facts };
+    case "query":
+      // A turn began. Bump the turn so agents spawned from here are
+      // distinguishable from the previous turn's, which stay in the map as the
+      // record of how the page was composed.
+      //
+      // The answer is deliberately NOT cleared on a warm turn: the article on
+      // screen is the one being extended, and blanking it would leave the page
+      // empty for the minutes the new synthesis takes.
+      return {
+        ...s,
+        phase: "working",
+        turn: s.turn + 1,
+        // The page keeps the subject it was opened on. A follow-up deepens that
+        // article, so retitling it to the latest question would misname a page
+        // that is now about more than the question just asked.
+        topic: ev.warm ? s.topic : ev.text,
+        error: null,
+        answer: ev.warm ? s.answer : "",
+      };
     case "answer":
       return { ...s, phase: "answered", answer: ev.text, error: null };
     case "error":
@@ -96,6 +128,7 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
       agents.set(ev.agentId, {
         id: ev.agentId,
         parentId: ev.parentAgentId,
+        turn: s.turn,
         status: "active",
         body: "",
         tokens: 0,
@@ -103,9 +136,10 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
         toolCalls: 0,
         tools: [],
       });
-      // A new query begins — clear the prior answer/error so it doesn't
-      // linger while this run produces.
-      return { ...s, phase: "working", agents, answer: "", error: null };
+      // Turn boundaries are marked by `query`, which arrives before any agent —
+      // this case no longer has to infer one (and must not clear `answer`, or a
+      // warm turn would blank the article it is extending).
+      return { ...s, phase: "working", agents };
     }
     case "agent:produce":
       return patch(s, ev.agentId, (a) => ({

--- a/packages/harness-cli/templates/basic/harness/state.ts
+++ b/packages/harness-cli/templates/basic/harness/state.ts
@@ -120,7 +120,10 @@ export function reduce(s: AppState, ev: WorkflowEvent): AppState {
     case "answer":
       return { ...s, phase: "answered", answer: ev.text, error: null };
     case "error":
-      return { ...s, phase: "error", error: ev.message, answer: "" };
+      // Keep `answer`. On a follow-up it is the article being deepened, and a
+      // failed turn is no reason to blank the page the reader already has; on a
+      // fresh turn the preceding `query` already cleared it.
+      return { ...s, phase: "error", error: ev.message };
 
     // ── framework agent events (shared across every harness) ──
     case "agent:spawn": {
@@ -362,6 +365,12 @@ export function toolCount(agents: Iterable<AgentView>): number {
 
 /** Research agents (those that use tools) vs the tool-less synth agent. */
 export const isResearchAgent = (a: AgentView): boolean => a.tools.length > 0;
+
+/** Still working — generating, or waiting on a tool call. Both count as live:
+ *  an agent spends most of its run in `tool`, so treating only `active` as
+ *  working would read as "finished" for most of the research. */
+export const isLiveAgent = (a: AgentView): boolean =>
+  a.status === "active" || a.status === "tool";
 
 /**
  * The report body a research agent is WRITING, streamed. The model emits its

--- a/packages/harness-cli/templates/basic/targets/_shared/App.tsx
+++ b/packages/harness-cli/templates/basic/targets/_shared/App.tsx
@@ -25,6 +25,7 @@ import {
   wikipediaSources,
   reportHeadings,
   isResearchAgent,
+  isLiveAgent,
   type AppState,
   type AgentView,
   type WikiSource,
@@ -77,7 +78,7 @@ function AgentEntry({ a }: { a: AgentView }): ReactElement {
   const bodyRef = useRef<HTMLDivElement>(null);
   const reasoning = cleanNarration(a.body);
   const report = extractStreamingReport(a.body); // null until the report tool call starts
-  const live = a.status === "active" || a.status === "tool";
+  const live = isLiveAgent(a);
   const lastLine = (t: string): string => t.split("\n").filter(Boolean).slice(-1)[0] ?? "";
   const preview = report !== null ? lastLine(report) || "writing report…" : lastLine(reasoning) || "thinking…";
   const status =
@@ -194,7 +195,7 @@ export function HarnessApp(): ReactElement {
   // the real synth once it exists and is harmless before then.
   const thisTurn = agents.filter((a) => a.turn === state.turn);
   const synth = [...thisTurn].reverse().find((a) => !isResearchAgent(a));
-  const live = thisTurn.filter((a) => a.status === "active" && isResearchAgent(a));
+  const live = thisTurn.filter((a) => isLiveAgent(a) && isResearchAgent(a));
   // The log keeps every turn's agents as the record of how this page was
   // composed — but calling the finished ones "reading" is false the moment a
   // follow-up starts, so the present tense counts only what is live.

--- a/packages/harness-cli/templates/basic/targets/_shared/App.tsx
+++ b/packages/harness-cli/templates/basic/targets/_shared/App.tsx
@@ -186,7 +186,23 @@ export function HarnessApp(): ReactElement {
 
   const agents: AgentView[] = [...state.agents.values()];
   const research = agents.filter(isResearchAgent);
-  const synth = agents.find((a) => !isResearchAgent(a));
+  // Agents accumulate across turns (they are the composition history), so the
+  // synth must be picked from THIS turn — `find` over the whole map would pin it
+  // to the first turn's synth forever, and a follow-up would never render.
+  // `isResearchAgent` is "has recorded a tool call", so a research agent looks
+  // synth-like until its first call: take the LAST match in this turn, which is
+  // the real synth once it exists and is harmless before then.
+  const thisTurn = agents.filter((a) => a.turn === state.turn);
+  const synth = [...thisTurn].reverse().find((a) => !isResearchAgent(a));
+  const live = thisTurn.filter((a) => a.status === "active" && isResearchAgent(a));
+  // The log keeps every turn's agents as the record of how this page was
+  // composed — but calling the finished ones "reading" is false the moment a
+  // follow-up starts, so the present tense counts only what is live.
+  const plural = (n: number): string => (n === 1 ? "" : "s");
+  const researchNote =
+    live.length > 0
+      ? `${live.length} agent${plural(live.length)} reading Wikipedia in parallel.`
+      : `${research.length} agent${plural(research.length)} researched this page.`;
   const sources = wikipediaSources(agents);
   const working = state.phase === "working";
   // The article prose = the final answer, or the synth's report streaming in
@@ -197,7 +213,9 @@ export function HarnessApp(): ReactElement {
   // reasoning streaming so the report pane is alive, not a static spinner.
   const synthThinking = synth && !report ? cleanNarration(synth.body) : "";
   const headings = report ? reportHeadings(report) : [];
-  const title = topic || "__NAME__";
+  // `state.topic` is authoritative (it survives a reload and is the same on
+  // every surface); the local one only covers the instant before `query` lands.
+  const title = state.topic || topic || "__NAME__";
 
   return (
     <div className="wiki">
@@ -303,8 +321,7 @@ export function HarnessApp(): ReactElement {
             <section id="research" className="wiki-log">
               <h2>Research</h2>
               <p className="wiki-log-note">
-                {research.length} agent{research.length === 1 ? "" : "s"} reading Wikipedia in parallel. Expand an agent
-                to follow its reasoning and findings.
+                {researchNote} Expand an agent to follow its reasoning and findings.
               </p>
               {research.map((a) => (
                 <AgentEntry key={a.id} a={a} />


### PR DESCRIPTION
## What

A follow-up question now **deepens the article** instead of writing a new one beside it.

`basic`'s surface is a wiki page and the intent is that each turn accretes onto it. Three
things prevented that, all observed on a real two-turn run:

- **Synthesis wrote a standalone article.** The previous page was already in synth's KV
  prefix (it forks the trunk, which `commitTurn` populated) — nothing asked it to carry it
  forward.
- **A follow-up's synthesis could never render.** The view selected the *first* non-research
  agent ever seen, so once turn one's synth entered the map it was pinned there for the
  session and later turns displayed nothing.
- **The research log described history as live** — the heading counted every agent ever
  spawned and called them "reading in parallel".

## How

Four files, all in `templates/basic`. No SDK change, no agents change, no new mechanism.

| file | change |
|---|---|
| `harness/protocol.ts` | `{ type: "query", text, warm }` — turn boundary, emitted before any work |
| `harness/harness.ts` | a named `SYNTH` mode table (`fresh` \| `deepen`), the deepen prompts, and the trunk re-base |
| `harness/state.ts` | `turn` on each agent; `turn` + `topic` on state; a `query` reducer case |
| `targets/_shared/App.tsx` | synth selected from *this* turn; heading counts only live agents |

Two details worth review:

**Nothing is re-sent.** The deepen prompts point at the article already in the prefix. The
`query` event mirrors the one `reasoning.run` emits at `runPlanner` rather than inventing a
variant.

**The trunk is re-based, not appended.** Committing each rewritten page beside the drafts it
supersedes grows the trunk quadratically in turn count against a fixed `nCtx`. Setting
`session.trunk = null` takes `commitTurn`'s documented cold path — fresh branch, prefill,
`promote` — and `promote`'s `retainOnly` reclaims the old one. `set trunk(branch: Branch |
null)` accepts null by type; no new SDK surface.

## Deliberately not included

`basic` is an onboarding surface, so fixes were sorted by concepts added rather than by
correctness. Unchanged: the `parallel` orchestrator, `pruneOnReturn`, the serialized-notes
shape, and `enableThinking` (setting it `false` does not suppress Qwen3.5's thinking — it
removes the delimiter, so the tokens land in visible content instead of `reasoning_content`;
see `agents/src/types.ts:286`). No sampling changes.

Three concepts are added: a turn has an announced boundary, agents carry their turn, and the
trunk is re-based each turn.

## Verification

Scaffolded fresh from the modified templates (templates are not in the monorepo build, so
scaffolding is the only real check): CLI build, `npm install`, `typecheck` across all three
tsconfigs, `build:web`, `build:desktop` — all clean. `npx vitest run packages/harness-cli/test/`
— 14 files, 159 tests passing.

Then the behaviour itself, two turns through the browser bridge on `qwen3.5-4b`:

```
306.7s  ANSWER turn=1  1485ch  paris=true  coffee=false
          headings: ["What the sources establish","Historical Nuances","Limitations","Bottom line"]
308.7s  QUERY  turn=2  warm=true  "what about coffee there?"
485.4s  agent:spawn 196609            <- turn 2's own synth
509.2s  ANSWER turn=2  2427ch  paris=true  coffee=true
          headings: ["Capital and History","French Coffee Culture","Bottom line"]
```

The page grew and integrated rather than appending — turn one's sections folded into
"Capital and History" beside a new "French Coffee Culture". KV at turn two's answer (2420
cells) is below turn one's (5912), confirming the re-base reclaims rather than accumulates.
