### PR TITLE
release: agents 5.0.0, rig 5.0.0, channel-verify 0.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1825,9 +1825,9 @@
       "version": "2.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^4.0.0",
+        "@lloyal-labs/lloyal-agents": "^5.0.0",
         "@lloyal-labs/lloyal.node": "^3.1.1",
-        "@lloyal-labs/rig": "^4.0.0",
+        "@lloyal-labs/rig": "^5.0.0",
         "effection": "^4.0.2"
       }
     },
@@ -1840,8 +1840,8 @@
         "linkedom": "^0.18.12"
       },
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^4.0.0",
-        "@lloyal-labs/rig": "^4.0.0",
+        "@lloyal-labs/lloyal-agents": "^5.0.0",
+        "@lloyal-labs/rig": "^5.0.0",
         "effection": "^4.0.2"
       }
     },
@@ -1850,14 +1850,14 @@
       "version": "2.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "peerDependencies": {
-        "@lloyal-labs/lloyal-agents": "^4.0.0",
-        "@lloyal-labs/rig": "^4.0.0",
+        "@lloyal-labs/lloyal-agents": "^5.0.0",
+        "@lloyal-labs/rig": "^5.0.0",
         "effection": "^4.0.2"
       }
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",
@@ -1872,7 +1872,7 @@
     },
     "packages/channel-verify": {
       "name": "@lloyal-labs/channel-verify",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"
@@ -1901,11 +1901,11 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "4.0.0",
+      "version": "5.0.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@lloyal-labs/channel-verify": "^0.2.0",
-        "@lloyal-labs/lloyal-agents": "^4.0.0",
+        "@lloyal-labs/channel-verify": "^0.3.0",
+        "@lloyal-labs/lloyal-agents": "^5.0.0",
         "@lloyal-labs/sdk": "^3.0.0",
         "@mozilla/readability": "^0.6.0",
         "effection": "^4.0.2",

--- a/packages/abilities/corpus/package.json
+++ b/packages/abilities/corpus/package.json
@@ -25,9 +25,9 @@
     "build": "tsc -b"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^4.0.0",
+    "@lloyal-labs/lloyal-agents": "^5.0.0",
     "@lloyal-labs/lloyal.node": "^3.1.1",
-    "@lloyal-labs/rig": "^4.0.0",
+    "@lloyal-labs/rig": "^5.0.0",
     "effection": "^4.0.2"
   }
 }

--- a/packages/abilities/web/package.json
+++ b/packages/abilities/web/package.json
@@ -29,8 +29,8 @@
     "linkedom": "^0.18.12"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^4.0.0",
-    "@lloyal-labs/rig": "^4.0.0",
+    "@lloyal-labs/lloyal-agents": "^5.0.0",
+    "@lloyal-labs/rig": "^5.0.0",
     "effection": "^4.0.2"
   }
 }

--- a/packages/abilities/wikipedia/package.json
+++ b/packages/abilities/wikipedia/package.json
@@ -24,8 +24,8 @@
     "build": "tsc -b"
   },
   "peerDependencies": {
-    "@lloyal-labs/lloyal-agents": "^4.0.0",
-    "@lloyal-labs/rig": "^4.0.0",
+    "@lloyal-labs/lloyal-agents": "^5.0.0",
+    "@lloyal-labs/rig": "^5.0.0",
     "effection": "^4.0.2"
   }
 }

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/lloyal-agents",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Multi-agent inference inside the decode loop — structured concurrency over shared KV state",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/channel-verify/package.json
+++ b/packages/channel-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/channel-verify",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Apache-2.0, zero-dependency verification primitives for the Lloyal app channel — canonical-JSON signing payloads and Ed25519 verification",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,8 +40,8 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@lloyal-labs/channel-verify": "^0.2.0",
-    "@lloyal-labs/lloyal-agents": "^4.0.0",
+    "@lloyal-labs/channel-verify": "^0.3.0",
+    "@lloyal-labs/lloyal-agents": "^5.0.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@mozilla/readability": "^0.6.0",
     "effection": "^4.0.2",


### PR DESCRIPTION
The wire-format change in #94 renamed fields on **public exported types** and merged without bumps, so the published `4.0.0`/`0.2.0` do not carry it.

```
agents          AbilityManifest.appProtocolVersion → abilityProtocolVersion
channel-verify  CatalogVersion.appProtocolVersion  → abilityProtocolVersion
                CHANNEL_CATALOG_URL → /v1/abilities/catalog.json
```

Both are breaking for a TypeScript consumer, not cosmetic — hence majors for `agents` and `rig`, and a `0.x` minor for `channel-verify`, which is how 0.x signals breaking.

Two majors in one day is heavy. The alternative is worse: shipping a renamed public field under a patch breaks consumers silently at a version range that promised not to.

**The three abilities stay at `2.0.0`** — channel-only, never on npm, and not yet signed into the catalog at that version, so `2.0.0` is still unclaimed. Only their peer ranges move to `^5.0.0`.

Lockfile reconciled per workspace with `npm version` and verified in sync — a stale lockfile fails `npm ci` even though `release.yml` uses `npm install`.

**64 test files, 572 passed / 2 skipped.**

Tag `v5.0.0` after merge; that publishes all three and unblocks the worker path cutover and the re-sign.