### PR TITLE
feat(timeline): documents in, cited chronology out — slice 1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           node-version: 24
 
       - run: npm install
-      - run: npx tsc -b packages/sdk packages/agents packages/rig packages/channel-verify
+      - run: npx tsc -b packages/sdk packages/agents packages/rig packages/channel-verify packages/abilities/timeline
 
   gpu-tests:
     name: GPU Integration Tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           test -f packages/channel-verify/dist/esm/package.json
 
       - name: Typecheck
-        run: npx tsc -b packages/sdk packages/agents packages/rig packages/channel-verify packages/binding packages/relay packages/host
+        run: npx tsc -b packages/sdk packages/agents packages/rig packages/channel-verify packages/binding packages/relay packages/host packages/abilities/timeline
 
       - name: Publish packages
         if: success() && (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && !inputs.skip_publish))

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,10 @@
       "resolved": "packages/sdk",
       "link": true
     },
+    "node_modules/@lloyal-labs/timeline-ability": {
+      "resolved": "packages/abilities/timeline",
+      "link": true
+    },
     "node_modules/@lloyal-labs/tsampler": {
       "version": "0.2.0",
       "license": "Apache-2.0"
@@ -494,6 +498,15 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chrono-node": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.10.1.tgz",
+      "integrity": "sha512-tPOsBzYVAK5zth+CiHCgp5NGeqRc4mMD8FPthQ5IxkgjPWWxIFdM5odnmfw//IRAzl6C++Xy8olQW7wn5qBR1g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
     },
     "node_modules/ci-info": {
@@ -1831,6 +1844,19 @@
         "effection": "^4.0.2"
       }
     },
+    "packages/abilities/timeline": {
+      "name": "@lloyal-labs/timeline-ability",
+      "version": "2.0.0",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "chrono-node": "^2.10.1"
+      },
+      "peerDependencies": {
+        "@lloyal-labs/lloyal-agents": "^5.0.0",
+        "@lloyal-labs/rig": "^5.0.0",
+        "effection": "^4.0.2"
+      }
+    },
     "packages/abilities/web": {
       "name": "@lloyal-labs/web-ability",
       "version": "2.0.0",
@@ -1857,7 +1883,7 @@
     },
     "packages/agents": {
       "name": "@lloyal-labs/lloyal-agents",
-      "version": "5.0.0",
+      "version": "5.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@lloyal-labs/sdk": "^3.0.0",

--- a/packages/abilities/timeline/LICENSE
+++ b/packages/abilities/timeline/LICENSE
@@ -1,0 +1,107 @@
+# Functional Source License, Version 1.1, Apache 2.0 Future License
+
+## Abbreviation
+
+FSL-1.1-Apache-2.0
+
+## Notice
+
+Copyright 2026 Lloyal Labs
+
+## Terms and Conditions
+
+### Licensor ("We")
+
+The party offering the Software under these Terms and Conditions.
+
+### The Software
+
+The "Software" is each version of the software that we make available under
+these Terms and Conditions, as indicated by our inclusion of these Terms and
+Conditions with the Software.
+
+### License Grant
+
+Subject to your compliance with this License Grant and the Patents,
+Redistribution and Trademark clauses below, we hereby grant you the right to
+use, copy, modify, create derivative works, publish, and distribute the
+Software for any Permitted Purpose identified below.
+
+### Permitted Purpose
+
+A "Permitted Purpose" is any purpose other than a Competing Use. A
+"Competing Use" means making the Software available to others in a
+commercial product or service that:
+
+1. substitutes for the Software;
+
+2. substitutes for any other product or service we offer using the Software
+   that exists as of the date we make the Software available; or
+
+3. offers the same or substantially similar functionality as the Software.
+
+Permitted Purposes specifically include using the Software:
+
+1. for your internal use and access;
+
+2. for non-commercial education;
+
+3. for non-commercial research; and
+
+4. in connection with professional services that you provide to a Licensee
+   using the Software in accordance with these Terms and Conditions.
+
+### Patents
+
+To the extent your use for a Permitted Purpose would necessarily infringe our
+patents, the license grant above includes a license under our patents. If you
+make a claim against any party that the Software infringes or contributes to
+the infringement of any patent, then your patent license to the Software ends
+immediately.
+
+### Redistribution
+
+The Terms and Conditions apply to all copies, modifications and derivatives
+of the Software.
+
+If you redistribute any copies, modifications or derivatives of the Software,
+you must include a copy of or a link to these Terms and Conditions and not
+remove any copyright notices provided in or with the Software.
+
+### Disclaimer
+
+THE SOFTWARE IS PROVIDED "AS IS" AND WITHOUT WARRANTIES OF ANY KIND,
+INCLUDING WITHOUT LIMITATION WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE,
+MERCHANTABILITY, TITLE OR NON-INFRINGEMENT.
+
+IN NO EVENT WILL WE HAVE ANY LIABILITY TO YOU ARISING OUT OF OR RELATED TO
+THE SOFTWARE, INCLUDING INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL
+DAMAGES, EVEN IF WE HAVE BEEN INFORMED OF THEIR POSSIBILITY IN ADVANCE.
+
+### Trademarks
+
+Except for displaying the License Details and identifying us as the origin of
+the Software, you have no right under these Terms and Conditions to use our
+trademarks, trade names, service marks or product names.
+
+## Grant of Future License
+
+We hereby irrevocably grant you an additional license to use the Software
+under the Apache License, Version 2.0 that is effective on the second
+anniversary of the date we make the Software available. On or after that
+date, you may use the Software under the Apache License, Version 2.0, in
+which case the following will apply:
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not
+use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/packages/abilities/timeline/README.md
+++ b/packages/abilities/timeline/README.md
@@ -1,0 +1,52 @@
+# @lloyal-labs/timeline-ability
+
+Turns documents and transcripts into a **cited chronology** — every row carries
+the span it came from, so a reader can open the page rather than take the model's
+word for it.
+
+```sh
+npx lloyal-ai install lloyal/timeline
+```
+
+## What it returns
+
+| | |
+|---|---|
+| `rows` | dated events, each assertion carrying its supporting span and page |
+| `unresolved` | events it could not date — recorded, never guessed |
+| `unprocessed` | segments that failed — visible, never dropped |
+
+Partial dates stay partial: `"March 2024"` resolves to `2024-03`, never
+`2024-03-01`. Two sources disagreeing produce two assertions, not one consensus.
+
+## Configure
+
+```ts
+yield* store.set('timeline', {
+  locale: 'en-GB',                    // REQUIRED — see below
+  criteria: 'Only decisions, notices and statutory deadlines.',
+});
+```
+
+`locale` has no default on purpose. `03/04/24` is 3 April under `en-GB` and
+4 March under `en-US`, and a chronology silently wrong by a year is worse than
+one that refuses to start.
+
+`criteria` is your domain's definition of an event. A casework harness means
+something different by it than a tax harness, and this package has no business
+guessing which.
+
+## Tool
+
+`build_timeline({ documents })` — takes `EvidenceDocument`s (text plus
+character-span → page/speaker regions) and returns the result above.
+
+## Honest floor
+
+- On evidence that fits one context, a prompt is likely cheaper and better.
+- Dates are computed, never guessed: an expression the parser only partly
+  understands goes to `unresolved` rather than becoming a confident wrong row.
+- Slice 1 does not yet reconcile across documents or judge whether a cited span
+  supports its claim.
+
+Protocol: `timeline_chronology`.

--- a/packages/abilities/timeline/ability.json
+++ b/packages/abilities/timeline/ability.json
@@ -1,0 +1,18 @@
+{
+  "name": "timeline",
+  "abilityProtocolVersion": "3.0",
+  "protocol": {
+    "name": "timeline_chronology",
+    "useWhen": "reconstructing when events happened across evidence too large, indirect or contradictory for a single-context answer — building a chronology, establishing sequence, or ordering records whose order matters.",
+    "tools": ["build_timeline"]
+  },
+  "configSchema": {
+    "type": "object",
+    "required": ["locale"],
+    "properties": {
+      "locale": { "type": "string" },
+      "criteria": { "type": "string" },
+      "segmentChars": { "type": "number" }
+    }
+  }
+}

--- a/packages/abilities/timeline/package.json
+++ b/packages/abilities/timeline/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@lloyal-labs/timeline-ability",
+  "version": "2.0.0",
+  "private": true,
+  "description": "HDK ability — turns documents and transcripts into a cited chronology, preserving partial dates, attributed claims and processing failures. Distributed via the signed channel, never public npm.",
+  "license": "SEE LICENSE IN LICENSE",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist/",
+    "ability.json",
+    "skill.eta",
+    "attention-surface.json",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -b"
+  },
+  "dependencies": {
+    "chrono-node": "^2.10.1"
+  },
+  "peerDependencies": {
+    "@lloyal-labs/lloyal-agents": "^5.0.0",
+    "@lloyal-labs/rig": "^5.0.0",
+    "effection": "^4.0.2"
+  }
+}

--- a/packages/abilities/timeline/skill.eta
+++ b/packages/abilities/timeline/skill.eta
@@ -1,0 +1,28 @@
+You are reconstructing what happened and when, from evidence that arrived out of order.
+<% if (it.agentCount > 1) { -%>
+
+You are one of <%= it.agentCount %> parallel agents. The other agents are covering:
+<%= it.siblingTasks.map(function(q) { return '- ' + q }).join('\n') %>
+
+Stay on your own segments. The other agents handle the rest.
+<% } -%>
+
+You have <%= it.maxTurns %> tool calls. Plan your reading within this budget.
+
+WHAT COUNTS AS AN EVENT:
+<%= it.criteria %>
+
+RULES FOR RECORDING AN EVENT:
+- Quote the exact words that carry the date. Do not paraphrase them — a citation a reader cannot verify is worse than no citation.
+- Record what the source claims, not what you conclude. "The patient reported symptoms began Tuesday" is the patient reporting, not an observation.
+- Say whether the event occurred, was scheduled, fell due, took effect, was cancelled, or is hypothetical. These are different rows, and a reader acts on the difference.
+- A negated event is still an event. "No follow-up occurred in April" is recorded, marked negated.
+- Give the date expression exactly as written, and separately say what it means: an absolute date, an offset from something else, a qualified month, or a partial date. Never compute the date yourself — arithmetic is done for you.
+- If a date is relative, name what it is relative to. "Three days later" needs its anchor or it cannot be placed.
+- If you cannot date something, record it anyway and say so. An undated event is a task for someone; a guessed date is a defect.
+
+PROCESS:
+1. Read your segments in full. Do not skim for dates — the modality and the actor matter as much as the number.
+2. For each event, record the exact supporting words, the date expression as written, who is asserting it, and whether it occurred or was merely scheduled, due, effective, cancelled or hypothetical.
+3. Note any event you could not date, and why.
+4. Call report() with everything you found, including what you checked and found nothing for.

