### PR TITLE
Wire format: abilityProtocolVersion + catalog under /v1/abilities

### DIFF
--- a/packages/abilities/corpus/ability.json
+++ b/packages/abilities/corpus/ability.json
@@ -1,6 +1,6 @@
 {
   "name": "corpus",
-  "appProtocolVersion": "3.0",
+  "abilityProtocolVersion": "3.0",
   "protocol": {
     "name": "corpus_research",
     "useWhen": "investigating a local document corpus — finding occurrences of terms, reading specific files at line offsets, semantic retrieval over indexed corpus content.",

--- a/packages/abilities/web/ability.json
+++ b/packages/abilities/web/ability.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "appProtocolVersion": "3.0",
+  "abilityProtocolVersion": "3.0",
   "protocol": {
     "name": "web_research",
     "useWhen": "gathering evidence from the open web — verifying current claims, retrieving primary sources from URLs, surveying official documentation and authoritative discussion.",

--- a/packages/abilities/wikipedia/ability.json
+++ b/packages/abilities/wikipedia/ability.json
@@ -1,6 +1,6 @@
 {
   "name": "wikipedia",
-  "appProtocolVersion": "3.0",
+  "abilityProtocolVersion": "3.0",
   "protocol": {
     "name": "wikipedia_research",
     "useWhen": "answering questions about established facts, historical events, biographies, scientific concepts, geography, or other general-knowledge topics covered by Wikipedia's encyclopedic content.",

--- a/packages/agents/src/ability-types.ts
+++ b/packages/agents/src/ability-types.ts
@@ -91,7 +91,7 @@ export type Service = (typeof SERVICES)[number];
 
 /**
  * The declarative ability manifest — content of `ability.json` plus the
- * `appProtocolVersion` declaration. Imported into the ability's factory
+ * `abilityProtocolVersion` declaration. Imported into the ability's factory
  * and passed to `defineAbility(...)`.
  *
  * `manifest.name` is the **ability identifier** used in code paths
@@ -107,7 +107,7 @@ export interface AbilityManifest {
    * refuses to register abilities whose declared version is not in
    * `SUPPORTED_ABILITY_PROTOCOL_VERSIONS` (currently `['3.0']`).
    */
-  readonly appProtocolVersion?: string;
+  readonly abilityProtocolVersion?: string;
   /** The model-facing identity. */
   readonly protocol: AbilityProtocol;
   /**

--- a/packages/agents/test/invariants/scenarios/xss-metadata-injection.scenario.test.ts
+++ b/packages/agents/test/invariants/scenarios/xss-metadata-injection.scenario.test.ts
@@ -24,7 +24,7 @@ import type { AbilityManifest, Source, Tool } from '../../../src';
 function manifestWith(useWhen: string): AbilityManifest {
   return {
     name: 'ability',
-    appProtocolVersion: '3.0',
+    abilityProtocolVersion: '3.0',
     protocol: { name: 'app_research', useWhen, tools: ['app_tool'] },
   };
 }

--- a/packages/channel-verify/src/index.ts
+++ b/packages/channel-verify/src/index.ts
@@ -72,7 +72,7 @@
  * The canonical channel catalog URL. Clients never accept a URL argument — to
  * point at a different channel, fork this package and edit the constant.
  */
-export const CHANNEL_CATALOG_URL = 'https://apps.lloyal.ai/v1/catalog.json';
+export const CHANNEL_CATALOG_URL = 'https://apps.lloyal.ai/v1/abilities/catalog.json';
 
 /**
  * The current Lloyal platform Ed25519 public key (raw 32 bytes) —
@@ -213,7 +213,7 @@ export interface CatalogVersion {
   version: string;
   manifestUrl: string;
   tarballUrl: string;
-  appProtocolVersion: string;
+  abilityProtocolVersion: string;
   sizeBytes: number;
   /**
    * npm package name as declared in the tarball's `package.json`. The catalog
@@ -458,7 +458,7 @@ function isWellFormedEntry(value: unknown): boolean {
         typeof ver.version === 'string' &&
         typeof ver.manifestUrl === 'string' &&
         typeof ver.tarballUrl === 'string' &&
-        typeof ver.appProtocolVersion === 'string' &&
+        typeof ver.abilityProtocolVersion === 'string' &&
         typeof ver.sizeBytes === 'number' &&
         typeof ver.importName === 'string'
       );

--- a/packages/channel-verify/test/catalog-golden.test.ts
+++ b/packages/channel-verify/test/catalog-golden.test.ts
@@ -201,11 +201,48 @@ describe('frozen production catalog', () => {
   });
 });
 
+
+/**
+ * A minimal catalog that is well-formed under the CURRENT shape rule.
+ *
+ * The frozen fixture deliberately is NOT — it predates the
+ * `appProtocolVersion` → `abilityProtocolVersion` rename. Shape-predicate tests
+ * need a valid document, which is a different job from the fixture's: the
+ * fixture is the SIGNATURE oracle, bytes no test can regenerate. Conflating the
+ * two is what made these tests fail for a reason unrelated to what they assert.
+ */
+const shapeValidCatalog = {
+  signedAt: '2026-08-16T00:00:00.000Z',
+  publisherKeyId: 'lloyal-platform-2026-q2',
+  signature: 'AA==',
+  entries: [
+    {
+      name: 'lloyal/example',
+      versions: [
+        {
+          version: '1.0.0',
+          manifestUrl: 'https://apps.lloyal.ai/v1/abilities/bundles/x.manifest.json',
+          tarballUrl: 'https://apps.lloyal.ai/v1/abilities/bundles/x.tgz',
+          abilityProtocolVersion: '3.0',
+          sizeBytes: 1,
+          importName: '@lloyal-labs/example-ability',
+        },
+      ],
+    },
+  ],
+};
+
 // ── Shape checking ───────────────────────────────────────────────
 
 describe('isWellFormedCatalog', () => {
-  it('accepts the real catalog', () => {
-    expect(isWellFormedCatalog(catalog)).toBe(true);
+  // The fixture is the PRE-rename production catalog, whose versions carry
+  // `appProtocolVersion`. The shape rule now requires `abilityProtocolVersion`,
+  // so it must NOT validate — the deliberate break, asserted rather than left as
+  // a red test. Its SIGNATURE still verifies (above): the rename changes what we
+  // accept, never whether the platform signed those bytes. When the channel is
+  // re-signed a new fixture is captured and this flips back to `accepts`.
+  it('rejects the pre-rename catalog — the field rename is a deliberate break', () => {
+    expect(isWellFormedCatalog(catalog)).toBe(false);
   });
 
   it('rejects null and non-objects without throwing', () => {
@@ -236,7 +273,7 @@ describe('isWellFormedCatalog', () => {
     // A well-formed document with a garbage signature must still pass the
     // shape gate — conflating the two would let a caller treat "parses" as
     // "verified".
-    expect(isWellFormedCatalog({ ...catalog, signature: 'not-base64!!' })).toBe(
+    expect(isWellFormedCatalog({ ...shapeValidCatalog, signature: 'not-base64!!' })).toBe(
       true,
     );
   });
@@ -336,7 +373,7 @@ describe('the base64 globals are a stated requirement, not an assumption', () =>
 
 describe('vendored constants', () => {
   it('points at the production channel', () => {
-    expect(CHANNEL_CATALOG_URL).toBe('https://apps.lloyal.ai/v1/catalog.json');
+    expect(CHANNEL_CATALOG_URL).toBe('https://apps.lloyal.ai/v1/abilities/catalog.json');
   });
 
   it('lists exactly the vendored key ids', () => {
@@ -443,7 +480,7 @@ describe('isWellFormedCatalog validates entries, not just the top level', () => 
       version: '1.0.0',
       manifestUrl: 'u',
       tarballUrl: 'u',
-      appProtocolVersion: '3.0',
+      abilityProtocolVersion: '3.0',
       sizeBytes: 1,
       importName: 'n',
     };
@@ -460,7 +497,7 @@ describe('isWellFormedCatalog validates entries, not just the top level', () => 
   });
 
   it('tolerates unknown fields so a newer catalog still validates', () => {
-    const withExtra = JSON.parse(JSON.stringify(catalog)) as Record<string, unknown>;
+    const withExtra = JSON.parse(JSON.stringify(shapeValidCatalog)) as Record<string, unknown>;
     (withExtra.entries as Record<string, unknown>[])[0].futureField = 'x';
     expect(isWellFormedCatalog(withExtra)).toBe(true);
   });

--- a/packages/rig/src/define-ability.ts
+++ b/packages/rig/src/define-ability.ts
@@ -14,7 +14,7 @@
  *   `name` and `protocol.name` match `[a-z][a-z0-9_-]{1,63}`; `protocol.tools`
  *   is a non-empty unique array of names matching the same regex;
  *   `protocol.useWhen` is a single bounded sentence with no chat-role markers,
- *   code fences, or newlines (metadata sanitization); `appProtocolVersion` (if
+ *   code fences, or newlines (metadata sanitization); `abilityProtocolVersion` (if
  *   declared) is in `SUPPORTED_ABILITY_PROTOCOL_VERSIONS`; `services` (if present)
  *   is an array of the closed service set. A malformed manifest fails the
  *   moment the ability module is imported.
@@ -202,7 +202,7 @@ function assertAbilityProtocolVersion(version: string | undefined): void {
   if (version === undefined) return;
   if (!SUPPORTED_ABILITY_PROTOCOL_VERSIONS.includes(version)) {
     throw new Error(
-      `defineAbility: manifest.appProtocolVersion ${JSON.stringify(version)} is not in the ` +
+      `defineAbility: manifest.abilityProtocolVersion ${JSON.stringify(version)} is not in the ` +
         `supported set ${JSON.stringify(SUPPORTED_ABILITY_PROTOCOL_VERSIONS)}. ` +
         `This build of @lloyal-labs/rig only validates abilities targeting one of those versions.`,
     );
@@ -312,7 +312,7 @@ export function defineAbility(
   // the ability is ever enabled. (Tool-map + skill checks need the setup output, so
   // they run when the factory runs — the same enable-time point as before.)
   assertIdentifier(manifest.name, 'manifest.name');
-  assertAbilityProtocolVersion(manifest.appProtocolVersion);
+  assertAbilityProtocolVersion(manifest.abilityProtocolVersion);
   assertIdentifier(manifest.protocol.name, 'manifest.protocol.name');
   assertUseWhen(manifest.protocol.useWhen);
   assertProtocolTools(manifest.protocol.tools);

--- a/packages/rig/src/protocol.ts
+++ b/packages/rig/src/protocol.ts
@@ -120,7 +120,7 @@ export interface ValidatedModelFamily {
  *
  * Extending the fleet for a new family requires re-running the
  * verification gates against that family and updating this
- * constant. `appProtocolVersion` does NOT bump for fleet expansion —
+ * constant. `abilityProtocolVersion` does NOT bump for fleet expansion —
  * only for changes to the marker, catalog format, or tool-selection
  * rule that require re-validation across all listed families.
  */
@@ -135,7 +135,7 @@ export const VALIDATED_MODELS_3_0: readonly ValidatedModelFamily[] = [
 /**
  * The Ability protocol version this build of `@lloyal-labs/rig` ships.
  *
- * Abilities declare `appProtocolVersion` in `ability.json`; `defineAbility` and
+ * Abilities declare `abilityProtocolVersion` in `ability.json`; `defineAbility` and
  * `registry.enable` refuse to enable abilities whose declared version is not in
  * {@link SUPPORTED_ABILITY_PROTOCOL_VERSIONS}.
  */

--- a/packages/rig/src/registry.ts
+++ b/packages/rig/src/registry.ts
@@ -154,10 +154,10 @@ export function* createAbilityRegistry(
             }),
         );
 
-        const declared = ability.manifest.appProtocolVersion ?? '3.0';
+        const declared = ability.manifest.abilityProtocolVersion ?? '3.0';
         if (!SUPPORTED_ABILITY_PROTOCOL_VERSIONS.includes(declared)) {
           throw new Error(
-            `Ability "${ability.manifest.name}" declares appProtocolVersion="${declared}", ` +
+            `Ability "${ability.manifest.name}" declares abilityProtocolVersion="${declared}", ` +
               `but the framework supports [${SUPPORTED_ABILITY_PROTOCOL_VERSIONS.map((v) => `"${v}"`).join(', ')}]. ` +
               `Upgrade the ability or use a framework version that supports this protocol.`,
           );

--- a/packages/rig/test/bundle.test.ts
+++ b/packages/rig/test/bundle.test.ts
@@ -89,7 +89,7 @@ export default function* () {
     manifest: {
       name: ${JSON.stringify(abilityName)},
       version: '1.0.0',
-      appProtocolVersion: '3.0',
+      abilityProtocolVersion: '3.0',
       protocol: {
         name: ${JSON.stringify(protocolName)},
         useWhen: 'test bundle',
@@ -174,7 +174,7 @@ async function buildSignedCatalog(
       version: f.version,
       manifestUrl: f.manifestUrl,
       tarballUrl: f.tarballUrl,
-      appProtocolVersion: '3.0',
+      abilityProtocolVersion: '3.0',
       sizeBytes: f.tarballBytes.byteLength,
       importName: `@lloyal-labs/${f.name}-ability`,
     });

--- a/packages/rig/test/define-ability.test.ts
+++ b/packages/rig/test/define-ability.test.ts
@@ -56,7 +56,7 @@ class FakeSource extends Source<unknown, unknown> {
 
 const baseManifest: AbilityManifest = {
   name: 'jira',
-  appProtocolVersion: '3.0',
+  abilityProtocolVersion: '3.0',
   protocol: {
     name: 'jira_research',
     useWhen: 'investigating tickets and project state in a JIRA workspace',
@@ -117,8 +117,8 @@ describe('defineAbility happy path', () => {
     expect(ability.tools.map((t) => t.name)).toEqual(['jira_search', 'jira_read']);
   });
 
-  it('accepts an absent appProtocolVersion', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: undefined })).not.toThrow();
+  it('accepts an absent abilityProtocolVersion', () => {
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: undefined })).not.toThrow();
   });
 
   it('accepts a function-typed agent template (no static double-emission check)', async () => {
@@ -203,12 +203,12 @@ describe('defineAbility useWhen grammar', () => {
   });
 });
 
-// ── appProtocolVersion — eager ──────────────────────────────────
+// ── abilityProtocolVersion — eager ──────────────────────────────────
 
-describe('defineAbility appProtocolVersion', () => {
+describe('defineAbility abilityProtocolVersion', () => {
   it('rejects an unsupported Ability protocol version', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: '4.0' })).toThrow(
-      /appProtocolVersion.*"4\.0".*supported set/,
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: '4.0' })).toThrow(
+      /abilityProtocolVersion.*"4\.0".*supported set/,
     );
   });
 });

--- a/packages/rig/test/registry.test.ts
+++ b/packages/rig/test/registry.test.ts
@@ -22,7 +22,7 @@
  * 5. **`ensure()` teardown fires on `disable`.**
  * 6. **`ensure()` teardown fires on registry scope-exit, reverse order.**
  * 7. **Teardown is best-effort** — a throwing `ensure` doesn't strand siblings.
- * 8. **appProtocolVersion gate** — unsupported version rejects (ensure still fires).
+ * 8. **abilityProtocolVersion gate** — unsupported version rejects (ensure still fires).
  * 9. **Stored-config validation** — missing key / wrong type rejects.
  * 10. **Duplicate names** throw; the first survives.
  * 11. **`disable` idempotent** — unknown name is a no-op.
@@ -41,7 +41,7 @@ import { createInMemoryConfigStore } from '../src/config-store';
 
 function fakeApp(opts: {
   name: string;
-  appProtocolVersion?: string;
+  abilityProtocolVersion?: string;
   configSchema?: AbilityManifest['configSchema'];
   /** Override the model-facing protocol name (defaults to `${name}_research`). */
   protocolName?: string;
@@ -52,7 +52,7 @@ function fakeApp(opts: {
   const manifest: AbilityManifest = {
     name: opts.name,
     version: '1.0.0',
-    appProtocolVersion: opts.appProtocolVersion ?? '3.0',
+    abilityProtocolVersion: opts.abilityProtocolVersion ?? '3.0',
     protocol: {
       name: opts.protocolName ?? `${opts.name}_research`,
       useWhen: 'do things',
@@ -238,16 +238,16 @@ describe('createAbilityRegistry', () => {
     consoleError.mockRestore();
   });
 
-  it('rejects unsupported appProtocolVersion (and the factory ensure still fires)', async () => {
+  it('rejects unsupported abilityProtocolVersion (and the factory ensure still fires)', async () => {
     const onTeardown = vi.fn();
     await expect(
       run(function* () {
         const registry = yield* createAbilityRegistry({ configStore: createInMemoryConfigStore() });
         yield* registry.enable(
-          resourceFactory({ name: 'future', appProtocolVersion: '99.0' }, { onTeardown }),
+          resourceFactory({ name: 'future', abilityProtocolVersion: '99.0' }, { onTeardown }),
         );
       }),
-    ).rejects.toThrow('appProtocolVersion="99.0"');
+    ).rejects.toThrow('abilityProtocolVersion="99.0"');
     expect(onTeardown).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/rig/test/spine-render.test.ts
+++ b/packages/rig/test/spine-render.test.ts
@@ -72,7 +72,7 @@ function makeAbility(opts: {
   const manifest: AbilityManifest = {
     name: opts.name,
     version: '1.0.0',
-    appProtocolVersion: '3.0',
+    abilityProtocolVersion: '3.0',
     protocol: {
       name: protocolName,
       useWhen: opts.useWhen ?? `do ${opts.name} things`,

--- a/packages/rig/test/verification-gates.test.ts
+++ b/packages/rig/test/verification-gates.test.ts
@@ -17,7 +17,7 @@
  * - `P-no-prose-in-spine`     — `spine-render.test.ts` ("output shape is fixed across ability.skill / ability.examples content")
  * - `P-per-spawn-isolation`   — `spine-render.test.ts` ("does NOT include another ability templates")
  * - `P-metadata-grammar`      — `define-ability.test.ts` (identifier-regex + useWhen-forbidden-patterns + tools-uniqueness suites)
- * - `P-appProtocolVersion-compat` — **codified below** (gap closed by this file)
+ * - `P-abilityProtocolVersion-compat` — **codified below** (gap closed by this file)
  * - `P-no-ungranted-protected-dispatch` — `@lloyal-labs/lloyal-agents/test/authGuard.test.ts` (lives there because it exercises `DefaultAgentPolicy`)
  *
  * §10.3 (model-based routing equivalence) is intentionally absent —
@@ -35,7 +35,7 @@ import type { AbilityManifest, Source, Tool } from '@lloyal-labs/lloyal-agents';
 
 const baseManifest: AbilityManifest = {
   name: 'gate',
-  appProtocolVersion: '3.0',
+  abilityProtocolVersion: '3.0',
   protocol: {
     name: 'gate_research',
     useWhen: 'verify gate behavior',
@@ -66,44 +66,44 @@ function build(manifest: AbilityManifest) {
   });
 }
 
-// ── P-appProtocolVersion-compat ─────────────────────────────────
+// ── P-abilityProtocolVersion-compat ─────────────────────────────────
 
-describe('P-appProtocolVersion-compat (§10.4)', () => {
+describe('P-abilityProtocolVersion-compat (§10.4)', () => {
   it('accepts every version in SUPPORTED_ABILITY_PROTOCOL_VERSIONS', () => {
     for (const version of SUPPORTED_ABILITY_PROTOCOL_VERSIONS) {
-      expect(() => build({ ...baseManifest, appProtocolVersion: version })).not.toThrow();
+      expect(() => build({ ...baseManifest, abilityProtocolVersion: version })).not.toThrow();
     }
   });
 
-  it('accepts an undefined appProtocolVersion (abilities without one default to current)', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: undefined })).not.toThrow();
+  it('accepts an undefined abilityProtocolVersion (abilities without one default to current)', () => {
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: undefined })).not.toThrow();
   });
 
   it('rejects a version outside the supported set', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: '4.0' })).toThrow(
-      /appProtocolVersion.*supported set/,
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: '4.0' })).toThrow(
+      /abilityProtocolVersion.*supported set/,
     );
   });
 
   it('rejects an empty-string version', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: '' })).toThrow(/appProtocolVersion/);
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: '' })).toThrow(/abilityProtocolVersion/);
   });
 
   it('rejects a typo-shaped version (e.g. "3.0.1")', () => {
-    expect(() => build({ ...baseManifest, appProtocolVersion: '3.0.1' })).toThrow(/appProtocolVersion/);
+    expect(() => build({ ...baseManifest, abilityProtocolVersion: '3.0.1' })).toThrow(/abilityProtocolVersion/);
   });
 });
 
 // ── Factory manifest preserves the version round-trip ───────────
 
-describe('appProtocolVersion round-trip', () => {
+describe('abilityProtocolVersion round-trip', () => {
   it('preserves the version on the factory manifest', () => {
-    const factory = build({ ...baseManifest, appProtocolVersion: '3.0' });
-    expect(factory.manifest?.appProtocolVersion).toBe('3.0');
+    const factory = build({ ...baseManifest, abilityProtocolVersion: '3.0' });
+    expect(factory.manifest?.abilityProtocolVersion).toBe('3.0');
   });
 
   it('preserves undefined on the factory manifest (no implicit defaulting)', () => {
-    const factory = build({ ...baseManifest, appProtocolVersion: undefined });
-    expect(factory.manifest?.appProtocolVersion).toBeUndefined();
+    const factory = build({ ...baseManifest, abilityProtocolVersion: undefined });
+    expect(factory.manifest?.abilityProtocolVersion).toBeUndefined();
   });
 });

--- a/packages/rig/test/verification-properties.test.ts
+++ b/packages/rig/test/verification-properties.test.ts
@@ -56,7 +56,7 @@ const appArb = fc.record({
   const manifest: AbilityManifest = {
     name,
     version: '1.0.0',
-    appProtocolVersion: '3.0',
+    abilityProtocolVersion: '3.0',
     protocol: { name: protocolName, useWhen, tools: [...new Set(tools)] },
   };
   return {


### PR DESCRIPTION
The wire-format half of the rename. Both changes land together because **the path move is what makes the field rename safe**.

`isWellFormedCatalog` rejects a catalog missing the field it expects, so renaming `appProtocolVersion` in place would break every published client the moment the channel was re-signed. Moving the catalog to a new key at the same time means old clients keep reading the old, frozen `v1/catalog.json` with the old field, while clients built against this version read `v1/abilities/catalog.json` with the new one. Nothing is deleted, so nothing 404s.

## The frozen fixtures are untouched and still verify

That is the property worth stating: **the rename changes what we ACCEPT, never whether the platform signed those bytes.** Signature verification is over canonical bytes and cannot care what a field is called — which is why `rig`'s golden suite stayed green throughout.

## Three test changes, each a real assertion rather than a loosened one

- **The fixture is the pre-rename catalog, so it must now FAIL the shape check.** Asserted explicitly rather than left red — a red test is a claim nobody reads. When the channel is re-signed, a new fixture is captured and this flips back to `accepts`.
- **Two shape-predicate tests** (`never a trust check`, `tolerates unknown fields`) built their subject from the fixture, borrowing it as a convenient valid document. It stopped being one. They now use a minimal shape-valid catalog — which is what they always should have used. The fixture's job is to be the **signature oracle**, not a generic well-formed document; conflating the two is why they failed for a reason unrelated to what they assert.
- The vendored-constant assertion follows `CHANNEL_CATALOG_URL` to the new path.

## Not touched

`v1/binaries/**` — `backend-pack.ts` hardcodes that path across **29 published `lloyal.node` versions** with no env override, and it carries the Blackwell modules. This PR moves only the ability namespace.

## Verification

**64 test files, 572 passed / 2 skipped.**

## What follows

`channel-verify@0.3.0` + `rig@4.1.0` → worker path cutover + deploy → seed-copy → republish the three abilities at 2.0.0 → approve (signs + re-signs the catalog) → recapture the frozen fixture.