### PR TITLE
fix: catalog shape check required a field nothing reads

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1872,7 +1872,7 @@
     },
     "packages/channel-verify": {
       "name": "@lloyal-labs/channel-verify",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=24"
@@ -1901,10 +1901,10 @@
     },
     "packages/rig": {
       "name": "@lloyal-labs/rig",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@lloyal-labs/channel-verify": "^0.3.0",
+        "@lloyal-labs/channel-verify": "^0.3.1",
         "@lloyal-labs/lloyal-agents": "^5.0.0",
         "@lloyal-labs/sdk": "^3.0.0",
         "@mozilla/readability": "^0.6.0",

--- a/packages/channel-verify/package.json
+++ b/packages/channel-verify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/channel-verify",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Apache-2.0, zero-dependency verification primitives for the Lloyal app channel — canonical-JSON signing payloads and Ed25519 verification",
   "main": "dist/cjs/index.js",
   "types": "dist/cjs/index.d.ts",

--- a/packages/channel-verify/src/index.ts
+++ b/packages/channel-verify/src/index.ts
@@ -458,7 +458,14 @@ function isWellFormedEntry(value: unknown): boolean {
         typeof ver.version === 'string' &&
         typeof ver.manifestUrl === 'string' &&
         typeof ver.tarballUrl === 'string' &&
-        typeof ver.abilityProtocolVersion === 'string' &&
+          // NOT abilityProtocolVersion. This predicate exists to guarantee the
+          // fields callers DEREFERENCE — version, tarballUrl, importName,
+          // sizeBytes. Nothing in the resolution path reads the protocol
+          // version, so requiring it rejects catalogs that resolve perfectly
+          // well. Not hypothetical: the catalog is CUMULATIVE, so a single
+          // historical version signed before the field was renamed made the
+          // whole catalog invalid and every install fail. A shape check must
+          // assert what it needs and nothing more.
         typeof ver.sizeBytes === 'number' &&
         typeof ver.importName === 'string'
       );

--- a/packages/channel-verify/test/catalog-golden.test.ts
+++ b/packages/channel-verify/test/catalog-golden.test.ts
@@ -235,14 +235,12 @@ const shapeValidCatalog = {
 // ── Shape checking ───────────────────────────────────────────────
 
 describe('isWellFormedCatalog', () => {
-  // The fixture is the PRE-rename production catalog, whose versions carry
-  // `appProtocolVersion`. The shape rule now requires `abilityProtocolVersion`,
-  // so it must NOT validate — the deliberate break, asserted rather than left as
-  // a red test. Its SIGNATURE still verifies (above): the rename changes what we
-  // accept, never whether the platform signed those bytes. When the channel is
-  // re-signed a new fixture is captured and this flips back to `accepts`.
-  it('rejects the pre-rename catalog — the field rename is a deliberate break', () => {
-    expect(isWellFormedCatalog(catalog)).toBe(false);
+  // Valid again, and deliberately so. The shape check guarantees the fields
+  // callers dereference; the protocol version is not one of them. Requiring it
+  // made a CUMULATIVE catalog invalid the moment one historical version predated
+  // the rename — which is exactly what happened in production.
+  it('accepts the real catalog, old protocol field and all', () => {
+    expect(isWellFormedCatalog(catalog)).toBe(true);
   });
 
   it('rejects null and non-objects without throwing', () => {
@@ -480,7 +478,6 @@ describe('isWellFormedCatalog validates entries, not just the top level', () => 
       version: '1.0.0',
       manifestUrl: 'u',
       tarballUrl: 'u',
-      abilityProtocolVersion: '3.0',
       sizeBytes: 1,
       importName: 'n',
     };

--- a/packages/rig/package.json
+++ b/packages/rig/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lloyal-labs/rig",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Retrieval-Interleaved Generation for lloyal-agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -40,7 +40,7 @@
     "build": "tsc -b"
   },
   "dependencies": {
-    "@lloyal-labs/channel-verify": "^0.3.0",
+    "@lloyal-labs/channel-verify": "^0.3.1",
     "@lloyal-labs/lloyal-agents": "^5.0.0",
     "@lloyal-labs/sdk": "^3.0.0",
     "@mozilla/readability": "^0.6.0",


### PR DESCRIPTION
Found by verifying the live channel after approving the three abilities — **the catalog was signed correctly and every install would still have failed.**

`isWellFormedCatalog` required `abilityProtocolVersion` on every version. Nothing in the resolution path reads it: `bundle.ts` dereferences `name`, `versions`, `version`, `tarballUrl`, `importName`, `sizeBytes` — never the protocol version.

## Why that was an outage, not a nit

The catalog is **cumulative**. Approving `lloyal/web@2.0.0` adds it *alongside* `1.0.0`–`1.3.0`, which were signed before the rename and carry `appProtocolVersion`. Twelve historical versions made the whole live catalog invalid the instant it was re-signed:

```
before:  wellFormed: false   signature: true      ← every install fails
after:   wellFormed: true    signature: true
```

A perfectly good signature over a catalog no client would accept.

**No test could have caught this** — the fixtures are single-generation, so they never contain versions from both sides of a rename. It was only visible against the live, cumulative catalog.

## The rule

A shape check asserts what its callers dereference and nothing more. Requiring an unread field bought no safety and turned one historical row into a total outage.

## Test changes

Two assertions realigned rather than deleted:
- The frozen fixture is shape-valid again — which is the point. It lacks only the field that is no longer required.
- The drop-each-required-field loop no longer lists the protocol version, since dropping it must **not** reject.

`channel-verify@0.3.1`, `rig@5.0.1`. **64 test files, 572 passed / 2 skipped.**