--- a/packages/abilities/timeline/src/dates.ts
+++ b/packages/abilities/timeline/src/dates.ts
@@ -1,0 +1,301 @@
+/**
+ * Turning a date expression into a date, or refusing to.
+ *
+ * The model reads; this computes. It decides what a phrase MEANS — an absolute
+ * date, an offset from something, a qualified month, a partial year — and the
+ * arithmetic happens here, deterministically. A language model doing date
+ * arithmetic is strictly worse than `addDays`, and a parser deciding what counts
+ * as an event is strictly worse than a reader.
+ *
+ * THE HARD PART IS REFUSING. Natural-language date parsers answer confidently
+ * when they have understood only a fragment. Measured against chrono-node
+ * 2.10.1, anchored to 2019-03-14:
+ *
+ *   "the end of February"          → 2019-02-01   (matched "February")
+ *   "the 2nd Tuesday of November"  → 2019-03-12   (matched "Tuesday")
+ *   "in 2024"                      → no parse
+ *
+ * The first two are wrong and well-formed, which is the dangerous combination.
+ * So every parse is coverage-checked: if the parser consumed materially less
+ * than the phrase the extractor identified, the result is discarded and the
+ * event goes to `unresolved`. A visible gap beats a confident wrong date.
+ *
+ * @packageDocumentation
+ */
+
+import * as chrono from 'chrono-node';
+import type { NormalisedDate } from './types';
+
+/**
+ * A date expression, already decomposed by the extractor.
+ *
+ * The model emits structure rather than prose precisely so the ambiguity class
+ * above never reaches a parser: "the end of February" arrives as
+ * `{kind:'qualified', month:2, qualifier:'end-of'}` and is resolved by
+ * arithmetic, not guessed at.
+ */
+export type DateExpr =
+  /** As written: "18 March 2024", "03/04/24". Parsed, then coverage-checked. */
+  | { kind: 'absolute'; text: string }
+  /** "three days later", "the following Monday" — needs `anchorRef`. */
+  | {
+      kind: 'relative';
+      text: string;
+      anchorRef: string;
+      n: number;
+      unit: 'day' | 'week' | 'month' | 'year';
+      dir: 'before' | 'after';
+    }
+  /** "the end of February", "early 2024" — resolved by rule, never parsed. */
+  | {
+      kind: 'qualified';
+      text: string;
+      month?: number;
+      year?: number;
+      anchorRef?: string;
+      qualifier: 'start-of' | 'mid' | 'end-of';
+    }
+  /** "March 2024", "in 2024" — deliberately imprecise, and stays that way. */
+  | { kind: 'partial'; text: string; year: number; month?: number };
+
+/** An established fixed point a relative expression can be measured from. */
+export interface DateAnchor {
+  id: string;
+  /** ISO date. */
+  value: string;
+}
+
+/** Why a resolution was refused. Surfaced so a developer can act on it. */
+export type UnresolvedReason =
+  | 'no-parse'
+  | 'partial-parse'
+  | 'missing-anchor'
+  | 'incomplete-qualifier';
+
+export type DateResolution =
+  | { ok: true; date: NormalisedDate }
+  | { ok: false; reason: UnresolvedReason; detail: string };
+
+export interface DateResolver {
+  resolve(expr: DateExpr, anchors: readonly DateAnchor[]): DateResolution;
+}
+
+/**
+ * Fraction of the phrase a parser must consume for its answer to be trusted.
+ *
+ * "the end of February" is 19 characters and chrono matches 8 of them (~0.42),
+ * which is the fragment case. An exact-length rule would be too strict — parsers
+ * legitimately trim articles and trailing punctuation — so the bar is
+ * proportional, and stated rather than tuned silently.
+ */
+const MIN_COVERAGE = 0.8;
+
+/** Normalise for coverage comparison: parsers vary on case and punctuation. */
+function normalise(text: string): string {
+  return text
+    .toLowerCase()
+    .replace(/[.,;:]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/** ISO date truncated to the precision actually known. */
+function truncate(d: Date, granularity: 'day' | 'month' | 'year'): string {
+  const iso = d.toISOString();
+  if (granularity === 'year') return iso.slice(0, 4);
+  if (granularity === 'month') return iso.slice(0, 7);
+  return iso.slice(0, 10);
+}
+
+/** Days in a month, so "end of February" is the 29th in a leap year. */
+function lastDayOfMonth(year: number, month1: number): number {
+  return new Date(Date.UTC(year, month1, 0)).getUTCDate();
+}
+
+/**
+ * chrono-backed resolver — the only implementation.
+ *
+ * chrono is the sole natural-language parser whose `parse()` accepts an
+ * arbitrary reference date, which is the whole requirement for historical
+ * documents: "three days later" in a 2019 transcript must resolve against 2019.
+ * Sugar's parser is pinned to now, and moment, Luxon, date-fns and Temporal
+ * parse formats rather than prose.
+ */
+export class ChronoDateResolver implements DateResolver {
+  private readonly _parser: chrono.Chrono;
+
+  /**
+   * @param locale Selects the parser. REQUIRED — `03/04/24` is 3 April under
+   *   en-GB and 4 March under en-US, and a default would make a chronology
+   *   silently wrong by a year.
+   */
+  constructor(private readonly locale: string) {
+    this._parser = locale.toLowerCase().startsWith('en-us')
+      ? chrono.en.casual
+      : chrono.en.GB;
+  }
+
+  resolve(expr: DateExpr, anchors: readonly DateAnchor[]): DateResolution {
+    switch (expr.kind) {
+      case 'partial':
+        return this._partial(expr);
+      case 'qualified':
+        return this._qualified(expr, anchors);
+      case 'relative':
+        return this._relative(expr, anchors);
+      case 'absolute':
+        return this._absolute(expr, anchors);
+    }
+  }
+
+  /** Imprecise by construction — the whole point is that it stays imprecise. */
+  private _partial(
+    expr: Extract<DateExpr, { kind: 'partial' }>,
+  ): DateResolution {
+    const granularity = expr.month === undefined ? 'year' : 'month';
+    const value =
+      granularity === 'year'
+        ? String(expr.year).padStart(4, '0')
+        : `${String(expr.year).padStart(4, '0')}-${String(expr.month).padStart(2, '0')}`;
+    return { ok: true, date: { value, granularity, basis: 'explicit' } };
+  }
+
+  /** Resolved by rule. "End of February" is the 28th or the 29th — computed. */
+  private _qualified(
+    expr: Extract<DateExpr, { kind: 'qualified' }>,
+    anchors: readonly DateAnchor[],
+  ): DateResolution {
+    const year =
+      expr.year ??
+      (expr.anchorRef
+        ? Number(anchors.find((a) => a.id === expr.anchorRef)?.value.slice(0, 4))
+        : undefined);
+    if (!year || Number.isNaN(year)) {
+      return {
+        ok: false,
+        reason: 'incomplete-qualifier',
+        detail: `${JSON.stringify(expr.text)} has no year and no anchor to take one from`,
+      };
+    }
+    if (expr.month === undefined) {
+      // "early 2024" — a season, not a date. Honest as a year.
+      return {
+        ok: true,
+        date: { value: String(year), granularity: 'year', basis: 'inferred' },
+      };
+    }
+    const day =
+      expr.qualifier === 'start-of'
+        ? 1
+        : expr.qualifier === 'mid'
+          ? 15
+          : lastDayOfMonth(year, expr.month);
+    const value = `${String(year).padStart(4, '0')}-${String(expr.month).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    return { ok: true, date: { value, granularity: 'day', basis: 'inferred' } };
+  }
+
+  /** Arithmetic against a named anchor. Never against "now". */
+  private _relative(
+    expr: Extract<DateExpr, { kind: 'relative' }>,
+    anchors: readonly DateAnchor[],
+  ): DateResolution {
+    const anchor = anchors.find((a) => a.id === expr.anchorRef);
+    if (!anchor) {
+      return {
+        ok: false,
+        reason: 'missing-anchor',
+        detail: `${JSON.stringify(expr.text)} is relative to ${JSON.stringify(expr.anchorRef)}, which was not established`,
+      };
+    }
+    const base = new Date(`${anchor.value}T00:00:00Z`);
+    if (Number.isNaN(base.getTime())) {
+      return {
+        ok: false,
+        reason: 'missing-anchor',
+        detail: `anchor ${JSON.stringify(expr.anchorRef)} has an unparseable value ${JSON.stringify(anchor.value)}`,
+      };
+    }
+    const sign = expr.dir === 'before' ? -1 : 1;
+    const out = new Date(base);
+    const n = sign * expr.n;
+    if (expr.unit === 'day') out.setUTCDate(out.getUTCDate() + n);
+    else if (expr.unit === 'week') out.setUTCDate(out.getUTCDate() + n * 7);
+    else if (expr.unit === 'month') out.setUTCMonth(out.getUTCMonth() + n);
+    else out.setUTCFullYear(out.getUTCFullYear() + n);
+
+    return {
+      ok: true,
+      date: {
+        value: truncate(out, 'day'),
+        granularity: 'day',
+        basis: 'relative',
+        anchorId: anchor.id,
+      },
+    };
+  }
+
+  /**
+   * Parsed, then coverage-checked.
+   *
+   * The check is the point: chrono answers "the end of February" with 1
+   * February by matching the word "February" and discarding the qualifier. The
+   * result is well-formed and wrong, and only comparing what it consumed
+   * against what it was given reveals it.
+   */
+  private _absolute(
+    expr: Extract<DateExpr, { kind: 'absolute' }>,
+    anchors: readonly DateAnchor[],
+  ): DateResolution {
+    const ref = anchors.length > 0 ? new Date(`${anchors[0].value}T00:00:00Z`) : undefined;
+    const results = this._parser.parse(
+      expr.text,
+      ref && !Number.isNaN(ref.getTime()) ? ref : undefined,
+    );
+    if (results.length === 0) {
+      return {
+        ok: false,
+        reason: 'no-parse',
+        detail: `no date found in ${JSON.stringify(expr.text)}`,
+      };
+    }
+    const r = results[0];
+
+    const consumed = normalise(r.text).length;
+    const given = normalise(expr.text).length;
+    if (given > 0 && consumed / given < MIN_COVERAGE) {
+      return {
+        ok: false,
+        reason: 'partial-parse',
+        detail:
+          `only ${JSON.stringify(r.text)} of ${JSON.stringify(expr.text)} was ` +
+          `understood (${Math.round((consumed / given) * 100)}% < ${MIN_COVERAGE * 100}%); ` +
+          `the rest changes the meaning`,
+      };
+    }
+
+    // Precision comes from what chrono was CERTAIN of, not from the Date it
+    // returned — it fills unknown components silently, and reporting those as
+    // known is exactly the invented precision this refuses to produce.
+    const granularity: 'day' | 'month' | 'year' = r.start.isCertain('day')
+      ? 'day'
+      : r.start.isCertain('month')
+        ? 'month'
+        : 'year';
+
+    return {
+      ok: true,
+      date: {
+        value: truncate(r.start.date(), granularity),
+        granularity,
+        basis: 'explicit',
+      },
+    };
+  }
+}
+
+/** Construct the resolver. `locale` is required — see the constructor. */
+export function createDateResolver(locale: string): DateResolver {
+  return new ChronoDateResolver(locale);
+}
+
+export type { NormalisedDate } from './types';

--- a/packages/abilities/timeline/src/index.ts
+++ b/packages/abilities/timeline/src/index.ts
@@ -1,0 +1,106 @@
+/**
+ * `@lloyal-labs/timeline-ability` — documents in, cited chronology out.
+ *
+ * Turns records and transcripts into a dated sequence where every row carries
+ * the span that supports it, so a caseworker, clinician, paralegal or adviser
+ * can open the page rather than take the model's word for it. Partial dates stay
+ * partial, undated events stay visible, and a segment that fails to process is
+ * reported rather than dropped.
+ *
+ * @packageDocumentation
+ */
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  AbilityConfigStoreCtx,
+  renderTemplate,
+  type AbilityManifest,
+  type AgentRenderCtx,
+} from '@lloyal-labs/lloyal-agents';
+import { defineAbility } from '@lloyal-labs/rig';
+import { TimelineSource } from './source';
+
+export { TimelineSource } from './source';
+export type { TimelineSourceOpts } from './source';
+export { segmentDocument, DEFAULT_SEGMENT_CHARS } from './segment';
+export type { TimelineSegment } from './segment';
+export { createDateResolver, ChronoDateResolver } from './dates';
+export type { DateResolver, DateExpr, NormalisedDate } from './dates';
+export type {
+  TimelineResult,
+  TimelineRow,
+  TimelineAssertion,
+  AssertionSupport,
+} from './types';
+
+const dir = join(__dirname, '..');
+const manifest = JSON.parse(
+  readFileSync(join(dir, 'ability.json'), 'utf8'),
+) as AbilityManifest;
+const skillTemplate = readFileSync(join(dir, 'skill.eta'), 'utf8');
+
+/**
+ * What counts as an event, when the harness has not said.
+ *
+ * Deliberately generic — the domain belongs in config, not in this package. A
+ * casework harness means something different by "event" than a tax harness, and
+ * the Ability has no business guessing which.
+ */
+const DEFAULT_CRITERIA =
+  'Anything that happened, was scheduled, fell due, took effect, or was ' +
+  'cancelled, and that a reader would expect to see placed in time.';
+
+/**
+ * Construct the timeline ability.
+ *
+ * `locale` is REQUIRED and has no default: `03/04/24` is April 3rd under en-GB
+ * and March 4th under en-US, and guessing produces a chronology that is wrong by
+ * a year without ever looking wrong. Failing at enable() is the cheaper error.
+ */
+export const createTimelineAbility = defineAbility(manifest, function* () {
+  const cfgStore = yield* AbilityConfigStoreCtx.expect();
+  const cfg = (yield* cfgStore.get('timeline')) ?? {};
+
+  const locale = typeof cfg.locale === 'string' ? cfg.locale : undefined;
+  if (!locale) {
+    throw new Error(
+      'createTimelineAbility: missing config `locale` (e.g. "en-GB", "en-US"). ' +
+        'It has no default because 03/04/24 differs by a year between locales, ' +
+        'and a chronology that is silently wrong is worse than one that refuses ' +
+        'to start. Set it via the harness config store under the "timeline" key.',
+    );
+  }
+
+  const criteria =
+    typeof cfg.criteria === 'string' && cfg.criteria.trim().length > 0
+      ? cfg.criteria.trim()
+      : DEFAULT_CRITERIA;
+  const segmentChars =
+    typeof cfg.segmentChars === 'number' ? cfg.segmentChars : undefined;
+
+  const source = new TimelineSource({ locale, segmentChars });
+
+  return {
+    source,
+    // Keyed by tool name — the keys must equal manifest.protocol.tools as a
+    // set, so building the record from the source's own tools keeps the two in
+    // step rather than restating the list here.
+    tools: Object.fromEntries(source.tools.map((t) => [t.name, t])),
+    /**
+     * A FUNCTION, not the raw template.
+     *
+     * `criteria` is the domain's definition of an event and the most
+     * load-bearing line in the skill. It is not part of `AgentRenderCtx`, so a
+     * string template referencing `it.criteria` would render it as empty
+     * whenever the harness did not happen to merge it — losing the instruction
+     * silently, which is precisely the failure mode this ability exists to
+     * avoid. Closing over it at construction makes that unrepresentable.
+     */
+    skill: ((params: AgentRenderCtx) =>
+      renderTemplate(skillTemplate, {
+        ...params,
+        criteria,
+      })) satisfies (params: AgentRenderCtx) => string,
+  };
+});

--- a/packages/abilities/timeline/src/segment.ts
+++ b/packages/abilities/timeline/src/segment.ts
@@ -1,0 +1,83 @@
+/**
+ * Splitting evidence into units of work.
+ *
+ * A document is not one. A two-paragraph memo and a 600-page hearing transcript
+ * are not comparable, and one-agent-per-document makes the ability's floor a
+ * function of its largest input — which contradicts cost scaling with how full
+ * the cache is rather than how many files arrived.
+ *
+ * Every segment carries its offsets INTO THE PARENT, so an event extracted from
+ * segment 40 still cites a span the reader can open in the original. Offsets are
+ * never segment-local; that is the bug this shape exists to prevent.
+ *
+ * @packageDocumentation
+ */
+
+import type { EvidenceDocument } from '@lloyal-labs/lloyal-agents';
+
+export interface TimelineSegment {
+  docId: string;
+  /** Half-open `[start, end)` offsets into the PARENT document's text. */
+  span: [number, number];
+  /** `document.text.slice(...span)` — carried so extractors need only this. */
+  text: string;
+}
+
+/**
+ * Target segment size in characters.
+ *
+ * Characters rather than tokens because segmentation must not depend on a
+ * tokenizer being loaded — this runs before any model does, and a segmenter
+ * that needs a model is a segmenter that cannot report `unprocessed` when the
+ * model is missing.
+ */
+export const DEFAULT_SEGMENT_CHARS = 4000;
+
+/**
+ * Split on paragraph boundaries, packing up to `maxChars`.
+ *
+ * Boundaries are preferred over exact sizes: a segment that ends mid-sentence
+ * costs an extraction the context it needed, and the saving is nothing. A single
+ * paragraph longer than `maxChars` becomes its own oversized segment rather than
+ * being cut — losing a sentence is worse than a wide segment.
+ */
+export function segmentDocument(
+  doc: EvidenceDocument,
+  maxChars: number = DEFAULT_SEGMENT_CHARS,
+): TimelineSegment[] {
+  if (doc.text.length === 0) return [];
+
+  const segments: TimelineSegment[] = [];
+  const boundary = /\n\s*\n/g;
+
+  // Paragraph start offsets, in the parent's coordinates.
+  const starts: number[] = [0];
+  for (let m = boundary.exec(doc.text); m !== null; m = boundary.exec(doc.text)) {
+    starts.push(m.index + m[0].length);
+  }
+  starts.push(doc.text.length);
+
+  let segStart = 0;
+  for (let i = 1; i < starts.length; i++) {
+    const paraEnd = starts[i];
+    const wouldBe = paraEnd - segStart;
+    const isLast = i === starts.length - 1;
+
+    if (wouldBe >= maxChars || isLast) {
+      // Close the current segment at this boundary. `>= maxChars` rather than
+      // `>` so a single oversized paragraph closes immediately as its own
+      // segment instead of accreting the next one.
+      const end = paraEnd;
+      if (end > segStart) {
+        segments.push({
+          docId: doc.id,
+          span: [segStart, end],
+          text: doc.text.slice(segStart, end),
+        });
+      }
+      segStart = end;
+    }
+  }
+
+  return segments;
+}

--- a/packages/abilities/timeline/src/source.ts
+++ b/packages/abilities/timeline/src/source.ts
@@ -1,0 +1,45 @@
+import { Source } from '@lloyal-labs/lloyal-agents';
+import type { Tool } from '@lloyal-labs/lloyal-agents';
+import { BuildTimelineTool } from './tools/build-timeline';
+
+/**
+ * The chronology source.
+ *
+ * Holds no corpus of its own — the harness supplies `EvidenceDocument`s, because
+ * the domain owns where records live and how they are fetched. A casework
+ * harness reads a matter folder, a clinical one reads an export, and neither
+ * wants this package's opinion about storage.
+ *
+ * That is also what keeps the Ability domain-general: what counts as an event
+ * arrives as configured `criteria`, not as code here.
+ */
+export class TimelineSource extends Source {
+  readonly name = 'timeline';
+
+  private _tools: Tool[];
+
+  constructor(opts: TimelineSourceOpts) {
+    super();
+    this._tools = [
+      new BuildTimelineTool({
+        locale: opts.locale,
+        segmentChars: opts.segmentChars,
+      }),
+    ];
+  }
+
+  get tools(): Tool[] {
+    return this._tools;
+  }
+}
+
+/** Configuration for {@link TimelineSource}. */
+export interface TimelineSourceOpts {
+  /**
+   * BCP-47 locale selecting the date parser. Required — `03/04/24` is 3 April
+   * under en-GB and 4 March under en-US.
+   */
+  locale: string;
+  /** Target segment size in characters. Defaults to `DEFAULT_SEGMENT_CHARS`. */
+  segmentChars?: number;
+}

--- a/packages/abilities/timeline/src/tools/build-timeline.ts
+++ b/packages/abilities/timeline/src/tools/build-timeline.ts
@@ -22,6 +22,16 @@ export interface ExtractedEvent {
   description: string;
   /** Offsets into the SEGMENT; converted to document offsets before citing. */
   span: [number, number];
+  /**
+   * The exact words at `span`, as the skill instructs the model to quote them.
+   *
+   * Carried so the span can be VERIFIED rather than trusted. A segment-local
+   * offset that escapes into a document-level field stays in bounds and still
+   * resolves to a region — valid, self-consistent, and pointing at the wrong
+   * sentence. Comparing the quote against the text at the resolved span is what
+   * makes that visible.
+   */
+  quote: string;
   dateExpr: DateExpr;
   temporalStatus: TimelineAssertion['temporalStatus'];
   epistemicStatus: TimelineAssertion['epistemicStatus'];
@@ -146,6 +156,7 @@ export class BuildTimelineTool extends Tool<{ documents: EvidenceDocument[] }> {
             docId: doc.id,
             span,
             cites: resolveCites(doc, span),
+            quote: event.quote,
           };
           const assertion: TimelineAssertion = {
             id: `a${++seq}`,

--- a/packages/abilities/timeline/src/tools/build-timeline.ts
+++ b/packages/abilities/timeline/src/tools/build-timeline.ts
@@ -1,0 +1,184 @@
+import type { Operation } from 'effection';
+import { Tool, resolveCites, assertWellFormedDocument } from '@lloyal-labs/lloyal-agents';
+import type { EvidenceDocument, JsonSchema } from '@lloyal-labs/lloyal-agents';
+import { segmentDocument, DEFAULT_SEGMENT_CHARS } from '../segment';
+import { createDateResolver, type DateAnchor, type DateExpr } from '../dates';
+import type {
+  AssertionSupport,
+  TimelineAssertion,
+  TimelineResult,
+  TimelineRow,
+} from '../types';
+
+/**
+ * One extracted claim, as the model reports it.
+ *
+ * The date arrives DECOMPOSED — `{kind:'qualified', month:2, qualifier:'end-of'}`
+ * rather than the string "the end of February" — because a parser handed that
+ * string answers with 1 February and looks certain. The model says what the
+ * phrase means; arithmetic happens in `dates.ts`.
+ */
+export interface ExtractedEvent {
+  description: string;
+  /** Offsets into the SEGMENT; converted to document offsets before citing. */
+  span: [number, number];
+  dateExpr: DateExpr;
+  temporalStatus: TimelineAssertion['temporalStatus'];
+  epistemicStatus: TimelineAssertion['epistemicStatus'];
+  polarity: TimelineAssertion['polarity'];
+  attributedTo?: string;
+}
+
+/** Supplied by the harness; the model half is injected so this stays testable. */
+export type Extractor = (
+  segmentText: string,
+  docId: string,
+) => Operation<ExtractedEvent[]>;
+
+export interface BuildTimelineOpts {
+  locale: string;
+  segmentChars?: number;
+  /**
+   * How events are pulled from a segment.
+   *
+   * Injected rather than constructed here so segmentation, offset arithmetic,
+   * date resolution and coverage accounting are all testable without a model —
+   * which is what lets the invariants run on every fixture instead of only where
+   * weights happen to be present.
+   */
+  extract?: Extractor;
+}
+
+/**
+ * `build_timeline` — documents in, cited chronology out.
+ *
+ * Slice 1 covers segment → extract → date → cite. Reconciliation across
+ * documents and support judging arrive next; until then every extracted event
+ * becomes its own row, and nothing is merged, because a silent merge destroys
+ * evidence and an unmerged duplicate merely looks untidy.
+ */
+export class BuildTimelineTool extends Tool<{ documents: EvidenceDocument[] }> {
+  readonly name = 'build_timeline';
+  readonly protected = false;
+  // No native call, no shared-context decode — safe off the loop fiber.
+  readonly fanout = true;
+  readonly description =
+    'Build a dated chronology from a set of documents. Returns rows with the ' +
+    'exact supporting span for each claim, events that could not be dated, and ' +
+    'segments that failed to process.';
+  readonly parameters: JsonSchema = {
+    type: 'object',
+    properties: {
+      documents: {
+        type: 'array',
+        description: 'Evidence documents with text and locator regions.',
+      },
+    },
+    required: ['documents'],
+  };
+
+  private _locale: string;
+  private _segmentChars: number;
+  private _extract?: Extractor;
+
+  constructor(opts: BuildTimelineOpts) {
+    super();
+    this._locale = opts.locale;
+    this._segmentChars = opts.segmentChars ?? DEFAULT_SEGMENT_CHARS;
+    this._extract = opts.extract;
+  }
+
+  *execute(args: { documents: EvidenceDocument[] }): Operation<unknown> {
+    const documents = args.documents ?? [];
+    const resolver = createDateResolver(this._locale);
+
+    const rows: TimelineRow[] = [];
+    const unresolved: TimelineRow[] = [];
+    const unprocessed: TimelineResult['unprocessed'] = [];
+    let segmentsSeen = 0;
+    let seq = 0;
+
+    for (const doc of documents) {
+      // Fail loudly on malformed evidence at the boundary: unsorted regions
+      // yield citations that are quietly wrong rather than absent.
+      try {
+        assertWellFormedDocument(doc);
+      } catch (e) {
+        unprocessed.push({
+          docId: doc?.id ?? '(unknown)',
+          reason: e instanceof Error ? e.message : String(e),
+        });
+        continue;
+      }
+
+      // A document's own date is the anchor a relative expression measures from.
+      const anchors: DateAnchor[] = [];
+      const docDate = doc.metadata?.createdAt ?? doc.metadata?.publishedAt;
+      if (docDate) anchors.push({ id: `${doc.id}:document`, value: docDate.slice(0, 10) });
+
+      for (const segment of segmentDocument(doc, this._segmentChars)) {
+        segmentsSeen++;
+
+        let events: ExtractedEvent[];
+        try {
+          // Never throw out of a segment: one malformed page must not cost the
+          // other 599. The failure is recorded and the run continues.
+          events = this._extract
+            ? yield* this._extract(segment.text, doc.id)
+            : [];
+        } catch (e) {
+          unprocessed.push({
+            docId: doc.id,
+            span: segment.span,
+            reason: e instanceof Error ? e.message : String(e),
+          });
+          continue;
+        }
+
+        for (const event of events) {
+          // Segment-local offsets become document offsets HERE, once, so every
+          // span downstream is openable in the original.
+          const span: [number, number] = [
+            segment.span[0] + event.span[0],
+            segment.span[0] + event.span[1],
+          ];
+          const support: AssertionSupport = {
+            docId: doc.id,
+            span,
+            cites: resolveCites(doc, span),
+          };
+          const assertion: TimelineAssertion = {
+            id: `a${++seq}`,
+            description: event.description,
+            temporalStatus: event.temporalStatus,
+            epistemicStatus: event.epistemicStatus,
+            polarity: event.polarity,
+            ...(event.attributedTo ? { attributedTo: event.attributedTo } : {}),
+            supports: [support],
+          };
+
+          const resolution = resolver.resolve(event.dateExpr, anchors);
+          const row: TimelineRow = {
+            id: `r${seq}`,
+            date: resolution.ok ? resolution.date : null,
+            assertions: [assertion],
+          };
+          // An undatable event is recorded, never guessed and never dropped.
+          (resolution.ok ? rows : unresolved).push(row);
+        }
+      }
+    }
+
+    rows.sort((a, b) => {
+      const byDate = (a.date?.value ?? '').localeCompare(b.date?.value ?? '');
+      if (byDate !== 0) return byDate;
+      return (
+        (a.assertions[0]?.supports[0]?.span[0] ?? 0) -
+        (b.assertions[0]?.supports[0]?.span[0] ?? 0)
+      );
+    });
+
+    const result: TimelineResult = { rows, unresolved, unprocessed, segmentsSeen };
+    return result;
+  }
+}

--- a/packages/abilities/timeline/src/types.ts
+++ b/packages/abilities/timeline/src/types.ts
@@ -56,6 +56,14 @@ export interface AssertionSupport {
   span: [number, number];
   /** Every region the span touches — a sentence can cross a page or speaker. */
   cites: Cite[];
+  /**
+   * The words the extractor said it was pointing at.
+   *
+   * `document.text.slice(...span)` must equal this. It is the only way to catch
+   * an offset that is in bounds and wrong — which is what a segment-local index
+   * becomes when it escapes into a document-level field.
+   */
+  quote: string;
 }
 
 /**

--- a/packages/abilities/timeline/src/types.ts
+++ b/packages/abilities/timeline/src/types.ts
@@ -1,0 +1,104 @@
+/**
+ * The chronology, and the distinctions that must survive to reach it.
+ *
+ * Every field here exists because flattening it misstates something a
+ * professional acts on. That is the test for adding another.
+ *
+ * @packageDocumentation
+ */
+
+import type { Cite } from '@lloyal-labs/lloyal-agents';
+
+/** How precisely the source pinned the date. Never widened by inference. */
+export type DateGranularity = 'day' | 'month' | 'year';
+
+/** How the date was arrived at — audit needs this, not just the value. */
+export type DateBasis = 'explicit' | 'relative' | 'inferred';
+
+/**
+ * A resolved date, carrying its own precision.
+ *
+ * `value` is ISO, TRUNCATED to `granularity`: `"March 2024"` becomes
+ * `"2024-03"`, never `"2024-03-01"`. Inventing a day that the source did not
+ * state is the failure that makes a chronology unusable in front of someone
+ * else, and it is invisible once written.
+ */
+export interface NormalisedDate {
+  value: string;
+  granularity: DateGranularity;
+  basis: DateBasis;
+  /** Set when `basis === 'relative'` — what the offset was measured from. */
+  anchorId?: string;
+}
+
+/**
+ * What the source says happened, and in what sense.
+ *
+ * TWO INDEPENDENT DIMENSIONS. "The patient reported that surgery was scheduled
+ * for Friday" is `reported` × `scheduled`; "the taxpayer alleged that payment
+ * had occurred" is `alleged` × `occurred`. One enum can express neither.
+ */
+export type TemporalStatus =
+  | 'occurred'
+  | 'scheduled'
+  | 'due'
+  | 'effective'
+  | 'cancelled'
+  | 'hypothetical';
+
+/** Who is standing behind the claim, and how directly. */
+export type EpistemicStatus = 'observed' | 'recorded' | 'reported' | 'alleged';
+
+/** Evidence for one assertion, addressable by a human. */
+export interface AssertionSupport {
+  docId: string;
+  /** Half-open `[start, end)` offsets into the document's text. */
+  span: [number, number];
+  /** Every region the span touches — a sentence can cross a page or speaker. */
+  cites: Cite[];
+}
+
+/**
+ * One claim about one event.
+ *
+ * Evidence hangs off the ASSERTION rather than the row: when two sources
+ * disagree, a caller must be able to tell which citation supports which claim,
+ * and a row-level support list cannot say.
+ */
+export interface TimelineAssertion {
+  id: string;
+  description: string;
+  temporalStatus: TemporalStatus;
+  epistemicStatus: EpistemicStatus;
+  /** `negated` records that the source says it did NOT happen. Still an event. */
+  polarity: 'affirmed' | 'negated';
+  /** Who asserts it, when the source attributes the claim. */
+  attributedTo?: string;
+  supports: AssertionSupport[];
+}
+
+/** One dated line of the chronology. */
+export interface TimelineRow {
+  id: string;
+  /** `null` means undatable — the row lives in `unresolved`, never guessed. */
+  date: NormalisedDate | null;
+  /** ≥1. More than one means the sources disagree and both were kept. */
+  assertions: TimelineAssertion[];
+}
+
+/**
+ * The deliverable.
+ *
+ * `unresolved` and `unprocessed` are load-bearing: a chronology with a silent
+ * hole is a liability, one with a visible gap is a task for someone.
+ */
+export interface TimelineResult {
+  /** Dated, ordered by date then by first support offset. */
+  rows: TimelineRow[];
+  /** Events with no datable anchor. Recorded, never dropped, never guessed. */
+  unresolved: TimelineRow[];
+  /** Segments that failed. Their absence would otherwise be invisible. */
+  unprocessed: { docId: string; span?: [number, number]; reason: string }[];
+  /** Every segment the run was given, so coverage is checkable (T1). */
+  segmentsSeen: number;
+}

--- a/packages/abilities/timeline/test/ability.test.ts
+++ b/packages/abilities/timeline/test/ability.test.ts
@@ -1,0 +1,100 @@
+/**
+ * The ability contract — what `defineAbility` and the harness require, checked
+ * where a developer will see it rather than at someone else's enable().
+ */
+import { describe, it, expect } from 'vitest';
+import { run } from 'effection';
+import { AbilityConfigStoreCtx } from '@lloyal-labs/lloyal-agents';
+// The store factory lives in rig, not agents — agents defines the interface and
+// rig the concrete backend, the same split as Source and Tool.
+import { createInMemoryConfigStore } from '@lloyal-labs/rig';
+import { createTimelineAbility } from '../src/index';
+
+const enable = (config: Record<string, unknown> | null) =>
+  run(function* () {
+    const store = createInMemoryConfigStore();
+    if (config) yield* store.set('timeline', config);
+    yield* AbilityConfigStoreCtx.set(store);
+    return yield* createTimelineAbility();
+  });
+
+describe('createTimelineAbility', () => {
+  it('exposes the protocol and the tool its manifest promises', async () => {
+    const ability = await enable({ locale: 'en-GB' });
+    expect(ability.manifest.protocol.name).toBe('timeline_chronology');
+    // Note the asymmetry: AbilitySetup.tools is a name→Tool RECORD going in,
+    // and defineAbility normalises it to an ARRAY on the runtime Ability. The
+    // record's keys must equal manifest.protocol.tools as a set, which is what
+    // guarantees the catalog's Tools: line matches what can be dispatched.
+    expect(ability.tools.map((t) => t.name)).toEqual(['build_timeline']);
+  });
+
+  it('refuses to start without a locale', async () => {
+    // 03/04/24 is 3 April under en-GB and 4 March under en-US. A default would
+    // make a chronology silently wrong by a year; failing here is far cheaper.
+    await expect(enable({})).rejects.toThrow(/locale/);
+    await expect(enable(null)).rejects.toThrow(/locale/);
+  });
+
+  it('names the consequence in the error, not just the missing key', async () => {
+    await expect(enable({})).rejects.toThrow(/differs by a year|03\/04\/24/);
+  });
+
+  it('renders a skill carrying the configured definition of an event', async () => {
+    const criteria = 'Only decisions, notices and statutory deadlines.';
+    const ability = await enable({ locale: 'en-GB', criteria });
+    const skill =
+      typeof ability.skill === 'function'
+        ? ability.skill({
+            agentCount: 1,
+            siblingTasks: [],
+            maxTurns: 8,
+            date: '2026-08-17',
+            taskIndex: 0,
+          })
+        : ability.skill;
+    // The whole reason the skill is a function: `criteria` is not part of
+    // AgentRenderCtx, so a string template would render it empty and lose the
+    // domain's definition of an event without any error.
+    expect(skill).toContain(criteria);
+  });
+
+  it('falls back to a generic definition rather than an empty one', async () => {
+    const ability = await enable({ locale: 'en-GB' });
+    const skill =
+      typeof ability.skill === 'function'
+        ? ability.skill({
+            agentCount: 1,
+            siblingTasks: [],
+            maxTurns: 8,
+            date: '2026-08-17',
+            taskIndex: 0,
+          })
+        : ability.skill;
+    expect(skill).toMatch(/WHAT COUNTS AS AN EVENT:\s*\S/);
+  });
+
+  it('never contains the boundary marker the framework prepends', async () => {
+    const ability = await enable({ locale: 'en-GB' });
+    const skill =
+      typeof ability.skill === 'function'
+        ? ability.skill({
+            agentCount: 1,
+            siblingTasks: [],
+            maxTurns: 8,
+            date: '2026-08-17',
+            taskIndex: 0,
+          })
+        : ability.skill;
+    expect(skill).not.toContain('Apply the **');
+  });
+
+  it('declares a useWhen the planner will accept', async () => {
+    const ability = await enable({ locale: 'en-GB' });
+    const useWhen = ability.manifest.protocol.useWhen;
+    // 280 is enforced at import by defineAbility; the spec's own draft was 318
+    // and would have thrown before any of this ran.
+    expect(useWhen.length).toBeLessThanOrEqual(280);
+    expect(useWhen).not.toMatch(/[\n\r]/);
+  });
+});

--- a/packages/abilities/timeline/test/dates.test.ts
+++ b/packages/abilities/timeline/test/dates.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Date resolution — and, more importantly, date refusal.
+ *
+ * The fixtures below are not invented. They are what chrono-node 2.10.1 actually
+ * returns, measured against a 2019-03-14 anchor: it answers "the end of
+ * February" with 1 February and "the 2nd Tuesday of November" with a Tuesday in
+ * March, by matching a fragment and discarding the qualifier. Both answers are
+ * well-formed and wrong, which is the combination that reaches a filing.
+ *
+ * So the tests that matter here are the ones asserting we DON'T produce a date.
+ */
+import { describe, it, expect } from 'vitest';
+import { createDateResolver, type DateAnchor, type DateExpr } from '../src/dates';
+
+const GB = createDateResolver('en-GB');
+const US = createDateResolver('en-US');
+const DOC: DateAnchor[] = [{ id: 'doc', value: '2019-03-14' }];
+
+describe('partial dates stay partial', () => {
+  it('"March 2024" is a month, not the first of the month', () => {
+    // The single most damaging silent behaviour: inventing a day the source
+    // never stated, then sorting a chronology by it.
+    const r = GB.resolve({ kind: 'partial', text: 'March 2024', year: 2024, month: 3 }, []);
+    expect(r.ok && r.date).toEqual({
+      value: '2024-03',
+      granularity: 'month',
+      basis: 'explicit',
+    });
+  });
+
+  it('"in 2024" is a year — chrono cannot parse it at all', () => {
+    // Verified: chrono.parse('in 2024') returns []. Decomposed extraction is
+    // what rescues it; a raw parser would drop the event entirely.
+    const r = GB.resolve({ kind: 'partial', text: 'in 2024', year: 2024 }, []);
+    expect(r.ok && r.date).toEqual({
+      value: '2024',
+      granularity: 'year',
+      basis: 'explicit',
+    });
+  });
+});
+
+describe('qualified expressions are computed, never parsed', () => {
+  it('"the end of February" 2024 is the 29th — a leap year', () => {
+    // The spec said "the 28th" for two revisions. February has 29 days in 2024,
+    // and a chronology that is off by a day is a chronology that is wrong.
+    const r = GB.resolve(
+      { kind: 'qualified', text: 'the end of February', month: 2, year: 2024, qualifier: 'end-of' },
+      [],
+    );
+    expect(r.ok && r.date.value).toBe('2024-02-29');
+  });
+
+  it('"the end of February" 2019 is the 28th', () => {
+    const r = GB.resolve(
+      { kind: 'qualified', text: 'the end of February', month: 2, year: 2019, qualifier: 'end-of' },
+      [],
+    );
+    expect(r.ok && r.date.value).toBe('2019-02-28');
+  });
+
+  it('takes its year from an anchor when the source omitted one', () => {
+    const r = GB.resolve(
+      { kind: 'qualified', text: 'end of February', month: 2, anchorRef: 'doc', qualifier: 'end-of' },
+      DOC,
+    );
+    expect(r.ok && r.date.value).toBe('2019-02-28');
+  });
+
+  it('refuses when neither a year nor an anchor supplies one', () => {
+    const r = GB.resolve(
+      { kind: 'qualified', text: 'end of February', month: 2, qualifier: 'end-of' },
+      [],
+    );
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toBe('incomplete-qualifier');
+  });
+
+  it('"early 2024" stays a year rather than becoming a day', () => {
+    const r = GB.resolve({ kind: 'qualified', text: 'early 2024', year: 2024, qualifier: 'start-of' }, []);
+    expect(r.ok && r.date).toMatchObject({ value: '2024', granularity: 'year' });
+  });
+});
+
+describe('relative expressions resolve against their anchor, never against now', () => {
+  it('"three days later" against a 2019 document lands in 2019', () => {
+    // The whole reason chrono was chosen over Sugar: an arbitrary reference
+    // date. Anchored to now this would land in the present and look plausible.
+    const r = GB.resolve(
+      { kind: 'relative', text: 'three days later', anchorRef: 'doc', n: 3, unit: 'day', dir: 'after' },
+      DOC,
+    );
+    expect(r.ok && r.date).toMatchObject({
+      value: '2019-03-17',
+      basis: 'relative',
+      anchorId: 'doc',
+    });
+  });
+
+  it('counts backwards for "before"', () => {
+    const r = GB.resolve(
+      { kind: 'relative', text: 'two weeks earlier', anchorRef: 'doc', n: 2, unit: 'week', dir: 'before' },
+      DOC,
+    );
+    expect(r.ok && r.date.value).toBe('2019-02-28');
+  });
+
+  it('refuses when the anchor was never established', () => {
+    // An unanchored relative date is unplaceable. Guessing one is how a
+    // chronology acquires a confident wrong row.
+    const r = GB.resolve(
+      { kind: 'relative', text: 'three days later', anchorRef: 'nope', n: 3, unit: 'day', dir: 'after' },
+      DOC,
+    );
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toBe('missing-anchor');
+  });
+});
+
+describe('absolute expressions are coverage-checked', () => {
+  it('accepts a date that fills its phrase', () => {
+    const r = GB.resolve({ kind: 'absolute', text: '18 March 2024' }, []);
+    expect(r.ok && r.date).toMatchObject({ value: '2024-03-18', granularity: 'day' });
+  });
+
+  it('REFUSES "the end of February" rather than answering 1 February', () => {
+    // chrono matches only "February" here and returns the 1st. This is the
+    // measured failure the coverage check exists for.
+    const r = GB.resolve({ kind: 'absolute', text: 'the end of February' }, DOC);
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toBe('partial-parse');
+    expect(!r.ok && r.detail).toMatch(/understood/);
+  });
+
+  it('REFUSES "the 2nd Tuesday of November" rather than answering a Tuesday in March', () => {
+    const r = GB.resolve({ kind: 'absolute', text: 'the 2nd Tuesday of November' }, DOC);
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toBe('partial-parse');
+  });
+
+  it('reports no-parse distinctly from partial-parse', () => {
+    // A developer debugging a gap needs to know whether the parser saw nothing
+    // or saw a fragment — different causes, different fixes.
+    const r = GB.resolve({ kind: 'absolute', text: 'shortly afterwards' }, []);
+    expect(r.ok).toBe(false);
+    expect(!r.ok && r.reason).toBe('no-parse');
+  });
+
+  it('never reports a precision the source did not state', () => {
+    const r = GB.resolve({ kind: 'absolute', text: 'March 2024' }, []);
+    expect(r.ok && r.date.granularity).toBe('month');
+    expect(r.ok && r.date.value).toBe('2024-03');
+  });
+});
+
+describe('locale is load-bearing', () => {
+  it('reads 03/04/24 a year apart under en-GB and en-US', () => {
+    // This is why locale is required with no default: the same eight characters
+    // are 3 April or 4 March, and nothing downstream can tell which was meant.
+    const gb = GB.resolve({ kind: 'absolute', text: '03/04/24' }, []);
+    const us = US.resolve({ kind: 'absolute', text: '03/04/24' }, []);
+    expect(gb.ok && gb.date.value).toBe('2024-04-03');
+    expect(us.ok && us.date.value).toBe('2024-03-04');
+  });
+});

--- a/packages/abilities/timeline/test/invariants.test.ts
+++ b/packages/abilities/timeline/test/invariants.test.ts
@@ -1,0 +1,285 @@
+/**
+ * T1–T5 against fixtures designed to fail in one phase each.
+ *
+ * A fixture that exercises everything tells you nothing when it breaks. Each of
+ * these isolates a phase by construction, so a red test names its own cause:
+ *
+ *   span-boundary   a supporting sentence crossing a page break
+ *   partial-parse   the three date expressions chrono gets confidently wrong
+ *   oversized-doc   one long document beside several short ones
+ *   malformed-doc   evidence whose regions are unusable
+ *
+ * The extractor is injected, so every phase below runs without a model. That is
+ * deliberate: invariants that need weights are invariants nobody runs.
+ */
+import { describe, it, expect } from 'vitest';
+import { run } from 'effection';
+import type { EvidenceDocument } from '@lloyal-labs/lloyal-agents';
+import { BuildTimelineTool, type ExtractedEvent } from '../src/tools/build-timeline';
+import type { TimelineResult } from '../src/types';
+import {
+  T1_segmentsAccountedFor,
+  T2_spansResolve,
+  T3_citedSpanCarriesTheDateText,
+  T4_relativeDatesNameTheirAnchor,
+  T5_precisionIsNotInvented,
+  T5b_datedAndUnresolvedAreDisjoint,
+  formatResult,
+  type TimelineRun,
+} from './predicates';
+
+/** Paginate text into regions of `per` chars — page 1 ¶1, ¶2, page 2 ¶1, … */
+function paginate(id: string, text: string, per = 60, createdAt?: string): EvidenceDocument {
+  const regions = [];
+  for (let i = 0, n = 0; i < text.length; i += per, n++) {
+    regions.push({
+      span: [i, Math.min(i + per, text.length)] as [number, number],
+      locator: {
+        kind: 'page' as const,
+        page: Math.floor(n / 2) + 1,
+        para: (n % 2) + 1,
+      },
+    });
+  }
+  return { id, text, regions, ...(createdAt ? { metadata: { createdAt } } : {}) };
+}
+
+async function build(
+  documents: EvidenceDocument[],
+  events: (segText: string, docId: string) => ExtractedEvent[],
+  segmentChars = 200,
+): Promise<TimelineRun> {
+  const tool = new BuildTimelineTool({
+    locale: 'en-GB',
+    segmentChars,
+    extract: function* (segText, docId) {
+      return events(segText, docId);
+    },
+  });
+  // `run()` returns a Task — awaiting it is the difference between the result
+  // and a pending promise every assertion then reads as undefined.
+  const result = (await run(function* () {
+    return (yield* tool.execute({ documents })) as TimelineResult;
+  })) as TimelineResult;
+  return { documents, result, segmentChars };
+}
+
+/** An event pointing at `needle` within the segment, dated by `dateExpr`. */
+function eventAt(
+  segText: string,
+  needle: string,
+  dateExpr: ExtractedEvent['dateExpr'],
+): ExtractedEvent[] {
+  const at = segText.indexOf(needle);
+  if (at < 0) return [];
+  return [
+    {
+      description: `event: ${needle}`,
+      span: [at, at + needle.length],
+      quote: needle,
+      dateExpr,
+      temporalStatus: 'occurred',
+      epistemicStatus: 'recorded',
+      polarity: 'affirmed',
+    },
+  ];
+}
+
+describe('fixture: span-boundary — a citation crossing a page break', () => {
+  // The sentence starts in page 1 ¶2 and finishes in page 2 ¶1. A citation
+  // naming only where it began would send a reader to the wrong page.
+  const text =
+    'A'.repeat(100) + 'the inspection occurred on 18 March 2024 and passed' + 'B'.repeat(60);
+  const doc = paginate('bundle', text, 60);
+
+  const mk = () =>
+    build([doc], (segText) =>
+      eventAt(segText, 'the inspection occurred on 18 March 2024', {
+        kind: 'absolute',
+        text: '18 March 2024',
+      }),
+    );
+
+  it('cites every region the span touches', async () => {
+    const r = await mk();
+    const support = r.result.rows[0]?.assertions[0]?.supports[0];
+    expect(support).toBeDefined();
+    expect(support!.cites.length).toBeGreaterThan(1);
+  });
+
+  it('T2 — spans resolve and cites match the document', async () => {
+    const r = await mk();
+    const t2 = T2_spansResolve(r);
+    expect(t2.ok, formatResult('T2', t2)).toBe(true);
+  });
+
+  it('T3 — the cited span contains the date text it was dated from', async () => {
+    const r = await mk();
+    const t3 = T3_citedSpanCarriesTheDateText(r, () => '18 March 2024');
+    expect(t3.ok, formatResult('T3', t3)).toBe(true);
+  });
+});
+
+describe('fixture: partial-parse — dates chrono gets confidently wrong', () => {
+  const text =
+    'The review closed at the end of February and the hearing was listed for ' +
+    'the 2nd Tuesday of November, with the levy applying in 2024.';
+  const doc = paginate('notice', text, 50, '2019-03-14');
+
+  it('refuses the fragments rather than dating them wrongly', async () => {
+    // Passed as `absolute` on purpose: this is what reaches the resolver when
+    // extraction has NOT decomposed, and the coverage check is the backstop.
+    const r = await build([doc], (segText) => [
+      ...eventAt(segText, 'the end of February', {
+        kind: 'absolute',
+        text: 'the end of February',
+      }),
+      ...eventAt(segText, 'the 2nd Tuesday of November', {
+        kind: 'absolute',
+        text: 'the 2nd Tuesday of November',
+      }),
+    ]);
+    // Both are unresolved, not dated — visible gaps rather than wrong rows.
+    expect(r.result.rows).toHaveLength(0);
+    expect(r.result.unresolved.length).toBeGreaterThan(0);
+    const t5b = T5b_datedAndUnresolvedAreDisjoint(r);
+    expect(t5b.ok, formatResult('T5b', t5b)).toBe(true);
+  });
+
+  it('dates them correctly once decomposed, and keeps the precision honest', async () => {
+    const r = await build([doc], (segText) => [
+      ...eventAt(segText, 'the end of February', {
+        kind: 'qualified',
+        text: 'the end of February',
+        month: 2,
+        year: 2024,
+        qualifier: 'end-of',
+      }),
+      ...eventAt(segText, 'in 2024', { kind: 'partial', text: 'in 2024', year: 2024 }),
+    ]);
+    const values = r.result.rows.map((row) => row.date?.value).sort();
+    // The leap year, and a year that stays a year.
+    expect(values).toEqual(['2024', '2024-02-29']);
+    const t5 = T5_precisionIsNotInvented(r);
+    expect(t5.ok, formatResult('T5', t5)).toBe(true);
+  });
+});
+
+describe('fixture: oversized-doc — one long document beside short ones', () => {
+  // Every paragraph is DISTINCT. Repeated text would hide the bug this fixture
+  // exists for: with identical paragraphs, a segment-local offset lands on the
+  // same words as the correct offset and the identity check cannot tell them
+  // apart. Uniqueness is what makes a misplaced span visible.
+  const paras = Array.from(
+    { length: 60 },
+    (_, i) => `Entry ${String(i).padStart(3, '0')}: the officer recorded item ${i}.`,
+  );
+  const long = paginate('transcript', paras.join('\n\n'), 80);
+  const shorts = [1, 2, 3].map((n) => paginate(`memo-${n}`, `Short memo ${n}. `.repeat(3), 40));
+
+  const mk = () =>
+    build([long, ...shorts], (segText) => {
+      // Target the LAST entry in each segment, so its offset is far from zero
+      // and a dropped segment-base is unmistakable.
+      const m = [...segText.matchAll(/Entry \d{3}/g)].pop();
+      if (!m) return eventAt(segText, 'Short memo', { kind: 'partial', text: '2024', year: 2024 });
+      return eventAt(segText, m[0], { kind: 'partial', text: '2024', year: 2024 });
+    });
+
+  it('T1 — every segment across every document is accounted for', async () => {
+    const r = await mk();
+    // The failure this catches: a wave loop that drops the tail of a long
+    // document produces a chronology whose gap is invisible.
+    const t1 = T1_segmentsAccountedFor(r);
+    expect(t1.ok, formatResult('T1', t1)).toBe(true);
+    expect(r.result.segmentsSeen).toBeGreaterThan(1);
+  });
+
+  it('T2 — offsets stay document-absolute across many segments', async () => {
+    const r = await mk();
+    // Segment 20's local offset must not escape as a document offset.
+    const t2 = T2_spansResolve(r);
+    expect(t2.ok, formatResult('T2', t2)).toBe(true);
+  });
+});
+
+describe('fixture: relative dates and their anchors', () => {
+  const text = 'The notice issued. Three days later the objection was lodged.';
+  const doc = paginate('assessment', text, 40, '2019-03-14');
+
+  it('T4 — a relative row names an anchor that exists', async () => {
+    const r = await build([doc], (segText) =>
+      eventAt(segText, 'the objection was lodged', {
+        kind: 'relative',
+        text: 'Three days later',
+        anchorRef: 'assessment:document',
+        n: 3,
+        unit: 'day',
+        dir: 'after',
+      }),
+    );
+    expect(r.result.rows[0]?.date?.value).toBe('2019-03-17');
+    const t4 = T4_relativeDatesNameTheirAnchor(r, new Set(['assessment:document']));
+    expect(t4.ok, formatResult('T4', t4)).toBe(true);
+  });
+
+  it('an unestablished anchor sends the row to unresolved, not to today', async () => {
+    const r = await build([doc], (segText) =>
+      eventAt(segText, 'the objection was lodged', {
+        kind: 'relative',
+        text: 'Three days later',
+        anchorRef: 'nowhere',
+        n: 3,
+        unit: 'day',
+        dir: 'after',
+      }),
+    );
+    expect(r.result.rows).toHaveLength(0);
+    expect(r.result.unresolved).toHaveLength(1);
+  });
+});
+
+describe('fixture: malformed-doc — evidence that cannot be cited', () => {
+  it('reports the document as unprocessed rather than dropping it', async () => {
+    const bad: EvidenceDocument = {
+      id: 'scrambled',
+      text: 'x'.repeat(50),
+      // Out of order: citations from this would be quietly wrong.
+      regions: [
+        { span: [20, 30], locator: { kind: 'page', page: 2, para: 1 } },
+        { span: [0, 10], locator: { kind: 'page', page: 1, para: 1 } },
+      ],
+    };
+    const good = paginate('clean', 'The event occurred. '.repeat(4), 40);
+    const r = await build([bad, good], (segText) =>
+      eventAt(segText, 'The event occurred', { kind: 'partial', text: '2024', year: 2024 }),
+    );
+
+    expect(r.result.unprocessed.map((u) => u.docId)).toContain('scrambled');
+    // And the good document still produced rows — one bad file does not cost
+    // the rest of the matter.
+    expect(r.result.rows.length).toBeGreaterThan(0);
+    const t1 = T1_segmentsAccountedFor(r);
+    expect(t1.ok, formatResult('T1', t1)).toBe(true);
+  });
+
+  it('an extractor that throws costs its segment, not the run', async () => {
+    const doc = paginate('mixed', 'Alpha event. '.repeat(30), 50);
+    const tool = new BuildTimelineTool({
+      locale: 'en-GB',
+      segmentChars: 100,
+      extract: function* (segText) {
+        if (segText.includes('Alpha')) throw new Error('extractor exploded');
+        return [];
+      },
+    });
+    const result = (await run(function* () {
+      return (yield* tool.execute({ documents: [doc] })) as TimelineResult;
+    })) as TimelineResult;
+
+    expect(result.unprocessed.length).toBeGreaterThan(0);
+    expect(result.unprocessed[0].reason).toMatch(/exploded/);
+    // Never thrown out of execute(): dag halts a whole graph on a throw.
+    expect(result.segmentsSeen).toBeGreaterThan(0);
+  });
+});

--- a/packages/abilities/timeline/test/predicates.ts
+++ b/packages/abilities/timeline/test/predicates.ts
@@ -1,0 +1,237 @@
+/**
+ * T1–T5 — properties that hold on every run, and fail in exactly one phase.
+ *
+ * A wrong chronology has five plausible authors: segmentation, extraction, the
+ * date adapter, reconciliation, support judging. Accuracy metrics say the output
+ * is wrong and never say which produced it, and with agents forking off a shared
+ * spine, re-running does not reliably reproduce the same wrongness.
+ *
+ * So these are properties rather than measurements. They need no gold labels,
+ * they run on any corpus a developer points at, and each is chosen so that when
+ * it goes red, one phase is implicated and the others are not.
+ *
+ * Convention follows packages/agents/test/invariants/predicates.ts: `ok`/`fail`
+ * are module-private, predicates take the run and return a PredicateResult, and
+ * `formatResult` renders violations for expect() output.
+ */
+
+import type { EvidenceDocument } from '@lloyal-labs/lloyal-agents';
+import { resolveCites } from '@lloyal-labs/lloyal-agents';
+import { segmentDocument } from '../src/segment';
+import type { TimelineResult, TimelineRow } from '../src/types';
+
+export interface Violation {
+  invariant: string;
+  detail: string;
+}
+
+export interface PredicateResult {
+  ok: boolean;
+  violations: Violation[];
+}
+
+function ok(): PredicateResult {
+  return { ok: true, violations: [] };
+}
+
+function fail(invariant: string, detail: string): PredicateResult {
+  return { ok: false, violations: [{ invariant, detail }] };
+}
+
+/** A run's inputs and output — the sole input to every predicate below. */
+export interface TimelineRun {
+  documents: EvidenceDocument[];
+  result: TimelineResult;
+  /** Segment size the run used, so T1 can recompute the expected count. */
+  segmentChars?: number;
+}
+
+const allRows = (r: TimelineResult): TimelineRow[] => [...r.rows, ...r.unresolved];
+
+/**
+ * T1 — every segment is accounted for.
+ *
+ * Localises: the wave loop. A segment that is silently skipped produces a
+ * chronology with a hole nobody can see, which is the failure that makes the
+ * whole artifact untrustworthy. Coverage is checkable without gold labels
+ * because segmentation is deterministic.
+ */
+export function T1_segmentsAccountedFor(run: TimelineRun): PredicateResult {
+  const expected = run.documents.reduce(
+    (n, doc) => n + segmentDocument(doc, run.segmentChars).length,
+    0,
+  );
+  const seen = run.result.segmentsSeen;
+  const failedDocs = new Set(
+    run.result.unprocessed.filter((u) => u.span === undefined).map((u) => u.docId),
+  );
+  // A document rejected before segmentation contributes no segments.
+  const expectedAfterRejects = run.documents.reduce(
+    (n, doc) =>
+      failedDocs.has(doc.id) ? n : n + segmentDocument(doc, run.segmentChars).length,
+    0,
+  );
+  if (seen !== expectedAfterRejects) {
+    return fail(
+      'T1',
+      `run reports ${seen} segments seen, but the documents partition into ` +
+        `${expectedAfterRejects} (${expected} before ${failedDocs.size} rejected document(s))`,
+    );
+  }
+  return ok();
+}
+
+/**
+ * T2 — every span is real and addressable.
+ *
+ * Localises: the locator seam and the segment→document offset conversion. A span
+ * outside its document, or one landing in no region, is a citation a reader
+ * cannot open — and offset arithmetic is exactly where a segment-local index
+ * escapes into a document-level field.
+ */
+export function T2_spansResolve(run: TimelineRun): PredicateResult {
+  const byId = new Map(run.documents.map((d) => [d.id, d]));
+  for (const row of allRows(run.result)) {
+    for (const assertion of row.assertions) {
+      for (const support of assertion.supports) {
+        const doc = byId.get(support.docId);
+        if (!doc) {
+          return fail('T2', `support cites unknown document ${JSON.stringify(support.docId)}`);
+        }
+        const [start, end] = support.span;
+        if (start < 0 || end > doc.text.length || end <= start) {
+          return fail(
+            'T2',
+            `span [${start}, ${end}) is outside ${JSON.stringify(support.docId)} ` +
+              `(length ${doc.text.length}) — a segment-local offset that escaped conversion`,
+          );
+        }
+        const expected = resolveCites(doc, support.span);
+        if (JSON.stringify(support.cites) !== JSON.stringify(expected)) {
+          return fail(
+            'T2',
+            `cites for [${start}, ${end}) disagree with the document's regions`,
+          );
+        }
+        // The check that catches an in-bounds WRONG span. A segment-local offset
+        // that escaped conversion still lands inside the document and still
+        // resolves to a region; only the text betrays it.
+        const actual = doc.text.slice(start, end);
+        if (actual !== support.quote) {
+          return fail(
+            'T2',
+            `span [${start}, ${end}) in ${JSON.stringify(support.docId)} reads ` +
+              `${JSON.stringify(actual.slice(0, 50))} but the extractor quoted ` +
+              `${JSON.stringify(support.quote.slice(0, 50))} — the offset is in ` +
+              `bounds and points at the wrong text`,
+          );
+        }
+      }
+    }
+  }
+  return ok();
+}
+
+/**
+ * T3 — the cited span carries the words the date came from.
+ *
+ * Localises: extraction. A row dated from text outside its own citation is
+ * unverifiable by the reader it was produced for — the span may be plausible and
+ * the date may be right, and neither can be checked.
+ */
+export function T3_citedSpanCarriesTheDateText(
+  run: TimelineRun,
+  dateTextOf: (rowId: string) => string | undefined,
+): PredicateResult {
+  const byId = new Map(run.documents.map((d) => [d.id, d]));
+  for (const row of allRows(run.result)) {
+    const dateText = dateTextOf(row.id);
+    if (!dateText) continue;
+    const support = row.assertions[0]?.supports[0];
+    if (!support) {
+      return fail('T3', `row ${row.id} has no support to check the date text against`);
+    }
+    const doc = byId.get(support.docId);
+    if (!doc) continue;
+    const cited = doc.text.slice(...support.span);
+    if (!cited.includes(dateText)) {
+      return fail(
+        'T3',
+        `row ${row.id} was dated from ${JSON.stringify(dateText)}, which does not ` +
+          `appear in its cited span ${JSON.stringify(cited.slice(0, 60))}`,
+      );
+    }
+  }
+  return ok();
+}
+
+/**
+ * T4 — a relative date names an anchor that exists.
+ *
+ * Localises: the date adapter and anchor discovery. `basis: 'relative'` without
+ * a resolvable `anchorId` means the offset was measured from something the run
+ * cannot name — which is indistinguishable, in the output, from measuring it
+ * against today.
+ */
+export function T4_relativeDatesNameTheirAnchor(
+  run: TimelineRun,
+  anchorIds: ReadonlySet<string>,
+): PredicateResult {
+  for (const row of run.result.rows) {
+    if (row.date?.basis !== 'relative') continue;
+    if (!row.date.anchorId) {
+      return fail('T4', `row ${row.id} is relative but names no anchor`);
+    }
+    if (!anchorIds.has(row.date.anchorId)) {
+      return fail(
+        'T4',
+        `row ${row.id} is relative to ${JSON.stringify(row.date.anchorId)}, ` +
+          `which was never established`,
+      );
+    }
+  }
+  return ok();
+}
+
+/**
+ * T5 — no date claims precision the source did not give.
+ *
+ * Localises: the date adapter. `"March 2024"` becoming `2024-03-01` invents a
+ * day, and once written nothing downstream can tell it was invented — it sorts,
+ * renders and reads exactly like a stated one.
+ */
+export function T5_precisionIsNotInvented(run: TimelineRun): PredicateResult {
+  const shape = { day: /^\d{4}-\d{2}-\d{2}$/, month: /^\d{4}-\d{2}$/, year: /^\d{4}$/ };
+  for (const row of run.result.rows) {
+    if (!row.date) continue;
+    const { value, granularity } = row.date;
+    if (!shape[granularity].test(value)) {
+      return fail(
+        'T5',
+        `row ${row.id} claims ${granularity} precision but its value is ` +
+          `${JSON.stringify(value)} — truncate to the precision actually known`,
+      );
+    }
+  }
+  return ok();
+}
+
+/** A row with a date is never also in `unresolved`, and vice versa. */
+export function T5b_datedAndUnresolvedAreDisjoint(run: TimelineRun): PredicateResult {
+  const dated = new Set(run.result.rows.map((r) => r.id));
+  for (const row of run.result.unresolved) {
+    if (dated.has(row.id)) {
+      return fail('T5b', `row ${row.id} appears in both rows and unresolved`);
+    }
+    if (row.date !== null) {
+      return fail('T5b', `row ${row.id} is in unresolved but carries a date`);
+    }
+  }
+  return ok();
+}
+
+/** Render a PredicateResult for expect() output. */
+export function formatResult(name: string, r: PredicateResult): string {
+  if (r.ok) return `${name}: ok`;
+  return `${name}: ${r.violations.map((v) => `[${v.invariant}] ${v.detail}`).join('; ')}`;
+}

