### PR TITLE
chore(harness-cli): 0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2662,7 +2662,7 @@
     },
     "packages/harness-cli": {
       "name": "harness.dev",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",
@@ -2677,7 +2677,7 @@
         "ink-testing-library": "^4.0.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24"
       }
     },
     "packages/harness-cli/node_modules/@inkjs/ui": {

--- a/packages/harness-cli/package.json
+++ b/packages/harness-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "harness.dev",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "The Harness Development Kit CLI — scaffold HDK harnesses and apps.",
   "bin": {
     "harness.dev": "bin/run.js"


### PR DESCRIPTION
Cuts `harness.dev@0.10.0`. Two merged changes have been sitting unreleased because neither
carried a bump, so npm is still on 0.9.0.

## What ships

**#76 — Node and hardware floors.** `engines.node` moves to `>=24` on the CLI *and* on both
templates, and the wizard's model step now states a hardware floor beside the download size.

**#87 — a follow-up deepens the article.** In `basic`, a second question now grows the same
wiki page instead of writing a standalone one beside it: an explicit `query` turn boundary,
per-turn agent tagging so the current turn's synthesis can render at all, a live-agent count
that stops calling finished agents "reading", and a re-based trunk so the page costs one copy
per turn rather than one plus every draft.

## Why minor, not patch

Raising the Node floor from `>=20` to `>=24` breaks installs for anyone on Node 20–23. Pre-1.0,
that is a minor.

## Lockfile

`package-lock.json` still carried `engines: ">=20"` for this workspace — #76 edited
`package.json` without reconciling it. Reconciled here. Worth flagging because an unreconciled
lockfile is precisely how a publish gets skipped with no error: `release.yml` compares each
package's `package.json` version against npm and silently skips anything already published.

## After merge

Tag the merge commit `v0.10.0-cli` and push. `release.yml` fires on any `v*` tag, loops every
workspace, and publishes only those whose version is not yet on npm — so the tag suffix is
convention for readability, not a filter.

## Verification

`npm pack --dry-run` on the bumped workspace: `harness.dev-0.10.0.tgz`, 51 template files
present. Scaffold → install → typecheck (all three tsconfigs) → `build:web` → `build:desktop`
clean, and 14 files / 159 tests passing, from the #87 verification run on this same tree.
