### PR TITLE
chore(rig): 3.9.0 — ship the shared channel verifier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2928,7 +2928,7 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/channel-verify": "^0.1.0",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Version-only bump so #89's changes actually reach rig's users.

## Why

rig's source changed substantially in #89 — **−547/+192** across `packages/rig/src` — but its version didn't. Published `3.8.0` therefore still carries its own copy of the verifier, including the trust-root map that `Object.freeze` doesn't actually freeze. The fix is on main and reaches nobody until rig republishes.

Confirmed against the registry: `@lloyal-labs/rig@3.8.0` declares no `channel-verify` dependency.

## Why minor, not patch or major

Gains a runtime dependency on `@lloyal-labs/channel-verify`, two error messages are reworded, and `CHANNEL_TRUST_ROOTS.get` now returns a copy rather than the live key bytes.

No export was removed — the symbol and its `ReadonlyMap` type are unchanged, which is what kept this off a major and out of the app-republish cascade that a major would have forced through the apps' `peerDependencies`.

## Nothing else needs republishing

| consumer | range | accepts 3.9.0 |
|---|---|---|
| `apps/{wikipedia,corpus,web}` peerDep | `^3.5.0` | yes |
| `templates/{basic,research}` | `^3.8.0` | yes |
| `templates/app` | `^3.0.0` | yes |

## Verification

- `npm version minor -w packages/rig --no-git-tag-version` — lockfile reconciled in the same commit (a bare version-field edit leaves it stale and fails `npm ci`); `packages/rig` reads 3.9.0 in both
- full suite **727 passed / 2 skipped**, `tsc -b` clean
- exactly two files changed