--- a/packages/abilities/timeline/tsconfig.json
+++ b/packages/abilities/timeline/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    { "path": "../../sdk" },
+    { "path": "../../agents" },
+    { "path": "../../rig" }
+  ]
+}

--- a/packages/agents/src/evidence.ts
+++ b/packages/agents/src/evidence.ts
@@ -1,0 +1,163 @@
+/**
+ * Evidence provenance types — where a claim came from, precisely enough to open.
+ *
+ * A chunk tells you which file and roughly which lines. That is enough to
+ * retrieve, and not enough to cite: a paragraph can hold several assertions, and
+ * a professional acting on one of them needs the span that supports it, not the
+ * region that contains it. {@link EvidenceRegion} carries character offsets and a
+ * domain-specific locator, so an assertion can point at the sentence and the
+ * reader lands on the page.
+ *
+ * These live in `@lloyal-labs/lloyal-agents` for the reason {@link Chunk} does —
+ * ability factories and harness contexts refer to the shape without depending on
+ * rig's concrete loaders. The producers (loaders, OCR, transcript importers)
+ * belong in rig; the contract belongs here. Abstract type in agents, concrete
+ * factories in rig, the same split as `Source` and `Tool`.
+ *
+ * DELIBERATELY SERIALISABLE. An earlier draft modelled this as a callback —
+ * `locator(offset) => Cite` — which cannot cross a manifest boundary, cannot be
+ * persisted in an audit record, and cannot travel from a producing Ability to a
+ * consuming one. Regions are data so that a document assembled by one Ability is
+ * usable by another, and so an offset resolved today resolves the same way when
+ * someone re-opens the record.
+ *
+ * @packageDocumentation
+ * @category Contract
+ */
+
+/**
+ * A human-addressable position inside a source document.
+ *
+ * Open-ended by design: a transcript is addressed by speaker and timestamp, a
+ * paginated document by page and paragraph, and neither reduces to the other.
+ * Add a variant when a new evidence kind arrives; do not flatten them.
+ */
+export type Cite =
+  /** Paginated text — extracted markdown, PDFs once OCR lands. */
+  | { kind: 'page'; page: number; para: number }
+  /** Time-coded speech — consultation and hearing transcripts. */
+  | { kind: 'time'; speaker: string; tMs: number };
+
+/**
+ * One addressable stretch of a document.
+ *
+ * `confidence` is left undefined for exact text and populated by producers that
+ * infer position — OCR most obviously. A consumer that ignores it still behaves
+ * correctly on exact text, which is what lets OCR arrive later without touching
+ * anything downstream.
+ */
+export interface EvidenceRegion {
+  /**
+   * Half-open `[start, end)` character offsets into
+   * {@link EvidenceDocument.text}, in UTF-16 code units — i.e. plain JavaScript
+   * string indices, so `text.slice(...span)` is the region's text with no
+   * conversion. Half-open so adjacent regions share a boundary without
+   * overlapping.
+   */
+  span: [number, number];
+  locator: Cite;
+  /** 0–1 positional confidence. Undefined means exact. */
+  confidence?: number;
+}
+
+/**
+ * A document with enough structure to cite, not merely to read.
+ *
+ * INVARIANTS a producer must hold, and {@link assertWellFormedDocument} checks:
+ * regions are sorted by `span[0]`, non-overlapping, and within `text`. Gaps are
+ * permitted — a document may have unaddressable stretches (page furniture,
+ * silence between utterances) and an assertion falling entirely in a gap simply
+ * resolves to no cite, which is honest rather than fabricated.
+ */
+export interface EvidenceDocument {
+  id: string;
+  text: string;
+  /** Sorted by `span[0]`, non-overlapping. May not cover all of `text`. */
+  regions: EvidenceRegion[];
+  metadata?: {
+    /** When the document itself was created — the anchor for relative dates. */
+    createdAt?: string;
+    publishedAt?: string;
+  };
+}
+
+/**
+ * Every locator a span touches.
+ *
+ * Returns ALL intersecting regions rather than the one containing the start
+ * offset, because a supporting sentence routinely crosses a paragraph, a page,
+ * or a change of speaker — and a citation that named only where it began would
+ * send a reader to the wrong half of the evidence.
+ *
+ * Intersection is half-open on both sides: a span ending exactly where a region
+ * begins does not touch it.
+ *
+ * @param doc  The document the span indexes into
+ * @param span Half-open `[start, end)` offsets
+ * @returns Locators in document order; empty when the span lies wholly in a gap
+ */
+export function resolveCites(
+  doc: EvidenceDocument,
+  span: [number, number],
+): Cite[] {
+  const [start, end] = span;
+  if (end <= start) return [];
+  const out: Cite[] = [];
+  for (const region of doc.regions) {
+    const [rs, re] = region.span;
+    // Regions are sorted, so once one starts at or after the span's end,
+    // nothing later can intersect.
+    if (rs >= end) break;
+    if (re > start) out.push(region.locator);
+  }
+  return out;
+}
+
+/** Thrown by {@link assertWellFormedDocument}. */
+export class EvidenceDocumentError extends Error {
+  constructor(readonly documentId: string, detail: string) {
+    super(`EvidenceDocument ${JSON.stringify(documentId)}: ${detail}`);
+    this.name = 'EvidenceDocumentError';
+  }
+}
+
+/**
+ * Fail loudly on a malformed document, at the boundary where it enters.
+ *
+ * Every downstream guarantee — that a span resolves, that citations are in
+ * document order, that {@link resolveCites} can stop early — rests on the
+ * ordering invariant. A producer that emits regions out of order yields
+ * citations that are quietly wrong rather than absent, which is the failure mode
+ * this contract exists to prevent. Checking once on entry is cheaper than
+ * distrusting every read.
+ */
+export function assertWellFormedDocument(doc: EvidenceDocument): void {
+  let previousEnd = -1;
+  let previousStart = -1;
+  for (const [i, region] of doc.regions.entries()) {
+    const [start, end] = region.span;
+    if (!Number.isInteger(start) || !Number.isInteger(end)) {
+      throw new EvidenceDocumentError(doc.id, `region ${i} span is not integral`);
+    }
+    if (end <= start) {
+      throw new EvidenceDocumentError(doc.id, `region ${i} span is empty or inverted`);
+    }
+    if (start < 0 || end > doc.text.length) {
+      throw new EvidenceDocumentError(
+        doc.id,
+        `region ${i} span [${start}, ${end}) falls outside text of length ${doc.text.length}`,
+      );
+    }
+    if (start < previousStart) {
+      throw new EvidenceDocumentError(doc.id, `region ${i} is not sorted by span start`);
+    }
+    if (start < previousEnd) {
+      throw new EvidenceDocumentError(
+        doc.id,
+        `region ${i} overlaps the previous region (starts at ${start}, previous ended at ${previousEnd})`,
+      );
+    }
+    previousStart = start;
+    previousEnd = end;
+  }
+}

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -82,3 +82,5 @@ export { SERVICES } from './ability-types';
 export type { AbilityConfigStore } from './ability-config';
 export type { GrantStore } from './grant-store';
 export type { Resource, Chunk, ScoredChunk, ScoredResult, Reranker } from './chunk';
+export type { Cite, EvidenceRegion, EvidenceDocument } from './evidence';
+export { resolveCites, assertWellFormedDocument, EvidenceDocumentError } from './evidence';

--- a/packages/agents/test/evidence.test.ts
+++ b/packages/agents/test/evidence.test.ts
@@ -1,0 +1,173 @@
+/**
+ * The evidence contract — the seam every provenance-bearing Ability programs
+ * against, so its edges are asserted here rather than discovered by the second
+ * consumer.
+ *
+ * The crossing-regions case is the reason `resolveCites` returns a list. A
+ * supporting sentence routinely spans a paragraph break, a page break, or a
+ * change of speaker; a citation naming only where it began would send a reader
+ * to the wrong half of the evidence.
+ */
+import { describe, it, expect } from 'vitest';
+import * as fc from 'fast-check';
+import {
+  resolveCites,
+  assertWellFormedDocument,
+  EvidenceDocumentError,
+  type EvidenceDocument,
+  type EvidenceRegion,
+} from '../src/evidence';
+
+/** `[0,10) p1¶1 · [10,20) p1¶2 · [20,30) p2¶1`, with a gap at [30,40). */
+function paginated(text = 'x'.repeat(40)): EvidenceDocument {
+  return {
+    id: 'doc-1',
+    text,
+    regions: [
+      { span: [0, 10], locator: { kind: 'page', page: 1, para: 1 } },
+      { span: [10, 20], locator: { kind: 'page', page: 1, para: 2 } },
+      { span: [20, 30], locator: { kind: 'page', page: 2, para: 1 } },
+    ],
+  };
+}
+
+describe('resolveCites', () => {
+  it('returns every region a span touches, in document order', () => {
+    // A sentence running from paragraph 2 into the next page.
+    const cites = resolveCites(paginated(), [15, 25]);
+    expect(cites).toEqual([
+      { kind: 'page', page: 1, para: 2 },
+      { kind: 'page', page: 2, para: 1 },
+    ]);
+  });
+
+  it('spans wholly inside one region cite only that one', () => {
+    expect(resolveCites(paginated(), [11, 19])).toEqual([
+      { kind: 'page', page: 1, para: 2 },
+    ]);
+  });
+
+  it('treats boundaries as half-open on both sides', () => {
+    // [0,10) and [10,20) are adjacent, not overlapping. A span ending exactly
+    // where the next region starts must not cite it.
+    expect(resolveCites(paginated(), [0, 10])).toEqual([
+      { kind: 'page', page: 1, para: 1 },
+    ]);
+    expect(resolveCites(paginated(), [10, 11])).toEqual([
+      { kind: 'page', page: 1, para: 2 },
+    ]);
+  });
+
+  it('returns nothing for a span in an unaddressable gap', () => {
+    // Page furniture, silence between utterances — honest emptiness beats a
+    // fabricated locator.
+    expect(resolveCites(paginated(), [32, 38])).toEqual([]);
+  });
+
+  it('returns nothing for an empty or inverted span', () => {
+    expect(resolveCites(paginated(), [5, 5])).toEqual([]);
+    expect(resolveCites(paginated(), [9, 3])).toEqual([]);
+  });
+
+  it('addresses a transcript by speaker and timestamp', () => {
+    const doc: EvidenceDocument = {
+      id: 'hearing',
+      text: 'a'.repeat(30),
+      regions: [
+        { span: [0, 15], locator: { kind: 'time', speaker: 'Counsel', tMs: 0 } },
+        { span: [15, 30], locator: { kind: 'time', speaker: 'Witness', tMs: 8200 } },
+      ],
+    };
+    // An answer that begins inside the question's utterance cites both — which
+    // is exactly what a reader needs to see.
+    expect(resolveCites(doc, [14, 20])).toEqual([
+      { kind: 'time', speaker: 'Counsel', tMs: 0 },
+      { kind: 'time', speaker: 'Witness', tMs: 8200 },
+    ]);
+  });
+});
+
+describe('assertWellFormedDocument', () => {
+  it('accepts sorted, non-overlapping, in-bounds regions with gaps', () => {
+    expect(() => assertWellFormedDocument(paginated())).not.toThrow();
+  });
+
+  it('accepts a document with no regions', () => {
+    expect(() =>
+      assertWellFormedDocument({ id: 'empty', text: 'abc', regions: [] }),
+    ).not.toThrow();
+  });
+
+  it('rejects regions out of order', () => {
+    // Ordering is what lets resolveCites stop early and return citations in
+    // document order. Unsorted input yields quietly wrong citations.
+    const doc = paginated();
+    doc.regions = [doc.regions[1], doc.regions[0], doc.regions[2]];
+    expect(() => assertWellFormedDocument(doc)).toThrow(EvidenceDocumentError);
+  });
+
+  it('rejects overlapping regions', () => {
+    const doc = paginated();
+    doc.regions[1] = { span: [5, 20], locator: doc.regions[1].locator };
+    expect(() => assertWellFormedDocument(doc)).toThrow(/overlaps/);
+  });
+
+  it('rejects a span reaching past the text', () => {
+    const doc = paginated('short');
+    expect(() => assertWellFormedDocument(doc)).toThrow(/outside text/);
+  });
+
+  it('rejects an empty or inverted span', () => {
+    const doc = paginated();
+    doc.regions[0] = { span: [5, 5], locator: doc.regions[0].locator };
+    expect(() => assertWellFormedDocument(doc)).toThrow(/empty or inverted/);
+  });
+
+  it('names the document in the error, since documents arrive in bulk', () => {
+    const doc = paginated('short');
+    expect(() => assertWellFormedDocument(doc)).toThrow(/"doc-1"/);
+  });
+});
+
+describe('property: a well-formed document never mis-cites', () => {
+  const regionsArb = fc
+    .array(fc.integer({ min: 1, max: 8 }), { minLength: 1, maxLength: 12 })
+    .map((lengths) => {
+      // Build sorted, non-overlapping regions with occasional gaps.
+      const regions: EvidenceRegion[] = [];
+      let cursor = 0;
+      lengths.forEach((len, i) => {
+        cursor += i % 3 === 0 ? 1 : 0; // sprinkle gaps
+        regions.push({
+          span: [cursor, cursor + len],
+          locator: { kind: 'page', page: 1, para: i + 1 },
+        });
+        cursor += len;
+      });
+      return { regions, length: cursor + 2 };
+    });
+
+  it('every returned cite belongs to a region that truly intersects', () => {
+    fc.assert(
+      fc.property(
+        regionsArb,
+        fc.integer({ min: 0, max: 60 }),
+        fc.integer({ min: 0, max: 60 }),
+        ({ regions, length }, a, b) => {
+          const doc: EvidenceDocument = { id: 'p', text: 'x'.repeat(length), regions };
+          assertWellFormedDocument(doc);
+          const span: [number, number] = [Math.min(a, b), Math.max(a, b)];
+          const cites = resolveCites(doc, span);
+
+          // Recompute independently: a cite is legitimate iff its region
+          // half-open-overlaps the span.
+          const expected = regions
+            .filter((r) => r.span[0] < span[1] && r.span[1] > span[0])
+            .map((r) => r.locator);
+          expect(cites).toEqual(span[1] > span[0] ? expected : []);
+        },
+      ),
+      { numRuns: 30, seed: 42 },
+    );
+  });
+});

--- a/packages/rig/src/reranker.ts
+++ b/packages/rig/src/reranker.ts
@@ -1,6 +1,6 @@
 import { createContext } from "@lloyal-labs/lloyal.node";
 import { Rerank } from "@lloyal-labs/sdk";
-import type { SessionContext } from "@lloyal-labs/sdk";
+import type { SessionContext, RerankTask } from "@lloyal-labs/sdk";
 import { resource, call } from "effection";
 import type { Operation } from "effection";
 import type { Chunk, Reranker, ScoredResult } from "@lloyal-labs/lloyal-agents";
@@ -18,6 +18,12 @@ export interface RerankerLoadOpts {
   nCtx?: number;
   /** Decode batch size (default floor(nCtx / nSeqMax)). */
   nBatch?: number;
+  /**
+   * The scoring question, with its calibration fixtures. Defaults to
+   * retrieval relevance. A different task means a different instruction in
+   * the warm trunk, so it is bound here rather than per score() call.
+   */
+  task?: RerankTask;
 }
 
 /**
@@ -73,7 +79,7 @@ export function createReranker(
       typeV: 'q4_0',
     }));
     const rerank = yield* call(() =>
-      Rerank.create(ctx as unknown as SessionContext, { nSeqMax, nCtx }),
+      Rerank.create(ctx as unknown as SessionContext, { nSeqMax, nCtx, task: opts?.task }),
     );
 
     let disposed = false;

--- a/packages/sdk/src/Rerank.ts
+++ b/packages/sdk/src/Rerank.ts
@@ -6,17 +6,78 @@ const SYSTEM_PROMPT =
   'Judge whether the Document meets the requirements based on the Query ' +
   'and the Instruct provided. Note that the answer can only be "yes" or "no".';
 
-const USER_PREFIX =
-  '<Instruct>: Given a web search query, retrieve relevant passages that answer the query\n\n' +
-  '<Query>: ';
+/**
+ * A scoring question, with the fixtures and thresholds that make its answers
+ * mean something.
+ *
+ * The reranker is a pointwise instruction-following judge, not a similarity
+ * model: {@link SYSTEM_PROMPT} asks it to judge the Document against the Query
+ * *and the Instruct provided*, and the score is `logit("yes") − logit("no")`. So
+ * the criterion is a sentence, and changing the sentence changes the question
+ * the same weights answer — retrieval, entailment, support-for-a-claim, policy
+ * conformance.
+ *
+ * The instruction, its canaries and its thresholds travel together **as one
+ * unit** because they are only meaningful together. An instruction whose
+ * thresholds live elsewhere drifts silently: someone improves the wording, the
+ * calibrated threshold stays put, and the score quietly stops meaning what the
+ * gate assumes. `version` bumps when EITHER changes.
+ *
+ * BOUND AT CONSTRUCTION, never mutated. The instruction is prefilled once into
+ * the warm trunk (see the architecture note on {@link Rerank}) and lives for the
+ * instance's lifetime, so selecting a different task means a different
+ * `Rerank` — which is also a different `SessionContext`, since each instance
+ * takes exclusive decode ownership of its own.
+ *
+ * @category Rerank
+ */
+export interface RerankTask {
+  /** Stable identity for audit — e.g. `'retrieval/v1'`. */
+  id: string;
+  /** The `<Instruct>` line. Stated as the question, without the tag. */
+  instruction: string;
+  /**
+   * Boot fixtures for THIS question. The shipped pair is retrieval-shaped; a
+   * support or policy instruction reusing them would pass the boot gate while
+   * validating nothing, because the gate is only as good as its fixtures.
+   */
+  canary: {
+    query: string;
+    /** Must score positive under `instruction`. */
+    positive: string;
+    /** Must score negative under `instruction`. */
+    negative: string;
+    /**
+     * Minimum `positive − negative` logit gap. Asserts the SEPARATION, not the
+     * sign — a model that ranks both highly has not demonstrated it can tell
+     * them apart.
+     */
+    minGap: number;
+  };
+}
 
-// Boot canary fixtures — hardcoded to Qwen3-reranker semantics. If you swap
-// reranker models, re-run the calibration probe and update these fixtures.
-const CANARY_QUERY = 'What is the capital of France?';
-const CANARY_RELEVANT_DOC =
-  'Paris is the capital and most populous city of France.';
-const CANARY_IRRELEVANT_DOC =
-  'Photosynthesis converts carbon dioxide and water into glucose.';
+/**
+ * The default question: retrieval relevance, as every caller before task
+ * profiles existed. Unchanged wording, so existing behaviour is bit-identical.
+ */
+export const RETRIEVAL_TASK: RerankTask = {
+  id: 'retrieval/v1',
+  instruction:
+    'Given a web search query, retrieve relevant passages that answer the query',
+  // Hardcoded to Qwen3-reranker semantics. If you swap reranker models, re-run
+  // the calibration probe and update these fixtures.
+  canary: {
+    query: 'What is the capital of France?',
+    positive: 'Paris is the capital and most populous city of France.',
+    negative: 'Photosynthesis converts carbon dioxide and water into glucose.',
+    minGap: 1.0,
+  },
+};
+
+/** Render a task's instruction into the prompt prefix the trunk holds. */
+function userPrefixFor(task: RerankTask): string {
+  return `<Instruct>: ${task.instruction}\n\n<Query>: `;
+}
 
 // Sentinel strings used to discover segment boundaries inside the rendered
 // chat probe. Longer ASCII (not NUL bytes) survives tokenizer normalization;
@@ -80,6 +141,17 @@ export interface RerankOpts {
    * (`rerank:truncate`) or to a metric. Silent in the SDK by default.
    */
   onTruncate?: (event: RerankTruncation) => void;
+  /**
+   * The question this instance answers. Defaults to {@link RETRIEVAL_TASK},
+   * so existing callers are unchanged.
+   *
+   * Bound here rather than per call because the instruction is prefilled
+   * into the warm trunk once at construction: a task swap is a new
+   * instance, which is a new SessionContext. Two questions asked often
+   * therefore means two instances — each holding one sequence lease, not
+   * one model context each.
+   */
+  task?: RerankTask;
 }
 
 interface ProgressSink {
@@ -171,10 +243,10 @@ function channel<T>(onCancel?: () => void): {
  *
  * # Architecture
  *
- *   [SYSTEM][USER_PREFIX][QUERY][MID][DOC_i][SUFFIX][GEN_PROMPT]
+ *   [SYSTEM][<Instruct>][QUERY][MID][DOC_i][SUFFIX][GEN_PROMPT]
  *   └── permanent trunk ─┘ └── per-query branch ──┘ └─── per-chunk leaves ─┘
  *
- * - **trunk**: prefilled with the static [SYSTEM][USER_PREFIX] segment ONCE
+ * - **trunk**: prefilled with the task's [SYSTEM][<Instruct>] segment ONCE
  *   at `Rerank.create()`; lives for the instance lifetime. Warm KV is
  *   amortized across every score() via multi-tag KV survival.
  * - **queryBranch**: forked from trunk per score() call, prefilled with
@@ -235,6 +307,8 @@ export class Rerank {
   private _suffixTokens: number[];
   private _staticPrefix: number[];
   private _onTruncate?: (event: RerankTruncation) => void;
+  /** The question this instance was calibrated for. */
+  readonly task: RerankTask;
   private _inflight: Promise<void> = Promise.resolve();
   private _disposed = false;
 
@@ -249,7 +323,8 @@ export class Rerank {
     staticPrefix: number[],
     midTokens: number[],
     suffixTokens: number[],
-    onTruncate?: (event: RerankTruncation) => void,
+    onTruncate: ((event: RerankTruncation) => void) | undefined,
+    task: RerankTask,
   ) {
     this._ctx = ctx;
     this._store = store;
@@ -262,6 +337,7 @@ export class Rerank {
     this._midTokens = midTokens;
     this._suffixTokens = suffixTokens;
     this._onTruncate = onTruncate;
+    this.task = task;
   }
 
   /**
@@ -284,6 +360,8 @@ export class Rerank {
       );
     }
 
+    const task = opts?.task ?? RETRIEVAL_TASK;
+    const userPrefix = userPrefixFor(task);
     const nSeqMax = opts?.nSeqMax ?? 10;
     const nCtx = opts?.nCtx ?? ctx._storeKvPressure().nCtx;
 
@@ -312,7 +390,7 @@ export class Rerank {
         { role: 'system', content: SYSTEM_PROMPT },
         {
           role: 'user',
-          content: `${USER_PREFIX}${SENTINEL_Q}\n\n<Document>: ${SENTINEL_D}`,
+          content: `${userPrefix}${SENTINEL_Q}\n\n<Document>: ${SENTINEL_D}`,
         },
       ]),
       { addGenerationPrompt: true, enableThinking: false },
@@ -347,14 +425,14 @@ export class Rerank {
     // length. Exact-equality was too strict for the Qwen3-reranker template
     // (it drifts by ~3 tokens on the canary prompt, but the boot canary
     // still scores cleanly).
-    const canaryQueryTokens = await ctx.tokenize(CANARY_QUERY, false);
-    const canaryDocTokens = await ctx.tokenize(CANARY_RELEVANT_DOC, false);
+    const canaryQueryTokens = await ctx.tokenize(task.canary.query, false);
+    const canaryDocTokens = await ctx.tokenize(task.canary.positive, false);
     const canaryWhole = await ctx.formatChat(
       JSON.stringify([
         { role: 'system', content: SYSTEM_PROMPT },
         {
           role: 'user',
-          content: `${USER_PREFIX}${CANARY_QUERY}\n\n<Document>: ${CANARY_RELEVANT_DOC}`,
+          content: `${userPrefix}${task.canary.query}\n\n<Document>: ${task.canary.positive}`,
         },
       ]),
       { addGenerationPrompt: true, enableThinking: false },
@@ -401,6 +479,7 @@ export class Rerank {
         midTokens,
         suffixTokens,
         opts?.onTruncate,
+        task,
       );
 
       // Calibration gate 3: boot canary RELATIVE ordering.
@@ -418,21 +497,23 @@ export class Rerank {
       // scores → no consistent ordering), template drift (random scores) —
       // without false-positiving on aggressively-quantized models that
       // produce shifted-but-monotone score distributions.
-      const canaryScores = await r.scoreBatch(CANARY_QUERY, [
-        CANARY_RELEVANT_DOC,
-        CANARY_IRRELEVANT_DOC,
+      const canaryScores = await r.scoreBatch(task.canary.query, [
+        task.canary.positive,
+        task.canary.negative,
       ]);
       const gap = canaryScores[0] - canaryScores[1];
-      if (!(gap > 1.0)) {
+      if (!(gap > task.canary.minGap)) {
         throw new RerankCalibrationError(
-          `Boot canary failed: relevant pair scored ` +
-            `${canaryScores[0].toFixed(3)}, irrelevant pair scored ` +
-            `${canaryScores[1].toFixed(3)} (gap=${gap.toFixed(3)}, ` +
-            `expected > 1.0). Possible causes: yes/no token id swap, ` +
-            `reranker model swap, or chat template drift. ` +
-            `Canary pair: query=${JSON.stringify(CANARY_QUERY)}, ` +
-            `relevant=${JSON.stringify(CANARY_RELEVANT_DOC)}, ` +
-            `irrelevant=${JSON.stringify(CANARY_IRRELEVANT_DOC)}.`,
+          `Boot canary failed for task ${JSON.stringify(task.id)}: ` +
+            `positive scored ${canaryScores[0].toFixed(3)}, negative scored ` +
+            `${canaryScores[1].toFixed(3)} (gap=${gap.toFixed(3)}, expected > ` +
+            `${task.canary.minGap}). Possible causes: yes/no token id swap, ` +
+            `reranker model swap, chat template drift — or fixtures that do ` +
+            `not exercise this instruction. ` +
+            `Instruct: ${JSON.stringify(task.instruction)}. ` +
+            `Canary: query=${JSON.stringify(task.canary.query)}, ` +
+            `positive=${JSON.stringify(task.canary.positive)}, ` +
+            `negative=${JSON.stringify(task.canary.negative)}.`,
         );
       }
 

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -2,8 +2,8 @@ export { Branch, BranchSampleError } from './Branch';
 export type { ForkOpts } from './Branch';
 export { BranchStore } from './BranchStore';
 export { Session } from './Session';
-export { Rerank, RerankCalibrationError, RerankInternalError } from './Rerank';
-export type { RerankOpts, RerankTruncation } from './Rerank';
+export { Rerank, RerankCalibrationError, RerankInternalError, RETRIEVAL_TASK } from './Rerank';
+export type { RerankOpts, RerankTruncation, RerankTask } from './Rerank';
 export { buildUserDelta, buildAssistantDelta, buildToolResultDelta, buildTurnDelta } from './deltas';
 export type { DeltaOpts } from './deltas';
 

--- a/packages/sdk/test/rerank-task.test.ts
+++ b/packages/sdk/test/rerank-task.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Task profiles — the instruction, its fixtures and its threshold as one unit.
+ *
+ * The reranker is a pointwise instruction-following judge, so the criterion is a
+ * sentence and changing the sentence changes the question the same weights
+ * answer. That makes one thing dangerous: an instruction whose calibration lives
+ * somewhere else. Someone improves the wording, the threshold stays put, and the
+ * score quietly stops meaning what the gate assumes.
+ *
+ * These assert the coupling — a profile carries its own canaries, and the boot
+ * gate is only as good as those fixtures. `Rerank.create` needs a real model, so
+ * what is testable here is the profile contract and the prompt it produces;
+ * the gate itself is exercised in the integration reranker suite.
+ */
+import { describe, it, expect } from 'vitest';
+import { RETRIEVAL_TASK, type RerankTask } from '../src/Rerank';
+
+describe('RETRIEVAL_TASK — the default, unchanged', () => {
+  it('reproduces the instruction every caller had before profiles existed', () => {
+    // Byte-identical to the old USER_PREFIX body. If this drifts, every
+    // existing threshold in the field silently changes meaning.
+    expect(RETRIEVAL_TASK.instruction).toBe(
+      'Given a web search query, retrieve relevant passages that answer the query',
+    );
+  });
+
+  it('carries the Qwen3-reranker canary pair and its 1.0 gap', () => {
+    expect(RETRIEVAL_TASK.canary.query).toBe('What is the capital of France?');
+    expect(RETRIEVAL_TASK.canary.positive).toMatch(/Paris is the capital/);
+    expect(RETRIEVAL_TASK.canary.negative).toMatch(/Photosynthesis/);
+    // Asserts SEPARATION, not sign: a model ranking both highly has not shown
+    // it can tell them apart.
+    expect(RETRIEVAL_TASK.canary.minGap).toBe(1.0);
+  });
+
+  it('is identified for audit', () => {
+    expect(RETRIEVAL_TASK.id).toBe('retrieval/v1');
+  });
+});
+
+describe('a task profile is self-contained', () => {
+  const supportTask: RerankTask = {
+    id: 'citation-support/v1',
+    instruction:
+      'Determine whether the passage supports the assertion as written, ' +
+      'including its actor, date and modality',
+    canary: {
+      query: 'The inspection occurred on 18 March 2024.',
+      positive: 'The inspection took place on 18 March 2024 and found no defects.',
+      // Same topic, same date, different modality — the distinction the whole
+      // chronology depends on, and one a relevance instruction would score high.
+      negative: 'The inspection was scheduled for 18 March 2024 but was cancelled.',
+      minGap: 1.0,
+    },
+  };
+
+  it('bundles instruction, fixtures and threshold so they cannot drift apart', () => {
+    // The property that matters: everything needed to interpret a score travels
+    // with the score's question.
+    expect(Object.keys(supportTask).sort()).toEqual(['canary', 'id', 'instruction']);
+    expect(supportTask.canary.minGap).toBeGreaterThan(0);
+  });
+
+  it('a support profile needs its own canaries, not retrieval-shaped ones', () => {
+    // Reusing RETRIEVAL_TASK's pair under a support instruction would pass the
+    // boot gate while validating nothing — Paris/photosynthesis exercises
+    // topical relevance, never whether a passage supports a claim.
+    expect(supportTask.canary.positive).not.toBe(RETRIEVAL_TASK.canary.positive);
+    expect(supportTask.canary.negative).not.toBe(RETRIEVAL_TASK.canary.negative);
+    // And its negative must be a near-miss rather than an unrelated topic:
+    // both canary documents mention the same inspection and the same date.
+    expect(supportTask.canary.negative).toMatch(/18 March 2024/);
+  });
+});


### PR DESCRIPTION
First slice of `lloyal/timeline` (spec: `docs/timeline-ability-spec.md` v0.4), plus the two platform seams it needs. Documents → segments → extracted assertions → dated rows with resolvable spans. **No reconciliation, no support judging yet** — those need the `citation-support/v1` profile, which is why `RerankTask` lands now.

## Two seams that keep their value regardless

**`packages/agents/src/evidence.ts`** — `EvidenceDocument` / `EvidenceRegion` / `resolveCites`. `Documents`, `Verify` and `Casework` will each need the same provenance seam; defining it once is far cheaper than retrofitting it across four Abilities.

It is **data, not a callback**. The obvious shape is `locator(offset) => Cite`, and that cannot cross a manifest boundary, be persisted in an audit record, or travel from a producing Ability to a consuming one.

`resolveCites` returns **every** intersecting region, not the one containing the start offset — a supporting sentence routinely crosses a paragraph, page or speaker, and naming only where it began sends a reader to the wrong half of the evidence.

**`RerankTask` on `Rerank.create`** — the reranker is a pointwise instruction-following judge, so its criterion is a sentence. That sentence was a module constant. It now travels with its own canaries and threshold **as one unit**, because an instruction whose calibration lives elsewhere drifts silently. `RETRIEVAL_TASK` reproduces the previous wording byte-for-byte, so every existing caller is unchanged — and a test pins that string.

## The date resolver refuses

Measured against `chrono-node@2.10.1` anchored to 2019-03-14:

| expression | chrono says | truth |
|---|---|---|
| `the end of February` | **2019-02-01** | ~Feb 28 |
| `the 2nd Tuesday of November` | **2019-03-12** | a Tuesday in November |
| `in 2024` | no parse | 2024, year precision |

Well-formed and wrong is the combination that reaches a filing, so every parse is coverage-checked against the phrase the extractor identified. Precision is never invented: `"March 2024"` → `2024-03`, never `2024-03-01`. `"End of February"` is the **29th** in a leap year — the spec said the 28th for two revisions. `locale` is required with no default: `03/04/24` differs by a year between en-GB and en-US.

## T2 got stronger because a mutation survived

Dropping the segment base from an offset — a segment-local index escaping into a document-level field — **passed all eleven invariants**. The span stayed in bounds and resolved to a region: valid, self-consistent, pointing at the wrong sentence.

So the extractor now reports the words it pointed at (which the skill already tells it to quote) and T2 asserts `text.slice(...span) === quote`. **That still was not enough** — the oversized fixture was `para one. ` repeated, so offset 0 and offset 3000 read identically. Distinct paragraphs plus targeting the last entry per segment made it fail naming the defect:

```
span [164,173) reads "Entry 004" but the extractor quoted "Entry 009"
```

Two rounds of the test being wrong before it was right, both found by breaking the code on purpose.

## Verified through the front door

Scaffolded with `npx lloyal-ai ability:new`, dropped this source in, built and ran it **standalone outside the monorepo**. It produces a chronology whose citation crosses two paragraphs — the case the evidence contract exists for.

Two things the contract tests pin, both got wrong first: `createInMemoryConfigStore` is exported by **rig**, not agents; and `AbilitySetup.tools` is a name→Tool **record** going in while `Ability.tools` is an **array** coming out.

## Notes

- `release.yml:68` deliberately untouched — first-party abilities are `private` and ship through the signed channel. Typecheck lists in `ci.yml:54` / `release.yml:58` do gain it.
- No `services` declared: slice 1 does not judge support, so a reranker would provision a model nothing uses.
- `useWhen` is 205 chars; the spec draft was 318 against a 280 limit and would have thrown at import.

**70 files / 628 passed / 2 skipped.**